### PR TITLE
fix: make banner button text visible by default

### DIFF
--- a/style.css
+++ b/style.css
@@ -685,9 +685,20 @@ button.white .ripple-effect {
     padding: 10px 0;
 }
 
-#banner button:hover {
+#banner button {
     color: #FFF;
     background-color: var(--accent);
+    border: 1px solid var(--accent);
+    transition: all 0.3s ease;
+}
+
+#banner button a {
+    color: #FFF;
+}
+
+#banner button:hover {
+    filter: brightness(1.2);
+    transform: scale(1.03);
 }
 
 #sm-banner {


### PR DESCRIPTION
Closes #232 

## Description

Fixed the visibility issue with the "Explore More" button text in the banner section.

Earlier, the button text was not visible in the default state and only appeared on hover because the text color was not explicitly defined.

### Changes made

* Added proper text color for the banner button
* Added text color styling for the anchor tag inside the button
* Improved hover behavior for both light and dark themes

### Before

* Button text was invisible until hovered

<img width="1919" height="1022" alt="Screenshot 2026-05-16 192252" src="https://github.com/user-attachments/assets/f16a643c-20ee-439b-90cd-129cb0d681f4" />
-

### After

* Button text is visible by default
* Hover effect looks consistent in both themes


<img width="1919" height="1031" alt="Screenshot 2026-05-17 003345" src="https://github.com/user-attachments/assets/da060363-c77f-475b-ad72-3abebce21518" />
-
<img width="1917" height="1026" alt="Screenshot 2026-05-17 003354" src="https://github.com/user-attachments/assets/ff7525a8-9445-4e47-b08e-ab6691fe6d00" />
