### PR TITLE
fix(hero): reduce translucent overlay opacity in light theme

### DIFF
--- a/style.css
+++ b/style.css
@@ -408,7 +408,13 @@ button.white .ripple-effect {
    ============================================ */
 
 #hero {
-    background-image: linear-gradient(to right, rgba(255, 255, 255, 0.9) 0%, rgba(255, 255, 255, 0.7) 40%, rgba(255, 255, 255, 0) 100%), url("images/hero4.png");
+
+    background-image: linear-gradient(to right, 
+        rgba(255, 255, 255, 0.75) 0%, 
+        rgba(255, 255, 255, 0.45) 35%, 
+        rgba(255, 255, 255, 0) 65%), 
+        url("images/hero4.png");
+
     height: 100vh;
     width: 100%;
     background-size: cover;
@@ -421,7 +427,11 @@ button.white .ripple-effect {
 }
 
 [data-theme="dark"] #hero {
-    background-image: linear-gradient(to right, rgba(0, 0, 0, 0.9) 0%, rgba(0, 0, 0, 0.7) 50%, rgba(0, 0, 0, 0) 100%), url("images/hero4.png");
+    background-image: linear-gradient(to right, 
+        rgba(0, 0, 0, 0.9) 0%, 
+        rgba(0, 0, 0, 0.7) 50%, 
+        rgba(0, 0, 0, 0) 100%), 
+        url("images/hero4.png");
 }
 
 #hero h4 {


### PR DESCRIPTION
## 📄 Description

Fix the unintended translucent overlay effect on the hero section image 
in light theme that was causing it to appear visually washed out.

The hero background uses a `linear-gradient` overlay on top of the image 
to ensure hero text remains readable. In light theme, the gradient opacity 
values were too high (`0.9` → `0.7`), covering too much of the image and 
making it look faded. This PR reduces the overlay intensity and shortens 
the fade range so the right side of the image is fully visible, while 
keeping enough contrast on the left for text readability.

Dark theme gradient is untouched — it was already visually balanced.

Files changed: `style.css` only. No HTML or JS changes required.

---

## 🔗 Related Issues

Fixes #265

---

## 🖼️ Screenshots (if applicable)

> **Before:** Hero image appears faded/washed out due to heavy white overlay.  
<img width="2048" height="1166" alt="image" src="https://github.com/user-attachments/assets/43128aaf-f2e7-4192-a0fc-a4bf92a171e8" />


> **After:** Hero image is clear on the right, text remains readable on the left.

<img width="2880" height="1640" alt="image" src="https://github.com/user-attachments/assets/3a161a52-dd84-4004-b753-c421a0050268" />

---

## 🧩 Type of Change

- [ ] 🐛 Bug Fix
- [ ] ✨ New Feature
- [x] ⚡ Enhancement / Optimization
- [ ] 🧰 Refactoring
- [ ] 🧾 Documentation Update
- [ ] 🔧 Other (please specify): ____________

---

## ✅ Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated relevant documentation.
- [x] My changes do not break any existing functionality.
- [x] I have tested my changes locally and they work as expected.
- [x] I have linked all relevant issues (if any).

---

## 💬 Additional Notes (Optional)

**Gradient values changed (light theme only):**

| Property | Before | After |
|---|---|---|
| Start opacity | `0.9` at `0%` | `0.75` at `0%` |
| Mid opacity | `0.7` at `40%` | `0.45` at `35%` |
| Fade end point | `0%` at `100%` | `0%` at `65%` |

Moving the fade endpoint from `100%` to `65%` is the key change — the 
image is now fully visible on the right side instead of having a faint 
white tint all the way to the edge.

Dark theme values (`rgba(0,0,0,...)`) are unchanged.