### PR TITLE
fix: sync dark mode on privacy and terms pages (#228)

### DIFF
--- a/privacy.css
+++ b/privacy.css
@@ -127,3 +127,50 @@
         font-size: 20px;
       }
     }
+
+
+    /* ===== Dark Mode ===== */
+[data-theme="dark"] body {
+  background: linear-gradient(135deg, #0f172a, #111827, #1e293b);
+  color: #e2e8f0;
+}
+
+[data-theme="dark"] .policy-container {
+  background: rgba(17, 24, 39, 0.85);
+  border-top-color: #38bdf8;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+}
+
+[data-theme="dark"] h1 {
+  color: #38bdf8;
+}
+
+[data-theme="dark"] h2 {
+  color: #38bdf8;
+}
+
+[data-theme="dark"] .subtitle {
+  color: #94a3b8;
+}
+
+[data-theme="dark"] p {
+  color: #cbd5e1;
+}
+
+[data-theme="dark"] ul li {
+  color: #cbd5e1;
+}
+
+[data-theme="dark"] .section {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+[data-theme="dark"] .section:hover {
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+}
+
+[data-theme="dark"] .footer-note {
+  color: #94a3b8;
+  border-top-color: rgba(255, 255, 255, 0.1);
+}

--- a/privacy.html
+++ b/privacy.html
@@ -5,7 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Privacy Policy - Cara</title>
   <link rel="stylesheet" href="privacy.css" />
-  
+  <!-- Dark mode: read theme from localStorage before page renders -->
+<script>
+  (function () {
+    const theme = localStorage.getItem('theme') || 'light';
+    document.documentElement.setAttribute('data-theme', theme);
+  })();
+</script>
 </head>
 <body>
 

--- a/terms.css
+++ b/terms.css
@@ -151,3 +151,54 @@
       }
 
     }
+
+    /* ===== Light Mode Override ===== */
+[data-theme="light"] body {
+  background: linear-gradient(to right, #f5f7fa, #e4ecf5);
+  color: #333;
+}
+
+[data-theme="light"] .container {
+  background: #ffffff;
+  border: none;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+  backdrop-filter: none;
+}
+
+[data-theme="light"] .header h1 {
+  background: none;
+  -webkit-background-clip: unset;
+  -webkit-text-fill-color: #088178;
+  color: #088178;
+}
+
+[data-theme="light"] .updated {
+  color: #666;
+}
+
+[data-theme="light"] .intro {
+  color: #555;
+}
+
+[data-theme="light"] .section {
+  background: #f9fbfc;
+  border: none;
+}
+
+[data-theme="light"] .section h2 {
+  color: #088178;
+}
+
+[data-theme="light"] .section p,
+[data-theme="light"] li {
+  color: #555;
+}
+
+[data-theme="light"] .footer {
+  color: #777;
+  border-top-color: #ddd;
+}
+
+[data-theme="light"] .bg-circle {
+  display: none;
+}

--- a/terms.html
+++ b/terms.html
@@ -11,7 +11,12 @@
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
       <link rel="stylesheet" href="./terms.css" >
 
-  
+  <script>
+  (function () {
+    const theme = localStorage.getItem('theme') || 'light';
+    document.documentElement.setAttribute('data-theme', theme);
+  })();
+</script>
 </head>
 
 <body>


### PR DESCRIPTION
# 📝 Pull Request Template

## 📄 Description

Provide a clear and concise description of what this pull request does.  
Include any background context and the motivation behind this change.

This PR fixes the dark mode sync issue on privacy.html and terms.html. Previously, these pages ignored the site-wide dark mode preference stored in localStorage, always rendering in their default theme regardless of user settings.
The fix adds an inline script to both pages that reads the theme from localStorage on page load and applies data-theme to <html> before the page renders — preventing any flash of wrong theme. Dark mode CSS rules were also added to privacy.css and light mode override rules to terms.css.

---

## 🔗 Related Issues

Fixes #228 

## 🖼️ Screenshots (if applicable)

<img width="2880" height="1604" alt="image" src="https://github.com/user-attachments/assets/d879843f-eefb-40cd-9857-343551c34e93" />

<img width="2880" height="1630" alt="image" src="https://github.com/user-attachments/assets/da69a62f-788a-4ed5-a8c4-7705a6fce031" />
<img width="2874" height="1652" alt="image" src="https://github.com/user-attachments/assets/ea177926-8bf6-43b6-a111-e385e073a092" />
<img width="2880" height="1640" alt="image" src="https://github.com/user-attachments/assets/474f5b71-6b57-4e8c-9100-e2e420678d68" />


---

## 🧩 Type of Change

Select the type of change your PR introduces (check all that apply):

- [x] 🐛 Bug Fix  
- [ ] ✨ New Feature  
- [ ] ⚡ Enhancement / Optimization  
- [ ] 🧰 Refactoring  
- [ ] 🧾 Documentation Update  
- [ ] 🔧 Other (please specify): ____________

---

## ✅ Checklist

Before submitting your PR, please confirm the following:

- [x] I have performed a self-review of my code.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have added or updated relevant documentation.  
- [x] My changes do not break any existing functionality.  
- [x] I have tested my changes locally and they work as expected.  
- [x] I have linked all relevant issues (if any).

---

## 💬 Additional Notes (Optional)

Root cause: the theme toggle IIFE in app.js looks for themeToggle buttons which don't exist on these pages, so the theme was never initialized. Additionally, neither privacy.css nor terms.css had any [data-theme] rules. Both issues are now resolved.
