### PR TITLE
Add password visibility toggle in login page #128

### DIFF
--- a/login.css
+++ b/login.css
@@ -440,6 +440,31 @@ p {
     transform: translateZ(20px) scale(0.98);
 }
 
+.password-group {
+    position: relative;
+}
+
+.toggle_password {
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: transparent;
+    border: none;
+    color: #00d4ff;
+    cursor: pointer;
+    font-size: 18px;
+    z-index: 5;
+    transition: 0.3s ease;
+}
+
+.toggle_password:hover {
+    color: #4ecdc4;
+}
+
+.toggle_password:focus {
+    outline: none;
+}
 .signup-link {
     text-align: center;
     margin-top: 20px;

--- a/login.html
+++ b/login.html
@@ -67,8 +67,9 @@
                     <div class="glow-line"></div>
                 </div>
 
-                <div class="input-group">
+                <div class="input-group password-group">
                    <input type="password" id="loginPassword" required class="input-field" placeholder="Enter your password">
+                   <button   type="button" id="togglePassword" class="toggle_password" aria-label="show password "><i class="ri-eye-line"></i></button>
                     <label for="loginPassword">Password</label>
                     <div class="glow-line"></div>
                 </div>

--- a/login.js
+++ b/login.js
@@ -1,5 +1,24 @@
 document.addEventListener('DOMContentLoaded', function () {
     const form = document.getElementById('loginForm');
+    const passwordInput = document.getElementById('loginPassword');
+    const togglePassword = document.getElementById('togglePassword');
+
+    if (passwordInput && togglePassword) {
+
+    togglePassword.addEventListener('click', function () {
+
+        const isPasswordHidden = passwordInput.type === 'password';
+
+        passwordInput.type = isPasswordHidden ? 'text' : 'password';
+
+        this.innerHTML = isPasswordHidden
+
+            ? '<i class="ri-eye-off-line"></i>'
+            : '<i class="ri-eye-line"></i>';
+    });
+    
+}
+
     if (!form) return;
 
     form.addEventListener('submit', function (e) {


### PR DESCRIPTION
# 📝 Add Password Visibility Toggle to Login Form #128 

## 📄 Description

Added a password visibility toggle to the login form.

Users can now show/hide their password while typing, making it easier to verify input before submitting the form and reducing login mistakes caused by hidden passwords.

The implementation is lightweight and keeps the existing login functionality and UI unchanged.


---

## 🔗 Related Issues

> Fixes #<128>

---

## 🖼️ Screenshot


<img width="1687" height="811" alt="Screenshot 2026-05-16 150036" src="https://github.com/user-attachments/assets/232142ff-0fa8-4700-b1ec-5a4c26fd75f9" />

---
## 🧩 Type of Change

Select the type of change your PR introduces (check all that apply):

- [ ] 🐛 Bug Fix  
- [x] ✨ New Feature  
- [x] ⚡ Enhancement / Optimization  
- [ ] 🧰 Refactoring  
- [ ] 🧾 Documentation Update  
- [ ] 🔧 Other (please specify): ____________

---

## ✅ Checklist

Before submitting your PR, please confirm the following:

- [x] I have performed a self-review of my code.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have added or updated relevant documentation.  
- [x] My changes do not break any existing functionality.  
- [x] I have tested my changes locally and they work as expected.  
- [x] I have linked all relevant issues (if any).

---

## 💬 Additional Notes 

Used the existing Remix Icon library for the visibility toggle icons to keep the implementation simple and consistent with the current UI.
