### PR TITLE
fix: add padding-top to cart page to prevent navbar overlap #124

### DIFF
--- a/style.css
+++ b/style.css
@@ -2006,3 +2006,7 @@ canvas {
   pointer-events: auto;
   transform: translateY(-10px) scale(1.08);
 }
+#page-header{
+    margin-top: 100px;
+    margin-left: 80px;
+}


### PR DESCRIPTION
## 📄 Description
The cart page content was overlapping with 
the fixed navbar, causing the "Your Cart" 
heading and "Review and manage your selected 
items" text to be hidden behind the navbar.

Added margin-top and margin-left to the 
page header to push content below the 
navbar and add proper spacing.

---

## 🔗 Related Issues
Fixes #[issue_number]

---

## 🖼️ Screenshots

### Before:
<img width="1918" height="367" alt="image" src="https://github.com/user-attachments/assets/ff51de58-8767-42cf-9155-003a3b97d0ad" />


### After:
<img width="1918" height="302" alt="image" src="https://github.com/user-attachments/assets/15e624bd-c6d7-4fa8-ba94-98e34e312dc0" />


---

## 🧩 Type of Change
- [x] 🐛 Bug Fix

---

## ✅ Checklist
- [x] I have performed a self-review of my code.
- [x] I have commented my code particularly 
      in hard-to-understand areas.
- [x] I have added or updated relevant documentation.
- [x] My changes do not break any existing functionality.
- [x] I have tested my changes locally and 
      they work as expected.
- [x] I have linked all relevant issues.

---

## 💬 Additional Notes
Added the following CSS to style.css:

#page-header {
  margin-top: 100px;
  margin-left: 80px;
}

This ensures the cart page content 
sits properly below the fixed navbar 
on all screen sizes.