### PR TITLE
Fixed  App Store & Google Play Buttons Not Clickable #208

### DIFF
--- a/about.html
+++ b/about.html
@@ -188,8 +188,15 @@
             <h4>Install App</h4>
             <p>From App Store or Google Play</p>
             <div class="row">
-                <img src="images/pay/app.jpg" alt="">
-                <img src="images/pay/play.jpg" alt="">
+                
+                <a href="https://www.apple.com/app-store/" target="_blank" rel="noopener noreferrer">
+                <img src="images/pay/app.jpg" alt="Download on the Apple Store">
+                </a>
+                <a href="https://play.google.com/store" target="_blank" rel="noopener noreferrer">
+                <img src="images/pay/play.jpg" alt="Download on the Google Play Store">
+                </a>
+
+                
             </div>
             <p>Secured Payment Gateways</p>
             <img src="images/pay/pay.png" alt="">

--- a/about.html
+++ b/about.html
@@ -188,15 +188,12 @@
             <h4>Install App</h4>
             <p>From App Store or Google Play</p>
             <div class="row">
-                
                 <a href="https://www.apple.com/app-store/" target="_blank" rel="noopener noreferrer">
                 <img src="images/pay/app.jpg" alt="Download on the Apple Store">
                 </a>
                 <a href="https://play.google.com/store" target="_blank" rel="noopener noreferrer">
                 <img src="images/pay/play.jpg" alt="Download on the Google Play Store">
-                </a>
-
-                
+                </a>     
             </div>
             <p>Secured Payment Gateways</p>
             <img src="images/pay/pay.png" alt="">

--- a/blog.html
+++ b/blog.html
@@ -200,15 +200,12 @@
             <h4>Install App</h4>
             <p>From App Store or Google Play</p>
             <div class="row">
-
                <a href="https://www.apple.com/app-store/" target="_blank" rel="noopener noreferrer">
                 <img src="images/pay/app.jpg" alt="Download on the Apple Store">
                 </a>
                 <a href="https://play.google.com/store" target="_blank" rel="noopener noreferrer">
                 <img src="images/pay/play.jpg" alt="Download on the Google Play Store">
-                </a>
-
-                
+                </a>    
             </div>
             <p>Secured Payment Gateways</p>
             <img src="images/pay/pay.png" alt="">

--- a/blog.html
+++ b/blog.html
@@ -200,8 +200,15 @@
             <h4>Install App</h4>
             <p>From App Store or Google Play</p>
             <div class="row">
-                <img src="images/pay/app.jpg" alt="">
-                <img src="images/pay/play.jpg" alt="">
+
+               <a href="https://www.apple.com/app-store/" target="_blank" rel="noopener noreferrer">
+                <img src="images/pay/app.jpg" alt="Download on the Apple Store">
+                </a>
+                <a href="https://play.google.com/store" target="_blank" rel="noopener noreferrer">
+                <img src="images/pay/play.jpg" alt="Download on the Google Play Store">
+                </a>
+
+                
             </div>
             <p>Secured Payment Gateways</p>
             <img src="images/pay/pay.png" alt="">

--- a/cart.html
+++ b/cart.html
@@ -147,8 +147,14 @@
             <h4>Install App</h4>
             <p>From App Store or Google Play</p>
             <div class="row">
-                <img src="images/pay/app.jpg" alt="">
-                <img src="images/pay/play.jpg" alt="">
+                
+                <a href="https://www.apple.com/app-store/" target="_blank" rel="noopener noreferrer">
+                <img src="images/pay/app.jpg" alt="Download on the Apple Store">
+                </a>
+                <a href="https://play.google.com/store" target="_blank" rel="noopener noreferrer">
+                <img src="images/pay/play.jpg" alt="Download on the Google Play Store">
+                </a>
+
             </div>
             <p>Secured Payment Gateways</p>
             <img src="images/pay/pay.png" alt="">

