### PR TITLE
fix: navbar underline animation shift

### DIFF
--- a/style.css
+++ b/style.css
@@ -145,6 +145,7 @@ body {
 }
 
 #navbar li a {
+    position: relative; /* Added postion-relative*/
     pointer-events: all;
     text-decoration: none;
     font-size: 22px;
@@ -165,12 +166,12 @@ body {
 
 #navbar li a.active::after {
     content: '';
-    width: 7%;
+    width: 100%;
     height: 2px;
     background: #088178;
     position: absolute;
     bottom: -4px;
-    left: 20px;
+    left: 2px; /* Changed top 2px */
 }
 
 /* home page */


### PR DESCRIPTION
-->Initially Navbar underline was not shifting to other menu options after clicking on it.
-->I have added a CSS property **position: relative;** in Navbar li a Id.
-->In navbar li a.active::after I have changed **Width to 100%**.
--> and left to 2 px;
After making all these changes, now the underline is shifting to the active menu option in Navbar, instead of sticking to one previously.
Attaching screenshot for reference.
![before](https://github.com/user-attachments/assets/b2325404-d10f-4daa-9240-21c3e325e503)
After <img width="666" height="277" alt="image" src="https://github.com/user-attachments/assets/997040dc-6ef1-41e3-add3-ca89108ed309" />

