### PR TITLE
Fixed home page product card navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@
         <h2>Featured Product</h2>
         <p>Summer Collection New Modern Design</p>
         <div class="pro-container">
-            <div class="pro" data-category="minimal">
+            <div class="pro" onclick="window.location.href='singleProduct.html';" data-category="street" onclick="window.location.href='singleProduct.html';">
                 <img src="images/products/f1.jpg" alt="Cartoon Astronaut T-Shirts">
                 <div class="des">
                     <span>adidas</span>
@@ -146,7 +146,7 @@
                 </div>
                 <a href="#" class="cart" onclick="addToCart('Cartoon Astronaut T-Shirts', '$78', 'images/products/f1.jpg', 1, 'M')"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
-            <div class="pro" data-category="minimal">
+            <div class="pro" onclick="window.location.href='singleProduct.html';" data-category="minimal">
                 <img src="images/products/f2.jpg" alt="Cartoon Astronaut T-Shirts">
                 <div class="des">
                     <span>adidas</span>
@@ -162,7 +162,7 @@
                 </div>
                 <a href="#" class="cart" onclick="addToCart('Cartoon Astronaut T-Shirts', '$78', 'images/products/f2.jpg', 1, 'M')"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
-            <div class="pro" data-category="minimal">
+            <div class="pro" onclick="window.location.href='singleProduct.html';" data-category="minimal">
                 <img src="images/products/f3.jpg" alt="">
                 <div class="des">
                     <span>adidas</span>
@@ -178,7 +178,7 @@
                 </div>
                 <a href="#" class="cart" onclick="addToCart('Cartoon Astronaut T-Shirts', '$78', 'images/products/f3.jpg', 1, 'M')"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
-            <div class="pro" data-category="minimal">
+            <div class="pro" onclick="window.location.href='singleProduct.html';" data-category="minimal">
                 <img src="images/products/f4.jpg" alt="">
                 <div class="des">
                     <span>adidas</span>
@@ -194,7 +194,7 @@
                 </div>
                 <a href="#" class="cart" onclick="addToCart('Cartoon Astronaut T-Shirts', '$78', 'images/products/f4.jpg', 1, 'M')"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
-            <div class="pro" data-category="street">
+            <div class="pro" onclick="window.location.href='singleProduct.html';" data-category="street">
                 <img src="images/products/f5.jpg" alt="">
                 <div class="des">
                     <span>adidas</span>
@@ -210,7 +210,7 @@
                 </div>
                 <a href="#" class="cart" onclick="addToCart('Cartoon Astronaut T-Shirts', '$78', 'images/products/f5.jpg', 1, 'M')"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
-            <div class="pro" data-category="street">
+            <div class="pro" onclick="window.location.href='singleProduct.html';" data-category="street">
                 <img src="images/products/f6.jpg" alt="">
                 <div class="des">
                     <span>adidas</span>
@@ -226,7 +226,7 @@
                 </div>
                 <a href="#" class="cart" onclick="addToCart('Cartoon Astronaut T-Shirts', '$78', 'images/products/f6.jpg', 1, 'M')"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
-            <div class="pro" data-category="street">
+            <div class="pro" onclick="window.location.href='singleProduct.html';" data-category="street">
                 <img src="images/products/f7.jpg" alt="">
                 <div class="des">
                     <span>adidas</span>
@@ -242,7 +242,7 @@
                 </div>
                 <a href="#" class="cart" onclick="addToCart('Cartoon Astronaut T-Shirts', '$78', 'images/products/f7.jpg', 1, 'M')"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
-            <div class="pro">
+            <div class="pro" onclick="window.location.href='singleProduct.html';">
                 <img src="images/products/f8.jpg" alt="">
                 <div class="des">
                     <span>adidas</span>
@@ -272,7 +272,7 @@
         <h2>New Arrivals</h2>
         <p>Summer Collection New Morden Design</p>
         <div class="pro-container">
-            <div class="pro" data-category="formal">
+            <div class="pro" onclick="window.location.href='singleProduct.html';" data-category="formal">
                 <img src="images/products/n1.jpg" alt="">
                 <div class="des">
                     <span>adidas</span>
@@ -288,7 +288,7 @@
                 </div>
                 <a href="#" class="cart" onclick="addToCart('Cartoon Astronaut T-Shirts', '$78', 'images/products/n1.jpg', 1, 'M')"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