--- a/cart.html
+++ b/cart.html
@@ -146,15 +146,13 @@
         <div class="col install">
             <h4>Install App</h4>
             <p>From App Store or Google Play</p>
-            <div class="row">
-                
+            <div class="row">       
                 <a href="https://www.apple.com/app-store/" target="_blank" rel="noopener noreferrer">
                 <img src="images/pay/app.jpg" alt="Download on the Apple Store">
                 </a>
                 <a href="https://play.google.com/store" target="_blank" rel="noopener noreferrer">
                 <img src="images/pay/play.jpg" alt="Download on the Google Play Store">
                 </a>
-
             </div>
             <p>Secured Payment Gateways</p>
             <img src="images/pay/pay.png" alt="">

--- a/contact.html
+++ b/contact.html
@@ -199,14 +199,12 @@
             <h4>Install App</h4>
             <p>From App Store or Google Play</p>
             <div class="row">
-
                <a href="https://www.apple.com/app-store/" target="_blank" rel="noopener noreferrer">
                 <img src="images/pay/app.jpg" alt="Download on the Apple Store">
                 </a>
                 <a href="https://play.google.com/store" target="_blank" rel="noopener noreferrer">
                 <img src="images/pay/play.jpg" alt="Download on the Google Play Store">
-                </a>
-                
+                </a>                
             </div>
             <p>Secured Payment Gateways</p>
             <img src="images/pay/pay.png" alt="">

--- a/contact.html
+++ b/contact.html
@@ -199,8 +199,14 @@
             <h4>Install App</h4>
             <p>From App Store or Google Play</p>
             <div class="row">
-                <img src="images/pay/app.jpg" alt="">
-                <img src="images/pay/play.jpg" alt="">
+
+               <a href="https://www.apple.com/app-store/" target="_blank" rel="noopener noreferrer">
+                <img src="images/pay/app.jpg" alt="Download on the Apple Store">
+                </a>
+                <a href="https://play.google.com/store" target="_blank" rel="noopener noreferrer">
+                <img src="images/pay/play.jpg" alt="Download on the Google Play Store">
+                </a>
+                
             </div>
             <p>Secured Payment Gateways</p>
             <img src="images/pay/pay.png" alt="">

--- a/index.html
+++ b/index.html
@@ -504,15 +504,13 @@
         <div class="col install">
             <h4>Install App</h4>
             <p>From App Store or Google Play</p>
-            <div class="row">
-                
+            <div class="row">               
                 <a href="https://www.apple.com/app-store/" target="_blank" rel="noopener noreferrer">
                 <img src="images/pay/app.jpg" alt="Download on the Apple Store">
                 </a>
                 <a href="https://play.google.com/store" target="_blank" rel="noopener noreferrer">
                 <img src="images/pay/play.jpg" alt="Download on the Google Play Store">
-                </a>
-                
+                </a>   
             </div>
             <p>Secured Payment Gateways</p>
             <img src="images/pay/pay.png" alt="">

--- a/index.html
+++ b/index.html
@@ -505,8 +505,14 @@
             <h4>Install App</h4>
             <p>From App Store or Google Play</p>
             <div class="row">
-                <img src="images/pay/app.jpg" alt="">
-                <img src="images/pay/play.jpg" alt="">
+                
+                <a href="https://www.apple.com/app-store/" target="_blank" rel="noopener noreferrer">
+                <img src="images/pay/app.jpg" alt="Download on the Apple Store">
+                </a>
+                <a href="https://play.google.com/store" target="_blank" rel="noopener noreferrer">
+                <img src="images/pay/play.jpg" alt="Download on the Google Play Store">
+                </a>
+                
             </div>
             <p>Secured Payment Gateways</p>
             <img src="images/pay/pay.png" alt="">

--- a/license.html
+++ b/license.html
@@ -214,8 +214,12 @@
             <h4>Install App</h4>
             <p>From App Store or Google Play</p>
             <div class="row">
