### PR TITLE
Fixed overlapping labels and placeholders on login form

### DIFF
--- a/login.css
+++ b/login.css
@@ -155,6 +155,14 @@ h2 {
     animation: scanLine 2s ease-in-out infinite;
 }
 
+.input-field::placeholder {
+    color: transparent;
+}
+
+.input-field:focus::placeholder {
+    color: rgba(0, 212, 255, 0.5);
+}
+
 @keyframes scanLine {
     0% { left: -100%; }
     50% { left: 100%; }


### PR DESCRIPTION
## 📄 Description

This PR fixes the overlapping issue between labels and placeholders on the login page.

The placeholder text is now hidden by default and becomes visible only when the input field is focused, improving readability and user experience.

---

## 🔗 Related Issues

Fixes #109

---

## 🖼️ Screenshots 

## Before:
* Labels and placeholders overlapped on the login form.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/293c0ebd-f2ef-496e-b352-bf7dec880304" />

## After:
* Labels and placeholders display correctly without overlap.
 
<img width="1920" height="1080" alt="Screenshot 2026-05-13 194123" src="https://github.com/user-attachments/assets/2a0c1a2e-892e-4cbe-a6b6-aaba1bcbb080" />


<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/bb983fa3-8bcf-4469-bed4-a07c42ffc7c6" />

---

## 🧩 Type of Change

* [x] 🐛 Bug Fix
* [ ] ✨ New Feature
* [ ] ⚡ Enhancement / Optimization
* [ ] 🧰 Refactoring
* [ ] 🧾 Documentation Update
* [ ] 🔧 Other (please specify): ____________

---

## ✅ Checklist

* [x] I have performed a self-review of my code.
* [x] My changes do not break any existing functionality.
* [x] I have tested my changes locally and they work as expected.
* [x] I have linked all relevant issues (if any).

---

## 💬 Additional Notes (Optional)

This fix only introduces minimal CSS changes to preserve the existing UI design while resolving the overlap issue.
