### PR TITLE
feat(ui): add hover animations to promotional banner cards

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,6 +1,110 @@
 @import url('https://fonts.googleapis.com/css2?family=Outfit:wght@100..900&family=League+Spartan:wght@100..900&display=swap');
 
 /* ============================================
+   BANNER CARD HOVER ANIMATIONS
+   Add this block to the end of style.css
+   ============================================ */
+
+/* ── Shared setup for both banner rows ── */
+#sm-banner .banner-box,
+#banner3 .banner-box {
+  overflow: hidden;          /* keeps zoomed bg clipped inside the card */
+  transition:
+    transform  0.35s cubic-bezier(0.25, 0.8, 0.25, 1),
+    box-shadow 0.35s cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+
+/* Background image lives on the pseudo-element so it can scale independently */
+#sm-banner .banner-box::before,
+#banner3  .banner-box::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: inherit;          /* picks up background-image from parent */
+  background-size: cover;
+  background-position: center;
+  transition: transform 0.55s cubic-bezier(0.25, 0.8, 0.25, 1);
+  z-index: 0;
+}
+
+/* Make sure text / buttons sit above the pseudo-element */
+#sm-banner .banner-box > *,
+#banner3  .banner-box > * {
+  position: relative;
+  z-index: 1;
+}
+
+/* ── Card lift + shadow on hover ── */
+#sm-banner .banner-box:hover,
+#banner3  .banner-box:hover {
+  transform: translateY(-8px) scale(1.02);
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.22);
+}
+
+/* ── Background zoom on hover ── */
+#sm-banner .banner-box:hover::before,
+#banner3  .banner-box:hover::before {
+  transform: scale(1.08);
+}
+
+/* ── Subtle dark overlay that appears on hover ── */
+#sm-banner .banner-box::after,
+#banner3  .banner-box::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0);
+  transition: background 0.35s ease;
+  z-index: 0;
+  border-radius: inherit;
+}
+
+#sm-banner .banner-box:hover::after,
+#banner3  .banner-box:hover::after {
+  background: rgba(0, 0, 0, 0.12);
+}
+
+/* ── Button animations inside banner cards ── */
+#sm-banner .banner-box button,
+#banner3  .banner-box button {
+  transition:
+    background-color 0.3s ease,
+    color            0.3s ease,
+    transform        0.3s cubic-bezier(0.25, 0.8, 0.25, 1),
+    box-shadow       0.3s ease;
+}
+
+#sm-banner .banner-box:hover button,
+#banner3  .banner-box:hover button {
+  transform: translateY(-3px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+}
+
+/* ── Heading slide-up micro-animation ── */
+#sm-banner .banner-box h2,
+#sm-banner .banner-box h4,
+#banner3  .banner-box h2,
+#banner3  .banner-box h3 {
+  transition: transform 0.35s ease, letter-spacing 0.35s ease;
+}
+
+#sm-banner .banner-box:hover h2,
+#sm-banner .banner-box:hover h4,
+#banner3  .banner-box:hover h2,
+#banner3  .banner-box:hover h3 {
+  transform: translateY(-4px);
+  letter-spacing: 0.5px;
+}
+
+/* ── Dark-theme adjustments ── */
+[data-theme="dark"] #sm-banner .banner-box:hover,
+[data-theme="dark"] #banner3  .banner-box:hover {
+  box-shadow: 0 20px 45px rgba(6, 182, 212, 0.18);
+}
+
+
+
+/* ============================================
    DARK THEME VARIABLES
    ============================================ */
 


### PR DESCRIPTION
## 📄 Description

Add smooth CSS-only hover micro-interactions to the `#sm-banner` and `#banner3` 
promotional banner cards on the homepage.

The banner cards were previously static with no hover feedback, making the UI 
feel flat and unresponsive. This update adds layered animations using CSS 
pseudo-elements and transitions — giving each card a lift, background zoom, 
overlay fade, and animated text/button response on hover. A pseudo-element 
approach ensures the background image scales independently from card content, 
so text and buttons never distort during zoom.

All changes are CSS-only. No HTML or JS was modified.

---

## 🔗 Related Issues

Closes #261 

---

| Before | After |
|--------|-------|
| Static cards, no hover feedback | Cards lift, bg zooms, text slides, buttons animate |


---

## 🧩 Type of Change

- [ ] 🐛 Bug Fix
- [ ] ✨ New Feature
- [x] ⚡ Enhancement / Optimization
- [ ] 🧰 Refactoring
- [ ] 🧾 Documentation Update
- [ ] 🔧 Other (please specify): ____________

---

## ✅ Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated relevant documentation.
- [x] My changes do not break any existing functionality.
- [x] I have tested my changes locally and they work as expected.
- [ ] I have linked all relevant issues (if any).

---

## 💬 Additional Notes (Optional)

**Implementation details:**
- `::before` pseudo-element handles background image zoom (`scale 1 → 1.08`) 
  independently from card content
- `::after` pseudo-element fades in a subtle dark overlay (`rgba 0 → 0.12`) 
  to maintain text readability during zoom
- Card lift uses `translateY(-8px) scale(1.02)` with 
  `cubic-bezier(0.25, 0.8, 0.25, 1)` easing for a snappy-in, relaxed-out feel
- Headings animate with `translateY(-4px)` + slight letter-spacing expansion
- Buttons lift independently with a drop shadow on parent card hover
- Dark mode handled — hover shadow swaps from black to cyan (`#06b6d4`) 
  to match the existing dark theme accent color

**Files changed:** `style.css` only