-                <img src="images/pay/app.jpg" alt="">
-                <img src="images/pay/play.jpg" alt="">
+               <a href="https://www.apple.com/app-store/" target="_blank" rel="noopener noreferrer">
+                <img src="images/pay/app.jpg" alt="Download on the Apple Store">
+                </a>
+                <a href="https://play.google.com/store" target="_blank" rel="noopener noreferrer">
+                <img src="images/pay/play.jpg" alt="Download on the Google Play Store">
+                </a>
             </div>
             <p>Secured Payment Gateways</p>
             <img src="images/pay/pay.png" alt="">

--- a/shop.html
+++ b/shop.html
@@ -141,8 +141,12 @@
             <h4>Install App</h4>
             <p>From App Store or Google Play</p>
             <div class="row">
-                <img src="images/pay/app.jpg" alt="">
-                <img src="images/pay/play.jpg" alt="">
+                <a href="https://www.apple.com/app-store/" target="_blank" rel="noopener noreferrer">
+                <img src="images/pay/app.jpg" alt="Download on the Apple Store">
+                </a>
+                <a href="https://play.google.com/store" target="_blank" rel="noopener noreferrer">
+                <img src="images/pay/play.jpg" alt="Download on the Google Play Store">
+                </a>
             </div>
             <p>Secured Payment Gateways</p>
             <img src="images/pay/pay.png" alt="">

--- a/singleProduct.html
+++ b/singleProduct.html
@@ -180,8 +180,12 @@
             <h4>Install App</h4>
             <p>From App Store ro Google Play</p>
             <div class="row">
-                <img src="images/pay/app.jpg" alt="">
-                <img src="images/pay/play.jpg" alt="">
+                 <a href="https://www.apple.com/app-store/" target="_blank" rel="noopener noreferrer">
+                <img src="images/pay/app.jpg" alt="Download on the Apple Store">
+                </a>
+                <a href="https://play.google.com/store" target="_blank" rel="noopener noreferrer">
+                <img src="images/pay/play.jpg" alt="Download on the Google Play Store">
+                </a>               
             </div>
             <p>Secured Payment Gateways</p>
             <img src="images/pay/pay.png" alt="">


### PR DESCRIPTION
# 📝 Bug Fix: App Store & Google Play Buttons Not Clickable #208

## 📄 Description

The App Store and Google Play buttons in the footer were only displayed as images and were not clickable.


This PR fixes the issue by wrapping both images inside anchor (`<a>`) tags so users can click them and be redirected to the respective store pages.


The change is small and does not affect any other UI or functionality.

---

## 🔗 Related Issues

> Fixes #<208>

---


## 🧩 Problem

Before this fix:

- App Store and Google Play icons were just images
- They were not clickable
- No redirection to external stores was happening

---

## ✅ Solution

Now both images are wrapped inside anchor tags:

```html
<a href="https://www.apple.com/app-store/" target="_blank" rel="noopener noreferrer">
  <img src="images/pay/app.jpg" alt="Download on the App Store">
</a>

<a href="https://play.google.com/store" target="_blank" rel="noopener noreferrer">
  <img src="images/pay/play.jpg" alt="Download on the Google Play Store">
</a>

```
## 🧩 Type of Change

Select the type of change your PR introduces (check all that apply):

- [x] 🐛 Bug Fix  
- [ ] ✨ New Feature  
- [ ] ⚡ Enhancement / Optimization  
- [ ] 🧰 Refactoring  
- [ ] 🧾 Documentation Update  
- [ ] 🔧 Other (please specify): ____________

---

## ✅ Checklist

Before submitting your PR, please confirm the following:

- [x] I have performed a self-review of my code.  
- [ ] I have commented my code, particularly in hard-to-understand areas.  
- [ ] I have added or updated relevant documentation.  
- [x] My changes do not break any existing functionality.  
- [x] I have tested my changes locally and they work as expected.  
- [ ] I have linked all relevant issues (if any).
