### PR TITLE
Fix overlapping placeholder and label issue in login page

### DIFF
--- a/login.css
+++ b/login.css
@@ -157,10 +157,11 @@ h2 {
 
 .input-field::placeholder {
     color: transparent;
+    transition : opacity 0.3s ease;
 }
 
 .input-field:focus::placeholder {
-    color: rgba(0, 212, 255, 0.5);
+     color: rgba(0, 212, 255, 0.35);
 }
 
 @keyframes scanLine {
@@ -320,13 +321,10 @@ p {
     position: relative;
 }
 
-.input-field::placeholder {
-    color: rgba(0, 212, 255, 0.35);
-}
 
 .input-field:focus ~ label,
 .input-field:not(:placeholder-shown) ~ label {
-    top: -12px;
+    top: -20px;
     font-size: 12px;
     color: #00d4ff;
     text-shadow: 0 0 5px rgba(0, 212, 255, 0.5);

--- a/login.html
+++ b/login.html
@@ -62,13 +62,13 @@
 
             <form id="loginForm">
                 <div class="input-group">
-                   <input type="text" id="loginEmail" required class="input-field" placeholder=" ">
+                   <input type="text" id="loginEmail" required class="input-field" placeholder="Enter your email">
                     <label for="loginEmail">Email</label>
                     <div class="glow-line"></div>
                 </div>
 
                 <div class="input-group">
-                   <input type="password" id="loginPassword" required class="input-field" placeholder=" ">
+                   <input type="password" id="loginPassword" required class="input-field" placeholder="Enter your password">
                     <label for="loginPassword">Password</label>
                     <div class="glow-line"></div>
                 </div>


### PR DESCRIPTION
# 📝 Pull Request Template

## 📄 Description
Fixed the overlapping issue between the floating label and placeholder text in the login form. 
The label now sits at input level by default and floats above on focus. 
Placeholder hint appears with low opacity when focused and disappears while typing.



---

## 🔗 Related Issues



> Fixes #163 

---

## 🖼️ Screenshots (if applicable)

BEFORE
---
<img width="296" height="320" alt="Screenshot 2026-05-16 085521" src="https://github.com/user-attachments/assets/e345ae88-9ead-497a-8075-4145fa30934f" />

AFTER
---
<img width="350" height="437" alt="image" src="https://github.com/user-attachments/assets/8dc85402-eb23-4b2f-8098-8c28ae2e7cb5" />


---

## 🧩 Type of Change

Select the type of change your PR introduces (check all that apply):

- [x] 🐛 Bug Fix  
- [ ] ✨ New Feature  
- [x] ⚡ Enhancement / Optimization  
- [ ] 🧰 Refactoring  
- [ ] 🧾 Documentation Update  
- [ ] 🔧 Other (please specify): ____________

---

## ✅ Checklist

Before submitting your PR, please confirm the following:

- [x] I have performed a self-review of my code.  
- [ ] I have commented my code, particularly in hard-to-understand areas.  
- [ ] I have added or updated relevant documentation.  
- [x] My changes do not break any existing functionality.  
- [x] I have tested my changes locally and they work as expected.  
- [ ] I have linked all relevant issues (if any).

---

## 💬 Additional Notes (Optional)

Add any other information, context, or comments that reviewers might find useful.
