### PR TITLE
Enhancement/cart button styling #125

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -101,9 +101,9 @@
 
     <section id="cart-actions" class="section-p1">
         <div class="cart-buttons">
-            <a href="shop.html" class="normals">Continue Shopping</a>
+            <a href="shop.html" class="continue-shopping">Continue Shopping</a>
             <!-- csritik-max -->
-             <a href="checkout.html" class="normals">Proceed to Checkout</a>
+             <a href="checkout.html" class="proceed-checkout">Proceed to Checkout</a>
         </div>
     </section>
 

--- a/style.css
+++ b/style.css
@@ -1223,13 +1223,6 @@ footer .copyright {
     cursor: pointer;
 }
 
-.normals{
-    margin:10px;
-    text-decoration: none;
-    font-size: 17px;
-}
-
-
 /* Continue Shopping Button -{csritik-max}*/
 a.normal {
   display: inline-block;
@@ -2010,3 +2003,52 @@ canvas {
     margin-top: 100px;
     margin-left: 80px;
 }
+/* Continue Shopping Button */
+.continue-shopping {
+  display: inline-block;
+  padding: 12px 24px;
+  border: 2px solid #088178;
+  color: #088178;
+  background: transparent;
+  border-radius: 5px;
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.continue-shopping:hover {
+  background: #054a47c2;
+  color: white;
+}
+
+/* Proceed to Checkout Button */
+.proceed-checkout {
+  display: inline-block;
+  padding: 12px 24px;
+  background: #088178;
+  color: white;
+  border: 2px solid #088178;
+  border-radius: 5px;
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  margin-left: 10px;
+  transition: all 0.3s ease;
+}
+
+.proceed-checkout:hover {
+  background: #066b63;
+  border-color: #066b63;
+}
+
+Then add classes to your HTML:
+html<a href="/shop.html" class="continue-shopping">
+  Continue Shopping
+</a>
+<a href="/checkout.html" class="proceed-checkout">
+  Proceed to Checkout
+</a>
+

--- a/style.css
+++ b/style.css
@@ -2006,3 +2006,7 @@ canvas {
   pointer-events: auto;
   transform: translateY(-10px) scale(1.08);
 }
+#page-header{
+    margin-top: 100px;
+    margin-left: 80px;
+}


### PR DESCRIPTION
## 📄 Description
The "Continue Shopping" and "Proceed to 
Checkout" in the cart page were plain 
unstyled links with no visual button 
appearance.

Updated their class names and added 
proper CSS button styling to make them 
more prominent and improve the overall 
user experience of the cart page.

---

## 🔗 Related Issues
Fixes #[issue_number]

---

## 🖼️ Screenshots

### Before:
<img width="492" height="140" alt="image" src="https://github.com/user-attachments/assets/e6f02483-17c7-4c2c-8221-865c46aa216b" />


### After:
[attach after screenshot]
<img width="737" height="387" alt="image" src="https://github.com/user-attachments/assets/cd808463-6c86-42a8-a20a-cb6c6c7b3b23" />

**on hover:**
continue shopping
<img width="755" height="202" alt="image" src="https://github.com/user-attachments/assets/0f2868fe-a048-4d10-9576-e78622fad869" />

proceed to checkout
<img width="523" height="148" alt="image" src="https://github.com/user-attachments/assets/e405488c-6141-497d-984e-cbb7f6b95498" />


---

## 🧩 Type of Change
- [x] ⚡ Enhancement / Optimization

---

## ✅ Checklist
- [x] I have performed a self-review 
      of my code.
- [x] I have commented my code in 
      hard-to-understand areas.
- [x] I have added or updated relevant 
      documentation.
- [x] My changes do not break any 
      existing functionality.
- [x] I have tested my changes locally 
      and they work as expected.
- [x] I have linked all relevant issues.

---

## 💬 Additional Notes
Changes made:
- Updated class names in HTML file (cart.html)
- Added CSS in style.css:
  → Continue Shopping: outline style
  → Proceed to Checkout: filled style
  → Hover effects on both buttons