-            <div class="pro" data-category="formal">
+            <div class="pro" onclick="window.location.href='singleProduct.html';" data-category="formal">
                 <img src="images/products/n2.jpg" alt="">
                 <div class="des">
                     <span>adidas</span>
@@ -304,7 +304,7 @@
                 </div>
                 <a href="#" class="cart" onclick="addToCart('Cartoon Astronaut T-Shirts', '$78', 'images/products/n2.jpg', 1, 'M')"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
-            <div class="pro" data-category="formal">
+            <div class="pro" onclick="window.location.href='singleProduct.html';" data-category="formal">
                 <img src="images/products/n3.jpg" alt="">
                 <div class="des">
                     <span>adidas</span>
@@ -320,7 +320,7 @@
                 </div>
                 <a href="#" class="cart" onclick="addToCart('Cartoon Astronaut T-Shirts', '$78', 'images/products/n3.jpg', 1, 'M')"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
-            <div class="pro" data-category="formal">
+            <div class="pro" onclick="window.location.href='singleProduct.html';" data-category="formal">
                 <img src="images/products/n4.jpg" alt="">
                 <div class="des">
                     <span>adidas</span>
@@ -336,7 +336,7 @@
                 </div>
                 <a href="#" class="cart" onclick="addToCart('Cartoon Astronaut T-Shirts', '$78', 'images/products/n4.jpg', 1, 'M')"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
-            <div class="pro" data-category="minimal">
+            <div class="pro" onclick="window.location.href='singleProduct.html';" data-category="minimal">
                 <img src="images/products/n5.jpg" alt="">
                 <div class="des">
                     <span>adidas</span>
@@ -352,7 +352,7 @@
                 </div>
                 <a href="#" class="cart" onclick="addToCart('Cartoon Astronaut T-Shirts', '$78', 'images/products/n5.jpg', 1, 'M')"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
-            <div class="pro" data-category="minimal">
+            <div class="pro" onclick="window.location.href='singleProduct.html';" data-category="minimal">
                 <img src="images/products/n6.jpg" alt="">
                 <div class="des">
                     <span>adidas</span>
@@ -368,7 +368,7 @@
                 </div>
                 <a href="#" class="cart" onclick="addToCart('Cartoon Astronaut T-Shirts', '$78', 'images/products/n6.jpg', 1, 'M')"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
-            <div class="pro" data-category="minimal">
+            <div class="pro" onclick="window.location.href='singleProduct.html';" data-category="minimal">
                 <img src="images/products/n7.jpg" alt="">
                 <div class="des">
                     <span>adidas</span>
@@ -384,7 +384,7 @@
                 </div>
                 <a href="#" class="cart" onclick="addToCart('Cartoon Astronaut T-Shirts', '$78', 'images/products/n7.jpg', 1, 'M')"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
-            <div class="pro" data-category="minimal">
+            <div class="pro" onclick="window.location.href='singleProduct.html';" data-category="minimal">
                 <img src="images/products/n8.jpg" alt="">
                 <div class="des">
                     <span>adidas</span>


### PR DESCRIPTION
## 📄 Description

This PR fixes the issue where product cards on the Home page were not navigating to the single product page when clicked.

The navigation behavior has now been aligned with the Shop page by adding proper click navigation to the product cards.

---

## 🔗 Related Issues

Fixes #108

---

## 🖼️ Screenshots
## Before

Product cards on the Home page were not navigating to the single product page when clicked.

<img width="1920" height="1080" alt="Screenshot 2026-05-15 215009" src="https://github.com/user-attachments/assets/7b696b47-0632-46e3-8611-557e83f3edff" />

## After

Added navigation functionality to Home page product cards.
Now clicking a product card correctly opens the single product page, matching the Shop page behavior.

<img width="1920" height="1080" alt="Screenshot 2026-05-15 215019" src="https://github.com/user-attachments/assets/1999f249-6f74-4107-851a-f088ed9f7753" />


---

## 🧩 Type of Change

* [x] 🐛 Bug Fix
* [ ] ✨ New Feature
* [ ] ⚡ Enhancement / Optimization
* [ ] 🧰 Refactoring
* [ ] 🧾 Documentation Update
* [ ] 🔧 Other (please specify): ____________

---

## ✅ Checklist

* [x] I have performed a self-review of my code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have added or updated relevant documentation.
* [x] My changes do not break any existing functionality.
* [x] I have tested my changes locally and they work as expected.
* [x] I have linked all relevant issues.

---

## 💬 Additional Notes 

The Home page product cards now redirect users to the single product page similar to the Shop page behavior.
