### PR TITLE
fix(banner): improve CTA button visibility on promotional cards

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,5 +1,71 @@
 @import url('https://fonts.googleapis.com/css2?family=Outfit:wght@100..900&family=League+Spartan:wght@100..900&display=swap');
 
+/* Banner3 — solid white button with dark text for max contrast */
+#banner3 .banner-box button {
+  background: rgba(255, 255, 255, 0.92);
+  color: #111;
+  border: none;
+  font-weight: 700;
+  font-size: 14px;
+  padding: 12px 24px;
+  border-radius: 6px;
+  cursor: pointer;
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.25);
+  transition: all 0.3s ease;
+  margin-top: 12px;
+  position: relative;
+  z-index: 2;
+}
+
+#banner3 .banner-box button:hover {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+  transform: translateY(-2px);
+}
+
+/* sm-banner buttons — same treatment */
+#sm-banner .banner-box button {
+  background: rgba(255, 255, 255, 0.92);
+  color: #111;
+  border: none;
+  font-weight: 700;
+  font-size: 14px;
+  padding: 12px 28px;
+  border-radius: 6px;
+  cursor: pointer;
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.25);
+  transition: all 0.3s ease;
+  position: relative;
+  z-index: 2;
+}
+
+#sm-banner .banner-box button:hover {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+  transform: translateY(-2px);
+}
+
+/* Dark theme adjustment */
+[data-theme="dark"] #banner3 .banner-box button,
+[data-theme="dark"] #sm-banner .banner-box button {
+  background: rgba(255, 255, 255, 0.15);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+}
+
+[data-theme="dark"] #banner3 .banner-box button:hover,
+[data-theme="dark"] #sm-banner .banner-box button:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
 /* ============================================
    DARK THEME VARIABLES
    ============================================ */


### PR DESCRIPTION
## 📄 Description

Fix low-visibility CTA buttons ("Learn More", "Explore", "Collection") on 
the `#banner3` and `#sm-banner` promotional cards that were blending into 
the background images due to a transparent/border-only button style.

The buttons previously used a near-invisible transparent background with a 
faint white border, making them extremely difficult to read against the card 
images — especially on the Seasonal Sale and T-Shirts cards. This PR replaces 
that style with a high-contrast frosted glass button that works across all 
background images and both light/dark themes.

Files changed: `style.css` only. No HTML or JS changes required.

---

## 🔗 Related Issues

Fixes #263

---

## 🖼️ Screenshots 

> **Before:** Buttons blend into the background image — low contrast, 
> hard to read.  
<img width="2048" height="1166" alt="image" src="https://github.com/user-attachments/assets/e4eac248-2a5d-49fe-aecb-7774599236e1" />

> **After:** Frosted white glass buttons with dark text — clearly visible 
> over any image, transitions to accent color on hover.
<img width="2048" height="1156" alt="image" src="https://github.com/user-attachments/assets/ae61586f-14b5-4046-9cc5-fea6d6dff3c0" />

---

## 🧩 Type of Change

- [ ] 🐛 Bug Fix
- [ ] ✨ New Feature
- [x] ⚡ Enhancement / Optimization
- [ ] 🧰 Refactoring
- [ ] 🧾 Documentation Update
- [ ] 🔧 Other (please specify): ____________

---

## ✅ Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added or updated relevant documentation.
- [x] My changes do not break any existing functionality.
- [x] I have tested my changes locally and they work as expected.
- [x] I have linked all relevant issues (if any).

---

## 💬 Additional Notes (Optional)

**What changed and why:**

| Property | Before | After |
|---|---|---|
| Background | `transparent` | `rgba(255,255,255,0.92)` |
| Text color | `#fff` (low contrast on light images) | `#111` (high contrast) |
| Border | Faint white border | Removed — not needed with solid bg |
| Effect | None | `backdrop-filter: blur(4px)` frosted glass |
| Shadow | None | `box-shadow` lifts button off the image |
| Hover | Color change only | Transitions to accent color + lift |
| `z-index` | Not set | `2` — renders above `::before`/`::after` pseudo-elements |

**Dark theme** is handled separately — buttons use a frosted dark glass 
style (`rgba(255,255,255,0.15)`) with white text and a subtle border, 
switching to the cyan accent (`#06b6d4`) on hover