### PR TITLE
feat: add styles for shop page search, product grid, and contact page…

### DIFF
--- a/style.css
+++ b/style.css
@@ -658,7 +658,7 @@ button.white .ripple-effect {
 
 [data-theme="dark"] #feature .fe-box h6 {
     color: #ffffff !important;
-    text-shadow: 0 1px 2px rgba(0,0,0,0.4);
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
 }
 
 #feature .fe-box:nth-child(1) h6 {
@@ -1092,6 +1092,481 @@ footer .copyright {
     color: #fff;
     font-weight: 600;
 }
+
+/* ============================================
+   TARGET 1: SHOP PAGE - SEARCH & FILTER
+   ============================================ */
+#search-filter {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    gap: 20px;
+    padding: 30px 80px;
+    background-color: var(--card-bg);
+    border-bottom: 1px solid var(--border-color);
+}
+
+.search-container {
+    display: flex;
+    align-items: center;
+    background: var(--input-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 50px;
+    padding: 6px 20px;
+    width: 100%;
+    max-width: 450px;
+    box-shadow: 0 4px 10px var(--shadow);
+    transition: all 0.3s ease;
+}
+
+.search-container:focus-within {
+    border-color: var(--accent);
+    box-shadow: 0 6px 15px var(--shadow-hover);
+}
+
+#searchInput {
+    flex: 1;
+    border: none;
+    background: transparent;
+    padding: 10px 5px;
+    font-size: 16px;
+    color: var(--text-primary);
+    outline: none;
+}
+
+#searchBtn {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 20px;
+    cursor: pointer;
+    transition: color 0.3s ease;
+    padding: 5px;
+}
+
+#searchBtn:hover {
+    color: var(--accent);
+}
+
+.filter-container {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+}
+
+.filter-container label {
+    font-weight: 600;
+    color: var(--text-primary);
+    font-size: 16px;
+}
+
+#categoryFilter {
+    padding: 12px 40px 12px 20px;
+    border-radius: 8px;
+    border: 1px solid var(--border-color);
+    background-color: var(--input-bg);
+    color: var(--text-primary);
+    font-size: 16px;
+    cursor: pointer;
+    outline: none;
+    transition: all 0.3s ease;
+    box-shadow: 0 4px 10px var(--shadow);
+    appearance: none;
+    background-image: url('data:image/svg+xml;utf8,<svg fill="%23088178" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M7 10l5 5 5-5z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+}
+
+#categoryFilter:focus,
+#categoryFilter:hover {
+    border-color: var(--accent);
+    box-shadow: 0 6px 15px var(--shadow-hover);
+}
+
+/* ============================================
+   TARGET 2: SHOP PAGE - PRODUCT CARDS GRID
+   ============================================ */
+#product1 .pro {
+    display: flex;
+    flex-direction: column;
+    padding: 15px;
+    padding-bottom: 75px;
+    /* Leave space for absolute buttons */
+    border-radius: 20px;
+    box-shadow: 0 5px 15px var(--shadow);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    position: relative;
+    background-color: var(--card-bg);
+    border: 1px solid var(--border-color);
+    overflow: hidden;
+}
+
+#product1 .pro:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 15px 35px var(--shadow-hover);
+}
+
+#product1 .pro img {
+    border-radius: 12px;
+    object-fit: cover;
+    width: 100%;
+    aspect-ratio: 1/1;
+    margin-bottom: 12px;
+}
+
+#product1 .pro .des {
+    padding: 0 5px;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+#product1 .pro .des h5 {
+    font-size: 17px;
+    font-weight: 600;
+    line-height: 1.3;
+    padding-top: 0;
+}
+
+#product1 .pro .des h4 {
+    font-size: 18px;
+    font-weight: 800;
+    color: var(--accent);
+    padding-top: 0;
+}
+
+/* Redesigned CTA Button and absolute positioning */
+#product1 .pro .buy-now-btn {
+    position: absolute;
+    bottom: 18px;
+    left: 15px;
+    width: calc(100% - 75px);
+    /* Flexible width avoiding cart icon */
+    background-color: var(--accent);
+    color: #fff;
+    border: none;
+    padding: 12px 0;
+    border-radius: 50px;
+    font-weight: 700;
+    font-size: 14px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    box-shadow: 0 4px 12px rgba(8, 129, 120, 0.2);
+}
+
+#product1 .pro .buy-now-btn:hover {
+    transform: translateY(-2px);
+    background-color: #066b63;
+    box-shadow: 0 6px 15px rgba(8, 129, 120, 0.35);
+}
+
+/* Polished Cart placement */
+#product1 .pro .cart {
+    position: absolute;
+    bottom: 18px;
+    right: 15px;
+    width: 42px;
+    height: 42px;
+    line-height: 42px;
+    text-align: center;
+    border-radius: 50%;
+    background-color: var(--cart-icon-bg);
+    color: var(--accent);
+    border: 1px solid var(--border-color);
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#product1 .pro .cart:hover {
+    background-color: var(--accent);
+    color: #fff;
+}
+
+/* ============================================
+   TARGET 3: CONTACT PAGE - LAYOUT & FORM PANELS
+   ============================================ */
+#contact-section {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 50px;
+    padding: 60px 80px;
+    background-color: var(--bg-primary);
+}
+
+.contact-left,
+.contact-right {
+    flex: 1;
+    min-width: 320px;
+}
+
+.contact-right {
+    display: flex;
+    flex-direction: column;
+    gap: 30px;
+}
+
+/* Left Panel - Heading & Stats */
+.contact-heading span {
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: 2px;
+    color: var(--accent);
+    text-transform: uppercase;
+}
+
+.contact-heading h2 {
+    font-size: 38px;
+    line-height: 1.2;
+    margin: 15px 0;
+}
+
+.contact-heading p {
+    font-size: 17px;
+    line-height: 1.6;
+    color: var(--text-secondary);
+}
+
+.contact-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 20px;
+    margin: 40px 0;
+}
+
+.stat-box {
+    background: var(--card-bg);
+    padding: 25px 20px;
+    border-radius: 12px;
+    border: 1px solid var(--border-color);
+    text-align: center;
+    box-shadow: 0 4px 15px var(--shadow);
+    transition: transform 0.3s ease;
+}
+
+.stat-box:hover {
+    transform: translateY(-5px);
+}
+
+.stat-box i {
+    font-size: 28px;
+    color: var(--accent);
+    margin-bottom: 15px;
+}
+
+.stat-box h4 {
+    font-size: 16px;
+    margin-bottom: 8px;
+    font-weight: 700;
+}
+
+.stat-box p {
+    font-size: 13px;
+    margin: 0;
+    line-height: 1.4;
+}
+
+/* Form Styles */
+.contact-form {
+    background: var(--card-bg);
+    padding: 40px;
+    border-radius: 16px;
+    box-shadow: 0 10px 30px var(--shadow);
+    border: 1px solid var(--border-color);
+}
+
+.contact-form span {
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: 2px;
+    color: var(--accent);
+    text-transform: uppercase;
+}
+
+.contact-form h2 {
+    font-size: 28px;
+    margin: 10px 0 30px;
+}
+
+.contact-form input,
+.contact-form select,
+.contact-form textarea {
+    width: 100%;
+    padding: 16px;
+    margin-bottom: 20px;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background: var(--input-bg);
+    color: var(--text-primary);
+    font-size: 15px;
+    font-family: inherit;
+    transition: all 0.3s ease;
+}
+
+.contact-form input:focus,
+.contact-form select:focus,
+.contact-form textarea:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px rgba(8, 129, 120, 0.15);
+}
+
+.contact-form textarea {
+    resize: vertical;
+}
+
+.contact-form button {
+    width: 100%;
+    background-color: var(--accent);
+    color: white;
+    padding: 16px;
+    font-size: 16px;
+    font-weight: 700;
+    border-radius: 8px;
+    border: none;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.contact-form button:hover {
+    background-color: #066b63;
+    transform: translateY(-2px);
+    box-shadow: 0 8px 20px rgba(8, 129, 120, 0.25);
+}
+
+/* Right Panel Cards */
+.team-card,
+.office-card,
+.faq-card {
+    background: var(--card-bg);
+    padding: 35px;
+    border-radius: 16px;
+    border: 1px solid var(--border-color);
+    box-shadow: 0 10px 30px var(--shadow);
+}
+
+.team-card h3,
+.office-card h3,
+.faq-card h3 {
+    font-size: 22px;
+    margin-bottom: 20px;
+    font-weight: 700;
+}
+
+.team-card p,
+.faq-card p {
+    font-size: 15px;
+    line-height: 1.6;
+    margin-bottom: 25px;
+}
+
+.team-member {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    margin-top: 25px;
+}
+
+.team-member img {
+    width: 75px;
+    height: 75px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 2px solid var(--accent);
+}
+
+.member-info h4 {
+    font-size: 18px;
+    margin-bottom: 4px;
+    font-weight: 700;
+}
+
+.member-info span {
+    display: block;
+    font-size: 13px;
+    color: var(--text-secondary);
+    margin-bottom: 6px;
+    font-weight: 600;
+}
+
+.member-info a {
+    display: block;
+    font-size: 14px;
+    color: var(--text-primary);
+    text-decoration: none;
+    margin-bottom: 4px;
+    transition: color 0.3s;
+}
+
+.member-info a:hover {
+    color: var(--accent);
+}
+
+.member-info small {
+    display: block;
+    font-size: 12px;
+    color: var(--text-secondary);
+    margin-top: 5px;
+}
+
+.office-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 15px;
+    margin-bottom: 20px;
+}
+
+.office-item i {
+    font-size: 20px;
+    color: var(--accent);
+    margin-top: 2px;
+}
+
+.office-item span {
+    font-size: 15px;
+    line-height: 1.5;
+    color: var(--text-primary);
+}
+
+.faq-card a {
+    display: inline-block;
+    padding: 12px 24px;
+    background: transparent;
+    color: var(--accent);
+    border: 2px solid var(--accent);
+    border-radius: 8px;
+    font-weight: 600;
+    text-decoration: none;
+    transition: all 0.3s ease;
+}
+
+.faq-card a:hover {
+    background: var(--accent);
+    color: white;
+}
+
+/* ============================================
+   MOBILE RESPONSIVENESS TWEAKS
+   ============================================ */
+@media (max-width: 768px) {
+    #contact-section {
+        padding: 40px 20px;
+        flex-direction: column;
+    }
+
+    #search-filter {
+        flex-direction: column;
+        align-items: stretch;
+        padding: 20px;
+    }
+
+    .search-container {
+        max-width: 100%;
+    }
+}
+
 
 /* ============================================
    SINGLE PRODUCT
@@ -1822,14 +2297,22 @@ input:focus {
     min-height: 44px;
 }
 
-#bar:hover { color: var(--accent); }
-#bar.active { transform: rotate(90deg); color: var(--accent); }
+#bar:hover {
+    color: var(--accent);
+}
+
+#bar.active {
+    transform: rotate(90deg);
+    color: var(--accent);
+}
 
 /* ============================================
    TOUCH TARGETS
    ============================================ */
 
-button, .cart, .theme-toggle {
+button,
+.cart,
+.theme-toggle {
     min-height: 44px;
     min-width: 44px;
 }
@@ -1847,13 +2330,34 @@ button, .cart, .theme-toggle {
    ============================================ */
 
 @media (max-width: 1200px) {
-    #header { padding: 16px 50px; }
-    #hero { padding: 0 60px; }
-    .section-p1 { padding: 40px 60px; }
-    #banner3 { padding: 0 60px; }
-    #blog { padding: 120px 100px 0 100px; }
-    #form-details { padding: 60px; margin: 20px; }
-    #product1 .pro { width: 30%; }
+    #header {
+        padding: 16px 50px;
+    }
+
+    #hero {
+        padding: 0 60px;
+    }
+
+    .section-p1 {
+        padding: 40px 60px;
+    }
+
+    #banner3 {
+        padding: 0 60px;
+    }
+
+    #blog {
+        padding: 120px 100px 0 100px;
+    }
+
+    #form-details {
+        padding: 60px;
+        margin: 20px;
+    }
+
+    #product1 .pro {
+        width: 30%;
+    }
 }
 
 /* ============================================
@@ -1861,40 +2365,112 @@ button, .cart, .theme-toggle {
    ============================================ */
 
 @media (max-width: 1024px) {
-    #header { padding: 14px 40px; }
-    #navbar li { padding: 0 12px; }
-    #navbar li a { font-size: 18px; }
+    #header {
+        padding: 14px 40px;
+    }
 
-    h1 { font-size: 52px; line-height: 58px; }
-    h2 { font-size: 40px; line-height: 46px; }
-    h4 { font-size: 24px; }
-    p  { font-size: 18px; }
+    #navbar li {
+        padding: 0 12px;
+    }
 
-    #hero { padding: 0 50px; }
-    .section-p1 { padding: 30px 40px; }
+    #navbar li a {
+        font-size: 18px;
+    }
 
-    #feature .fe-box { width: 160px; margin-top: 70px; }
+    h1 {
+        font-size: 52px;
+        line-height: 58px;
+    }
 
-    #product1 .pro { width: 45%; min-width: 220px; }
-    #product1 .pro-container { gap: 20px; justify-content: center; }
+    h2 {
+        font-size: 40px;
+        line-height: 46px;
+    }
 
-    #sm-banner .banner-box { min-width: 48%; height: 40vh; }
-    #banner3 { padding: 0 40px; }
-    #banner3 .banner-box { min-width: 30%; }
+    h4 {
+        font-size: 24px;
+    }
 
-    #newsletter .form { width: 50%; }
-    #blog { padding: 100px 80px 0 80px; }
+    p {
+        font-size: 18px;
+    }
 
-    #about-us img { width: 45%; }
-    #about-us div { width: 55%; }
+    #hero {
+        padding: 0 50px;
+    }
 
-    #contact-details .details { width: 42%; }
-    #contact-details .map { width: 54%; }
-    #form-details { padding: 50px 40px; margin: 20px; }
-    #form-details form { width: 60%; }
+    .section-p1 {
+        padding: 30px 40px;
+    }
 
-    .subtotal { width: 45%; }
-    #cart-add .coupon { width: 50%; }
+    #feature .fe-box {
+        width: 160px;
+        margin-top: 70px;
+    }
+
+    #product1 .pro {
+        width: 45%;
+        min-width: 220px;
+    }
+
+    #product1 .pro-container {
+        gap: 20px;
+        justify-content: center;
+    }
+
+    #sm-banner .banner-box {
+        min-width: 48%;
+        height: 40vh;
+    }
+
+    #banner3 {
+        padding: 0 40px;
+    }
+
+    #banner3 .banner-box {
+        min-width: 30%;
+    }
+
+    #newsletter .form {
+        width: 50%;
+    }
+
+    #blog {
+        padding: 100px 80px 0 80px;
+    }
+
+    #about-us img {
+        width: 45%;
+    }
+
+    #about-us div {
+        width: 55%;
+    }
+
+    #contact-details .details {
+        width: 42%;
+    }
+
+    #contact-details .map {
+        width: 54%;
+    }
+
+    #form-details {
+        padding: 50px 40px;
+        margin: 20px;
+    }
+
+    #form-details form {
+        width: 60%;
+    }
+
+    .subtotal {
+        width: 45%;
+    }
+
+    #cart-add .coupon {
+        width: 50%;
+    }
 }
 
 /* ============================================
@@ -1902,6 +2478,7 @@ button, .cart, .theme-toggle {
    ============================================ */
 
 @media (max-width: 799px) {
+
     /* Navbar slide panel */
     #navbar {
         display: flex;
@@ -1914,14 +2491,16 @@ button, .cart, .theme-toggle {
         height: 100vh;
         width: 300px;
         background-color: var(--card-bg);
-        box-shadow: 0 40px 60px rgba(0,0,0,0.1);
+        box-shadow: 0 40px 60px rgba(0, 0, 0, 0.1);
         padding: 80px 0 40px 20px;
         z-index: 999;
         overflow-y: auto;
         -webkit-overflow-scrolling: touch;
     }
 
-    #navbar.active { right: 0; }
+    #navbar.active {
+        right: 0;
+    }
 
     #navbar li {
         padding: 0;
@@ -1946,12 +2525,15 @@ button, .cart, .theme-toggle {
     }
 
     /* Mobile overlay when nav open */
-    body.nav-open { overflow: hidden; }
+    body.nav-open {
+        overflow: hidden;
+    }
+
     body.nav-open::after {
         content: '';
         position: fixed;
         inset: 0;
-        background: rgba(0,0,0,0.45);
+        background: rgba(0, 0, 0, 0.45);
         z-index: 998;
         backdrop-filter: blur(3px);
         -webkit-backdrop-filter: blur(3px);
@@ -1972,9 +2554,13 @@ button, .cart, .theme-toggle {
         padding-left: 20px;
     }
 
-    #lg-bag { display: none; }
+    #lg-bag {
+        display: none;
+    }
 
-    #header { padding: 12px 24px; }
+    #header {
+        padding: 12px 24px;
+    }
 
     /* Features 3 columns */
     #feature {
@@ -2000,20 +2586,53 @@ button, .cart, .theme-toggle {
         justify-items: center;
     }
 
-    #product1 .pro { width: 100%; min-width: unset; }
+    #product1 .pro {
+        width: 100%;
+        min-width: unset;
+    }
 
-    .section-p1 { padding: 24px; }
+    .section-p1 {
+        padding: 24px;
+    }
 
-    #banner h4 { font-size: 22px; }
-    #banner h2 { font-size: 30px; padding: 8px 0; }
-    #banner { height: 25vh; }
+    #banner h4 {
+        font-size: 22px;
+    }
 
-    #sm-banner .banner-box { min-width: 100%; height: 45vh; margin: 6px 0; }
+    #banner h2 {
+        font-size: 30px;
+        padding: 8px 0;
+    }
 
-    #banner3 { justify-content: space-around; flex-wrap: wrap; padding: 0 20px; gap: 16px; }
-    #banner3 .banner-box { width: 45%; margin: 10px; }
-    #banner3 .banner-box2 { width: 100%; }
-    #banner3 .banner-box3 { width: 45%; }
+    #banner {
+        height: 25vh;
+    }
+
+    #sm-banner .banner-box {
+        min-width: 100%;
+        height: 45vh;
+        margin: 6px 0;
+    }
+
+    #banner3 {
+        justify-content: space-around;
+        flex-wrap: wrap;
+        padding: 0 20px;
+        gap: 16px;
+    }
+
+    #banner3 .banner-box {
+        width: 45%;
+        margin: 10px;
+    }
+
+    #banner3 .banner-box2 {
+        width: 100%;
+    }
+
+    #banner3 .banner-box3 {
+        width: 45%;
+    }
 
     #newsletter {
         flex-direction: column;
@@ -2023,15 +2642,30 @@ button, .cart, .theme-toggle {
         height: auto;
     }
 
-    #newsletter h4 { font-size: 26px; }
-    #newsletter p  { font-size: 16px; }
+    #newsletter h4 {
+        font-size: 26px;
+    }
+
+    #newsletter p {
+        font-size: 16px;
+    }
+
     #newsletter .form {
         width: 100%;
         flex-direction: column;
         gap: 10px;
     }
-    #newsletter .form input { border-radius: 4px; width: 100%; }
-    #newsletter .form button { border-radius: 4px; width: 100%; padding: 14px; }
+
+    #newsletter .form input {
+        border-radius: 4px;
+        width: 100%;
+    }
+
+    #newsletter .form button {
+        border-radius: 4px;
+        width: 100%;
+        padding: 14px;
+    }
 
     footer {
         display: grid;
@@ -2039,11 +2673,26 @@ button, .cart, .theme-toggle {
         gap: 24px;
         padding: 40px 24px;
     }
-    footer .col { margin-bottom: 0; }
-    footer .copyright { grid-column: 1 / -1; }
-    footer h4 { font-size: 15px; }
-    footer p  { font-size: 15px; }
-    footer a  { font-size: 15px; }
+
+    footer .col {
+        margin-bottom: 0;
+    }
+
+    footer .copyright {
+        grid-column: 1 / -1;
+    }
+
+    footer h4 {
+        font-size: 15px;
+    }
+
+    footer p {
+        font-size: 15px;
+    }
+
+    footer a {
+        font-size: 15px;
+    }
 
     #pro-details {
         margin-top: 80px;
@@ -2052,41 +2701,145 @@ button, .cart, .theme-toggle {
         display: flex;
         gap: 30px;
     }
-    #pro-details .single-pro-image { width: 100%; margin-right: 0; }
-    #pro-details .single-pro-details { width: 100%; padding-top: 30px; }
 
-    #blog { padding: 60px 24px 0; }
-    #blog .blog-box { flex-direction: column; }
-    #blog .blog-img { width: 100%; margin-right: 0; }
-    #blog img { width: 100%; height: 400px; object-position: center; }
-    #blog .blog-details { margin-top: 30px; width: 100%; }
-    #blog .blog-box h1 { top: -7%; }
+    #pro-details .single-pro-image {
+        width: 100%;
+        margin-right: 0;
+    }
 
-    #about-us { flex-direction: column; }
-    #about-us img { width: 100%; }
-    #about-us div { width: 100%; padding: 20px; }
-    #about-app .video { width: 90%; height: auto; }
+    #pro-details .single-pro-details {
+        width: 100%;
+        padding-top: 30px;
+    }
 
-    #contact-details { flex-direction: column; }
-    #contact-details .details { width: 100%; }
-    #contact-details .map { width: 100%; height: 500px; margin-top: 50px; }
+    #blog {
+        padding: 60px 24px 0;
+    }
 
-    #form-details { flex-direction: column; padding: 30px 24px; margin: 16px; gap: 30px; }
-    #form-details form { width: 100%; display: flex; flex-direction: column; align-items: flex-start; }
-    #form-details form button { background-color: #088178; color: #fff; }
-    #form-details .social-media div { padding-bottom: 25px; display: flex; flex-direction: column; align-items: center; }
+    #blog .blog-box {
+        flex-direction: column;
+    }
 
-    #cart { overflow-x: auto; -webkit-overflow-scrolling: touch; }
-    #cart-add { flex-direction: column; padding: 0 24px; gap: 20px; }
-    #cart-add .coupon { width: 100%; display: flex; flex-direction: column; }
-    #cart-add .coupon input { width: 100%; margin-bottom: 10px; margin-right: 0; }
-    #cart-add .coupon button { width: 100%; padding: 14px; }
-    .subtotal { width: 100%; }
+    #blog .blog-img {
+        width: 100%;
+        margin-right: 0;
+    }
+
+    #blog img {
+        width: 100%;
+        height: 400px;
+        object-position: center;
+    }
+
+    #blog .blog-details {
+        margin-top: 30px;
+        width: 100%;
+    }
+
+    #blog .blog-box h1 {
+        top: -7%;
+    }
+
+    #about-us {
+        flex-direction: column;
+    }
+
+    #about-us img {
+        width: 100%;
+    }
+
+    #about-us div {
+        width: 100%;
+        padding: 20px;
+    }
+
+    #about-app .video {
+        width: 90%;
+        height: auto;
+    }
+
+    #contact-details {
+        flex-direction: column;
+    }
+
+    #contact-details .details {
+        width: 100%;
+    }
+
+    #contact-details .map {
+        width: 100%;
+        height: 500px;
+        margin-top: 50px;
+    }
+
+    #form-details {
+        flex-direction: column;
+        padding: 30px 24px;
+        margin: 16px;
+        gap: 30px;
+    }
+
+    #form-details form {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    #form-details form button {
+        background-color: #088178;
+        color: #fff;
+    }
+
+    #form-details .social-media div {
+        padding-bottom: 25px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+
+    #cart {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    #cart-add {
+        flex-direction: column;
+        padding: 0 24px;
+        gap: 20px;
+    }
+
+    #cart-add .coupon {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+    }
+
+    #cart-add .coupon input {
+        width: 100%;
+        margin-bottom: 10px;
+        margin-right: 0;
+    }
+
+    #cart-add .coupon button {
+        width: 100%;
+        padding: 14px;
+    }
+
+    .subtotal {
+        width: 100%;
+    }
 
     /* Forms: prevent iOS zoom */
-    input, textarea, select { font-size: 16px !important; border-radius: 6px; }
+    input,
+    textarea,
+    select {
+        font-size: 16px !important;
+        border-radius: 6px;
+    }
 
-    button.normal, button.white,
+    button.normal,
+    button.white,
     #form-details form button,
     #newsletter .form button,
     #cart-add .coupon button,
@@ -2105,23 +2858,68 @@ button, .cart, .theme-toggle {
    ============================================ */
 
 @media (min-width: 768px) and (max-width: 1024px) {
-    #header { padding: 14px 36px; }
-    #header img { height: 40px; width: auto; }
-    #navbar li { padding: 0 10px; }
-    #navbar li a { font-size: 16px; }
+    #header {
+        padding: 14px 36px;
+    }
 
-    h1 { font-size: 46px; line-height: 52px; }
-    h2 { font-size: 36px; line-height: 42px; }
-    h4 { font-size: 22px; }
-    p  { font-size: 17px; margin: 10px 0 16px; }
+    #header img {
+        height: 40px;
+        width: auto;
+    }
 
-    .section-p1 { padding: 32px 36px; }
+    #navbar li {
+        padding: 0 10px;
+    }
 
-    #hero { padding: 0 48px; background-position: top 20% right 0; }
-    #hero h4 { font-size: 20px; }
-    #hero h1 { font-size: 46px; line-height: 52px; }
-    #hero p  { font-size: 17px; }
-    #hero button { font-size: 15px; padding: 13px 70px 13px 55px; }
+    #navbar li a {
+        font-size: 16px;
+    }
+
+    h1 {
+        font-size: 46px;
+        line-height: 52px;
+    }
+
+    h2 {
+        font-size: 36px;
+        line-height: 42px;
+    }
+
+    h4 {
+        font-size: 22px;
+    }
+
+    p {
+        font-size: 17px;
+        margin: 10px 0 16px;
+    }
+
+    .section-p1 {
+        padding: 32px 36px;
+    }
+
+    #hero {
+        padding: 0 48px;
+        background-position: top 20% right 0;
+    }
+
+    #hero h4 {
+        font-size: 20px;
+    }
+
+    #hero h1 {
+        font-size: 46px;
+        line-height: 52px;
+    }
+
+    #hero p {
+        font-size: 17px;
+    }
+
+    #hero button {
+        font-size: 15px;
+        padding: 13px 70px 13px 55px;
+    }
 
     #feature {
         display: grid;
@@ -2129,8 +2927,18 @@ button, .cart, .theme-toggle {
         gap: 18px;
         justify-items: center;
     }
-    #feature .fe-box { width: 100%; max-width: 200px; margin: 16px 0; margin-top: 50px; padding: 22px 14px; }
-    #feature .fe-box h6 { font-size: 14px; }
+
+    #feature .fe-box {
+        width: 100%;
+        max-width: 200px;
+        margin: 16px 0;
+        margin-top: 50px;
+        padding: 22px 14px;
+    }
+
+    #feature .fe-box h6 {
+        font-size: 14px;
+    }
 
     #product1 .pro-container {
         display: grid;
@@ -2139,90 +2947,343 @@ button, .cart, .theme-toggle {
         justify-items: center;
         padding-top: 16px;
     }
-    #product1 .pro { width: 100%; min-width: unset; }
-    #product1 .pro img { height: 220px; object-fit: cover; }
 
-    #banner { height: 35vh; min-height: 220px; }
-    #banner h4 { font-size: 24px; }
-    #banner h2 { font-size: 36px; padding: 8px 0; }
+    #product1 .pro {
+        width: 100%;
+        min-width: unset;
+    }
 
-    #sm-banner { flex-direction: row; flex-wrap: nowrap; }
-    #sm-banner .banner-box { min-width: 50%; height: 44vh; padding: 28px 24px; }
-    #sm-banner h4   { font-size: 26px; }
-    #sm-banner h2   { font-size: 34px; }
-    #sm-banner span { font-size: 20px; }
+    #product1 .pro img {
+        height: 220px;
+        object-fit: cover;
+    }
 
-    #banner3 { padding: 0 36px; gap: 16px; flex-wrap: nowrap; }
-    #banner3 .banner-box { min-width: 0; flex: 1; height: 28vh; min-height: 200px; margin-bottom: 0; }
-    #banner3 h2 { font-size: 22px; }
-    #banner3 h3 { font-size: 17px; }
+    #banner {
+        height: 35vh;
+        min-height: 220px;
+    }
 
-    #newsletter { flex-direction: row; align-items: center; flex-wrap: nowrap; padding: 40px 36px; gap: 24px; height: auto; }
-    #newsletter h4 { font-size: 26px; }
-    #newsletter p  { font-size: 16px; }
-    #newsletter .form { width: 46%; flex-shrink: 0; flex-direction: row; }
-    #newsletter .form input { border-radius: 4px 0 0 4px; }
-    #newsletter .form button { border-radius: 0 4px 4px 0; white-space: nowrap; padding: 0 18px; width: auto; }
+    #banner h4 {
+        font-size: 24px;
+    }
 
-    footer { display: grid; grid-template-columns: repeat(3, 1fr); gap: 28px; padding: 48px 36px 32px; }
-    footer .copyright { grid-column: 1 / -1; text-align: center; }
-    footer h4 { font-size: 17px; margin-bottom: 14px; }
-    footer p  { font-size: 15px; }
-    footer a  { font-size: 15px; }
+    #banner h2 {
+        font-size: 36px;
+        padding: 8px 0;
+    }
 
-    #pro-details { flex-direction: row; gap: 32px; margin-top: 90px; }
-    #pro-details .single-pro-image { width: 44%; margin-right: 0; }
-    #pro-details .single-pro-details { width: 52%; padding-top: 20px; }
-    #pro-details .single-pro-details h2 { font-size: 22px; }
-    #pro-details .single-pro-details h4 { font-size: 18px; padding: 24px 0 16px; }
+    #sm-banner {
+        flex-direction: row;
+        flex-wrap: nowrap;
+    }
 
-    #blog { padding: 90px 60px 0; }
-    #blog .blog-box { flex-direction: row; align-items: center; }
-    #blog .blog-img { width: 48%; margin-right: 36px; }
-    #blog img { height: 260px; object-fit: cover; }
-    #blog .blog-details { width: 48%; }
-    #blog .blog-box h1 { font-size: 60px; }
+    #sm-banner .banner-box {
+        min-width: 50%;
+        height: 44vh;
+        padding: 28px 24px;
+    }
 
-    #about-us { flex-direction: row; }
-    #about-us img { width: 46%; height: auto; }
-    #about-us div { width: 54%; padding: 36px; }
-    #about-app .video { width: 80%; height: auto; }
+    #sm-banner h4 {
+        font-size: 26px;
+    }
 
-    #contact-details { flex-direction: row; align-items: flex-start; }
-    #contact-details .details { width: 40%; }
-    #contact-details .map { width: 56%; height: 380px; }
+    #sm-banner h2 {
+        font-size: 34px;
+    }
 
-    #form-details { flex-direction: row; padding: 52px 44px; margin: 24px; gap: 40px; }
-    #form-details form { width: 60%; }
-    #form-details form input, #form-details form textarea { font-size: 15px; padding: 11px 14px; margin-bottom: 20px; }
+    #sm-banner span {
+        font-size: 20px;
+    }
 
-    #cart table img { width: 120px; }
-    #cart table thead td { padding: 16px 12px; font-size: 15px; }
-    #cart table tbody tr td { padding: 14px 12px; font-size: 17px; }
+    #banner3 {
+        padding: 0 36px;
+        gap: 16px;
+        flex-wrap: nowrap;
+    }
 
-    #cart-add { flex-direction: row; align-items: flex-start; gap: 24px; padding: 0 36px; }
-    #cart-add .coupon { width: 48%; display: block; }
-    #cart-add .coupon input { width: 100%; margin-right: 0; margin-bottom: 12px; }
-    #cart-add .coupon button { width: auto; padding: 12px 22px; }
-    .subtotal { width: 48%; }
+    #banner3 .banner-box {
+        min-width: 0;
+        flex: 1;
+        height: 28vh;
+        min-height: 200px;
+        margin-bottom: 0;
+    }
 
-    #shop-hero h2 { font-size: 40px; }
-    #shop-hero p  { font-size: 18px; }
-    #pagination a { padding: 12px 18px; font-size: 15px; min-width: 46px; }
-    #blog-head, #about-head { height: 45vh; }
-    #blog-head h2, #about-head h2 { font-size: 40px; }
-    #blog-head p,  #about-head p  { font-size: 17px; }
+    #banner3 h2 {
+        font-size: 22px;
+    }
 
-    button.normal, button.white { min-height: 46px; padding: 13px 26px; font-size: 15px; }
-    input, textarea, select { font-size: 16px !important; }
+    #banner3 h3 {
+        font-size: 17px;
+    }
+
+    #newsletter {
+        flex-direction: row;
+        align-items: center;
+        flex-wrap: nowrap;
+        padding: 40px 36px;
+        gap: 24px;
+        height: auto;
+    }
+
+    #newsletter h4 {
+        font-size: 26px;
+    }
+
+    #newsletter p {
+        font-size: 16px;
+    }
+
+    #newsletter .form {
+        width: 46%;
+        flex-shrink: 0;
+        flex-direction: row;
+    }
+
+    #newsletter .form input {
+        border-radius: 4px 0 0 4px;
+    }
+
+    #newsletter .form button {
+        border-radius: 0 4px 4px 0;
+        white-space: nowrap;
+        padding: 0 18px;
+        width: auto;
+    }
+
+    footer {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 28px;
+        padding: 48px 36px 32px;
+    }
+
+    footer .copyright {
+        grid-column: 1 / -1;
+        text-align: center;
+    }
+
+    footer h4 {
+        font-size: 17px;
+        margin-bottom: 14px;
+    }
+
+    footer p {
+        font-size: 15px;
+    }
+
+    footer a {
+        font-size: 15px;
+    }
+
+    #pro-details {
+        flex-direction: row;
+        gap: 32px;
+        margin-top: 90px;
+    }
+
+    #pro-details .single-pro-image {
+        width: 44%;
+        margin-right: 0;
+    }
+
+    #pro-details .single-pro-details {
+        width: 52%;
+        padding-top: 20px;
+    }
+
+    #pro-details .single-pro-details h2 {
+        font-size: 22px;
+    }
+
+    #pro-details .single-pro-details h4 {
+        font-size: 18px;
+        padding: 24px 0 16px;
+    }
+
+    #blog {
+        padding: 90px 60px 0;
+    }
+
+    #blog .blog-box {
+        flex-direction: row;
+        align-items: center;
+    }
+
+    #blog .blog-img {
+        width: 48%;
+        margin-right: 36px;
+    }
+
+    #blog img {
+        height: 260px;
+        object-fit: cover;
+    }
+
+    #blog .blog-details {
+        width: 48%;
+    }
+
+    #blog .blog-box h1 {
+        font-size: 60px;
+    }
+
+    #about-us {
+        flex-direction: row;
+    }
+
+    #about-us img {
+        width: 46%;
+        height: auto;
+    }
+
+    #about-us div {
+        width: 54%;
+        padding: 36px;
+    }
+
+    #about-app .video {
+        width: 80%;
+        height: auto;
+    }
+
+    #contact-details {
+        flex-direction: row;
+        align-items: flex-start;
+    }
+
+    #contact-details .details {
+        width: 40%;
+    }
+
+    #contact-details .map {
+        width: 56%;
+        height: 380px;
+    }
+
+    #form-details {
+        flex-direction: row;
+        padding: 52px 44px;
+        margin: 24px;
+        gap: 40px;
+    }
+
+    #form-details form {
+        width: 60%;
+    }
+
+    #form-details form input,
+    #form-details form textarea {
+        font-size: 15px;
+        padding: 11px 14px;
+        margin-bottom: 20px;
+    }
+
+    #cart table img {
+        width: 120px;
+    }
+
+    #cart table thead td {
+        padding: 16px 12px;
+        font-size: 15px;
+    }
+
+    #cart table tbody tr td {
+        padding: 14px 12px;
+        font-size: 17px;
+    }
+
+    #cart-add {
+        flex-direction: row;
+        align-items: flex-start;
+        gap: 24px;
+        padding: 0 36px;
+    }
+
+    #cart-add .coupon {
+        width: 48%;
+        display: block;
+    }
+
+    #cart-add .coupon input {
+        width: 100%;
+        margin-right: 0;
+        margin-bottom: 12px;
+    }
+
+    #cart-add .coupon button {
+        width: auto;
+        padding: 12px 22px;
+    }
+
+    .subtotal {
+        width: 48%;
+    }
+
+    #shop-hero h2 {
+        font-size: 40px;
+    }
+
+    #shop-hero p {
+        font-size: 18px;
+    }
+
+    #pagination a {
+        padding: 12px 18px;
+        font-size: 15px;
+        min-width: 46px;
+    }
+
+    #blog-head,
+    #about-head {
+        height: 45vh;
+    }
+
+    #blog-head h2,
+    #about-head h2 {
+        font-size: 40px;
+    }
+
+    #blog-head p,
+    #about-head p {
+        font-size: 17px;
+    }
+
+    button.normal,
+    button.white {
+        min-height: 46px;
+        padding: 13px 26px;
+        font-size: 15px;
+    }
+
+    input,
+    textarea,
+    select {
+        font-size: 16px !important;
+    }
 }
 
 @media (min-width: 900px) and (max-width: 1024px) {
-    #feature { grid-template-columns: repeat(6, 1fr); }
-    #feature .fe-box { max-width: 160px; margin-top: 80px; }
-    #product1 .pro-container { grid-template-columns: repeat(3, 1fr); }
-    #newsletter .form { width: 42%; }
-    footer { grid-template-columns: repeat(4, 1fr); }
+    #feature {
+        grid-template-columns: repeat(6, 1fr);
+    }
+
+    #feature .fe-box {
+        max-width: 160px;
+        margin-top: 80px;
+    }
+
+    #product1 .pro-container {
+        grid-template-columns: repeat(3, 1fr);
+    }
+
+    #newsletter .form {
+        width: 42%;
+    }
+
+    footer {
+        grid-template-columns: repeat(4, 1fr);
+    }
 }
 
 /* ============================================
@@ -2230,29 +3291,87 @@ button, .cart, .theme-toggle {
    ============================================ */
 
 @media (max-width: 600px) {
-    h1 { font-size: 36px; line-height: 40px; }
-    h2 { font-size: 28px; line-height: 34px; }
-    h4 { font-size: 20px; }
-    p  { font-size: 16px; }
+    h1 {
+        font-size: 36px;
+        line-height: 40px;
+    }
 
-    #feature { grid-template-columns: repeat(2, 1fr); gap: 12px; }
-    #feature .fe-box { max-width: 100%; }
+    h2 {
+        font-size: 28px;
+        line-height: 34px;
+    }
 
-    #product1 .pro-container { grid-template-columns: 1fr; gap: 16px; }
-    #product1 .pro { max-width: 400px; margin: 0 auto; width: 100%; }
+    h4 {
+        font-size: 20px;
+    }
 
-    #banner { height: 35vh; min-height: 200px; }
-    #banner h4 { font-size: 18px; }
-    #banner h2 { font-size: 24px; }
+    p {
+        font-size: 16px;
+    }
 
-    #sm-banner .banner-box { height: 40vh; padding: 20px; }
-    #sm-banner h4 { font-size: 22px; }
-    #sm-banner h2 { font-size: 28px; }
-    #sm-banner span { font-size: 18px; }
+    #feature {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 12px;
+    }
 
-    #blog { padding: 50px 20px 0; }
-    #blog .blog-box h1 { font-size: 48px; top: -5%; }
-    #about-app .video { width: 100%; height: auto; }
+    #feature .fe-box {
+        max-width: 100%;
+    }
+
+    #product1 .pro-container {
+        grid-template-columns: 1fr;
+        gap: 16px;
+    }
+
+    #product1 .pro {
+        max-width: 400px;
+        margin: 0 auto;
+        width: 100%;
+    }
+
+    #banner {
+        height: 35vh;
+        min-height: 200px;
+    }
+
+    #banner h4 {
+        font-size: 18px;
+    }
+
+    #banner h2 {
+        font-size: 24px;
+    }
+
+    #sm-banner .banner-box {
+        height: 40vh;
+        padding: 20px;
+    }
+
+    #sm-banner h4 {
+        font-size: 22px;
+    }
+
+    #sm-banner h2 {
+        font-size: 28px;
+    }
+
+    #sm-banner span {
+        font-size: 18px;
+    }
+
+    #blog {
+        padding: 50px 20px 0;
+    }
+
+    #blog .blog-box h1 {
+        font-size: 48px;
+        top: -5%;
+    }
+
+    #about-app .video {
+        width: 100%;
+        height: auto;
+    }
 }
 
 /* ============================================
@@ -2260,90 +3379,293 @@ button, .cart, .theme-toggle {
    ============================================ */
 
 @media (max-width: 477px) {
-    #header { padding: 10px 16px; }
-    #header img { height: 36px; width: auto; }
-    .mobile i { font-size: 22px; padding-left: 14px; }
+    #header {
+        padding: 10px 16px;
+    }
 
-    h1 { font-size: 32px; line-height: 36px; }
-    h2 { font-size: 26px; line-height: 32px; }
-    h4 { font-size: 18px; }
-    p  { font-size: 15px; margin: 8px 0 14px; }
+    #header img {
+        height: 36px;
+        width: auto;
+    }
 
-    .section-p1 { padding: 16px; }
+    .mobile i {
+        font-size: 22px;
+        padding-left: 14px;
+    }
+
+    h1 {
+        font-size: 32px;
+        line-height: 36px;
+    }
+
+    h2 {
+        font-size: 26px;
+        line-height: 32px;
+    }
+
+    h4 {
+        font-size: 18px;
+    }
+
+    p {
+        font-size: 15px;
+        margin: 8px 0 14px;
+    }
+
+    .section-p1 {
+        padding: 16px;
+    }
 
     #hero {
         background-position: 55%;
         padding: 0 20px;
     }
 
-    #hero h4 { font-size: 14px; padding-bottom: 8px; }
-    #hero button { font-size: 13px; padding: 10px 40px 10px 30px; margin-top: 8px; }
+    #hero h4 {
+        font-size: 14px;
+        padding-bottom: 8px;
+    }
 
-    #feature { grid-template-columns: repeat(2, 1fr); gap: 10px; }
-    #feature .fe-box { padding: 16px 8px; margin: 0; }
-    #feature .fe-box h6 { font-size: 13px; }
+    #hero button {
+        font-size: 13px;
+        padding: 10px 40px 10px 30px;
+        margin-top: 8px;
+    }
 
-    #product1 .pro { max-width: 100%; margin: 0; }
+    #feature {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 10px;
+    }
 
-    #banner { height: 40vh; }
-    #banner h4 { font-size: 15px; }
-    #banner h2 { font-size: 20px; }
-    #banner button { font-size: 13px; padding: 10px 18px; }
+    #feature .fe-box {
+        padding: 16px 8px;
+        margin: 0;
+    }
 
-    #sm-banner .banner-box { height: 50vh; padding: 0 20px; width: 100%; margin: 10px; }
-    #sm-banner h4 { font-size: 18px; }
-    #sm-banner h2 { font-size: 22px; }
-    #sm-banner span { font-size: 15px; padding-bottom: 10px; }
+    #feature .fe-box h6 {
+        font-size: 13px;
+    }
 
-    #banner3 { padding: 0 16px; gap: 10px; }
-    #banner3 .banner-box { width: 100%; margin: 10px; height: 22vh; min-height: 160px; }
-    #banner3 .banner-box2 { width: 100%; }
-    #banner3 .banner-box3 { width: 100%; }
-    #banner3 h2 { font-size: 20px; }
-    #banner3 h3 { font-size: 16px; }
+    #product1 .pro {
+        max-width: 100%;
+        margin: 0;
+    }
 
-    #newsletter { padding: 30px 16px; height: auto; }
-    #newsletter h4 { font-size: 20px; }
-    #newsletter p  { font-size: 14px; }
-    #newsletter .form { width: 100%; }
+    #banner {
+        height: 40vh;
+    }
 
-    footer { grid-template-columns: 1fr; padding: 30px 16px; gap: 20px; }
-    footer h4 { font-size: 16px; margin-bottom: 12px; }
-    footer p  { font-size: 14px; }
-    footer a  { font-size: 14px; }
+    #banner h4 {
+        font-size: 15px;
+    }
 
-    #pro-details { margin-top: 70px; }
-    #pro-details .single-pro-details h2 { font-size: 20px; }
-    #pro-details .single-pro-details h4 { font-size: 16px; padding: 20px 0 12px; }
-    #pro-details .single-pro-details input { width: 45px; height: 40px; }
+    #banner h2 {
+        font-size: 20px;
+    }
 
-    #blog { padding: 40px 16px 0; }
-    #blog .blog-box h1 { font-size: 40px; top: -4%; }
-    #blog img { height: 220px; }
+    #banner button {
+        font-size: 13px;
+        padding: 10px 18px;
+    }
 
-    #about-us img { height: 60vh; }
-    #about-us div { padding: 16px; }
-    #about-app .video { width: 100%; }
+    #sm-banner .banner-box {
+        height: 50vh;
+        padding: 0 20px;
+        width: 100%;
+        margin: 10px;
+    }
 
-    #contact-details .map { height: 320px; margin-top: 30px; }
-    #form-details { padding: 20px 16px; margin: 10px; }
-    #form-details form input, #form-details form textarea { padding: 10px 12px; margin-bottom: 16px; font-size: 15px; }
+    #sm-banner h4 {
+        font-size: 18px;
+    }
 
-    #cart table { font-size: 14px; }
-    #cart table img { width: 90px; }
-    #cart table thead td { padding: 12px 8px; font-size: 13px; }
-    #cart table tbody tr td { padding: 10px 8px; }
+    #sm-banner h2 {
+        font-size: 22px;
+    }
 
-    #cart-add { padding: 0 16px; }
-    #cart-add .coupon h3, .subtotal h3 { font-size: 20px; padding-bottom: 10px; }
-    .subtotal { padding: 20px; }
+    #sm-banner span {
+        font-size: 15px;
+        padding-bottom: 10px;
+    }
 
-    #pagination a { padding: 10px 14px; font-size: 14px; min-width: 40px; }
+    #banner3 {
+        padding: 0 16px;
+        gap: 10px;
+    }
 
-    #shop-hero h2 { font-size: 28px; }
-    #shop-hero p  { font-size: 16px; }
-    #blog-head h2, #about-head h2 { font-size: 28px; }
-    #blog-head p,  #about-head p  { font-size: 15px; }
+    #banner3 .banner-box {
+        width: 100%;
+        margin: 10px;
+        height: 22vh;
+        min-height: 160px;
+    }
+
+    #banner3 .banner-box2 {
+        width: 100%;
+    }
+
+    #banner3 .banner-box3 {
+        width: 100%;
+    }
+
+    #banner3 h2 {
+        font-size: 20px;
+    }
+
+    #banner3 h3 {
+        font-size: 16px;
+    }
+
+    #newsletter {
+        padding: 30px 16px;
+        height: auto;
+    }
+
+    #newsletter h4 {
+        font-size: 20px;
+    }
+
+    #newsletter p {
+        font-size: 14px;
+    }
+
+    #newsletter .form {
+        width: 100%;
+    }
+
+    footer {
+        grid-template-columns: 1fr;
+        padding: 30px 16px;
+        gap: 20px;
+    }
+
+    footer h4 {
+        font-size: 16px;
+        margin-bottom: 12px;
+    }
+
+    footer p {
+        font-size: 14px;
+    }
+
+    footer a {
+        font-size: 14px;
+    }
+
+    #pro-details {
+        margin-top: 70px;
+    }
+
+    #pro-details .single-pro-details h2 {
+        font-size: 20px;
+    }
+
+    #pro-details .single-pro-details h4 {
+        font-size: 16px;
+        padding: 20px 0 12px;
+    }
+
+    #pro-details .single-pro-details input {
+        width: 45px;
+        height: 40px;
+    }
+
+    #blog {
+        padding: 40px 16px 0;
+    }
+
+    #blog .blog-box h1 {
+        font-size: 40px;
+        top: -4%;
+    }
+
+    #blog img {
+        height: 220px;
+    }
+
+    #about-us img {
+        height: 60vh;
+    }
+
+    #about-us div {
+        padding: 16px;
+    }
+
+    #about-app .video {
+        width: 100%;
+    }
+
+    #contact-details .map {
+        height: 320px;
+        margin-top: 30px;
+    }
+
+    #form-details {
+        padding: 20px 16px;
+        margin: 10px;
+    }
+
+    #form-details form input,
+    #form-details form textarea {
+        padding: 10px 12px;
+        margin-bottom: 16px;
+        font-size: 15px;
+    }
+
+    #cart table {
+        font-size: 14px;
+    }
+
+    #cart table img {
+        width: 90px;
+    }
+
+    #cart table thead td {
+        padding: 12px 8px;
+        font-size: 13px;
+    }
+
+    #cart table tbody tr td {
+        padding: 10px 8px;
+    }
+
+    #cart-add {
+        padding: 0 16px;
+    }
+
+    #cart-add .coupon h3,
+    .subtotal h3 {
+        font-size: 20px;
+        padding-bottom: 10px;
+    }
+
+    .subtotal {
+        padding: 20px;
+    }
+
+    #pagination a {
+        padding: 10px 14px;
+        font-size: 14px;
+        min-width: 40px;
+    }
+
+    #shop-hero h2 {
+        font-size: 28px;
+    }
+
+    #shop-hero p {
+        font-size: 16px;
+    }
+
+    #blog-head h2,
+    #about-head h2 {
+        font-size: 28px;
+    }
+
+    #blog-head p,
+    #about-head p {
+        font-size: 15px;
+    }
 }
 
 /* ============================================
@@ -2351,17 +3673,55 @@ button, .cart, .theme-toggle {
    ============================================ */
 
 @media (max-width: 360px) {
-    #header { padding: 8px 12px; }
-    #header img { height: 30px; }
-    h1 { font-size: 28px; line-height: 32px; }
-    h2 { font-size: 22px; line-height: 28px; }
-    .section-p1 { padding: 12px; }
-    #hero { padding: 0 12px; }
-    #feature { grid-template-columns: repeat(2, 1fr); gap: 8px; }
-    #feature .fe-box { padding: 12px 6px; }
-    #newsletter .form input, #newsletter .form button { padding: 10px; font-size: 14px; }
-    #form-details { padding: 16px 12px; margin: 8px; }
-    footer { padding: 24px 12px; }
+    #header {
+        padding: 8px 12px;
+    }
+
+    #header img {
+        height: 30px;
+    }
+
+    h1 {
+        font-size: 28px;
+        line-height: 32px;
+    }
+
+    h2 {
+        font-size: 22px;
+        line-height: 28px;
+    }
+
+    .section-p1 {
+        padding: 12px;
+    }
+
+    #hero {
+        padding: 0 12px;
+    }
+
+    #feature {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 8px;
+    }
+
+    #feature .fe-box {
+        padding: 12px 6px;
+    }
+
+    #newsletter .form input,
+    #newsletter .form button {
+        padding: 10px;
+        font-size: 14px;
+    }
+
+    #form-details {
+        padding: 16px 12px;
+        margin: 8px;
+    }
+
+    footer {
+        padding: 24px 12px;
+    }
 }
 
 /* ============================================
@@ -2371,7 +3731,10 @@ button, .cart, .theme-toggle {
    ============================================ */
 
 @media (max-width: 640px) {
-    #main { height: auto; min-height: 100svh; }
+    #main {
+        height: auto;
+        min-height: 100svh;
+    }
 
     #top {
         position: relative !important;
@@ -2384,7 +3747,9 @@ button, .cart, .theme-toggle {
         min-height: 100svh;
     }
 
-    #back { display: none; }
+    #back {
+        display: none;
+    }
 
     #hero {
         position: relative !important;
@@ -2401,10 +3766,25 @@ button, .cart, .theme-toggle {
         box-sizing: border-box !important;
     }
 
-    #hero h4 { font-size: 14px !important; padding-bottom: 6px !important; }
-    #hero h2 { font-size: 24px !important; line-height: 28px !important; }
-    #hero h1 { font-size: 30px !important; line-height: 34px !important; }
-    #hero p  { font-size: 14px !important; margin: 6px 0 14px !important; }
+    #hero h4 {
+        font-size: 14px !important;
+        padding-bottom: 6px !important;
+    }
+
+    #hero h2 {
+        font-size: 24px !important;
+        line-height: 28px !important;
+    }
+
+    #hero h1 {
+        font-size: 30px !important;
+        line-height: 34px !important;
+    }
+
+    #hero p {
+        font-size: 14px !important;
+        margin: 6px 0 14px !important;
+    }
 
     /* Feature: kill the fixed 180px width */
     #feature {
@@ -2417,7 +3797,7 @@ button, .cart, .theme-toggle {
     }
 
     #feature .fe-box,
-    #feature > div {
+    #feature>div {
         width: 100% !important;
         min-width: 0 !important;
         max-width: 100% !important;
@@ -2448,12 +3828,17 @@ button, .cart, .theme-toggle {
 
 canvas {
     position: fixed;
-    top: 0; left: 0;
+    top: 0;
+    left: 0;
     pointer-events: none;
     z-index: -100;
 }
 
-#pagination { text-align: center; padding: 40px 0; margin-top: 20px; }
+#pagination {
+    text-align: center;
+    padding: 40px 0;
+    margin-top: 20px;
+}
 
 #pagination a {
     text-decoration: none;
@@ -2469,33 +3854,123 @@ canvas {
     text-align: center;
 }
 
-#pagination a:hover:not(.disabled) { background-color: #066e66; transform: translateY(-2px); box-shadow: 0 4px 8px rgba(8,129,120,0.3); }
-#pagination a.active { background-color: #066e66; box-shadow: 0 4px 12px rgba(8,129,120,0.4); transform: scale(1.1); }
-#pagination a.disabled { background-color: #ccc; cursor: not-allowed; opacity: 0.5; pointer-events: none; }
-#pagination a.pagination-arrow { padding: 15px 18px; font-size: 18px; }
-#pagination a.pagination-arrow i { display: flex; align-items: center; justify-content: center; }
+#pagination a:hover:not(.disabled) {
+    background-color: #066e66;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 8px rgba(8, 129, 120, 0.3);
+}
 
-[data-theme="dark"] #pagination a { background-color: #06b6d4; }
-[data-theme="dark"] #pagination a:hover:not(.disabled) { background-color: #0891b2; }
-[data-theme="dark"] #pagination a.active { background-color: #0891b2; box-shadow: 0 4px 12px rgba(6,182,212,0.4); }
-[data-theme="dark"] #pagination a.disabled { background-color: #2d3748; }
+#pagination a.active {
+    background-color: #066e66;
+    box-shadow: 0 4px 12px rgba(8, 129, 120, 0.4);
+    transform: scale(1.1);
+}
 
-.modal { display: none; position: fixed; z-index: 1000; left: 0; top: 0; width: 100%; height: 100%; background-color: rgba(0,0,0,0.5); justify-content: center; align-items: center; }
-.modal-content { background-color: var(--bg-primary); padding: 20px; border-radius: 8px; width: 90%; max-width: 400px; text-align: center; position: relative; }
-.close { position: absolute; top: 10px; right: 15px; font-size: 24px; cursor: pointer; }
-.quiz-options { display: flex; flex-direction: column; gap: 10px; margin-top: 20px; }
-.quiz-options button { padding: 10px; background-color: var(--accent); color: white; border: none; border-radius: 4px; cursor: pointer; }
-.quiz-options button:hover { background-color: #066a5c; }
+#pagination a.disabled {
+    background-color: #ccc;
+    cursor: not-allowed;
+    opacity: 0.5;
+    pointer-events: none;
+}
+
+#pagination a.pagination-arrow {
+    padding: 15px 18px;
+    font-size: 18px;
+}
+
+#pagination a.pagination-arrow i {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+[data-theme="dark"] #pagination a {
+    background-color: #06b6d4;
+}
+
+[data-theme="dark"] #pagination a:hover:not(.disabled) {
+    background-color: #0891b2;
+}
+
+[data-theme="dark"] #pagination a.active {
+    background-color: #0891b2;
+    box-shadow: 0 4px 12px rgba(6, 182, 212, 0.4);
+}
+
+[data-theme="dark"] #pagination a.disabled {
+    background-color: #2d3748;
+}
+
+.modal {
+    display: none;
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    justify-content: center;
+    align-items: center;
+}
+
+.modal-content {
+    background-color: var(--bg-primary);
+    padding: 20px;
+    border-radius: 8px;
+    width: 90%;
+    max-width: 400px;
+    text-align: center;
+    position: relative;
+}
+
+.close {
+    position: absolute;
+    top: 10px;
+    right: 15px;
+    font-size: 24px;
+    cursor: pointer;
+}
+
+.quiz-options {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 20px;
+}
+
+.quiz-options button {
+    padding: 10px;
+    background-color: var(--accent);
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.quiz-options button:hover {
+    background-color: #066a5c;
+}
 
 /* ============================================
    ACCESSIBILITY
    ============================================ */
 
 @media (prefers-reduced-motion: reduce) {
-    *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; }
+
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        transition-duration: 0.01ms !important;
+    }
 }
 
-a:focus-visible, button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible {
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible {
     outline: 3px solid var(--accent);
     outline-offset: 3px;
     border-radius: 4px;
@@ -2511,7 +3986,7 @@ a:focus-visible, button:focus-visible, input:focus-visible, textarea:focus-visib
 
 
 /* Feature box title text in dark mode */
-[data-theme="dark"] #feature .fe-box img + h6,
+[data-theme="dark"] #feature .fe-box img+h6,
 [data-theme="dark"] #feature .fe-box p {
     color: var(--text-primary);
 }


### PR DESCRIPTION
# 📝 Pull Request Template

## 📄 Description

This pull request completely refactors the UI/UX layout and responsive design mechanics for both the Shop and Contact pages. It introduces clean container structures, balanced viewport scaling, and premium design patterns to replace broken alignments on mobile and tablet devices.

Specifically, it wraps the disjointed shop search and filtering inputs into a sleek, aligned flex row dashboard, scales down the oversized product cards into uniform grid tiles with beautiful "Buy Now" interactive CTA buttons, and resolves the compressed text layout on the contact page by introducing a polished two-column form structure.

---

## 🔗 Related Issues

Fixes #105

---

## 🖼️ Screenshots (if applicable)

*Add your local screenshot links or drag-and-drop your layout images right here!*

---

## 🧩 Type of Change

- [ ] 🐛 Bug Fix  
- [ ] ✨ New Feature  
- [x] ⚡ Enhancement / Optimization  
- [x] 🧰 Refactoring  
- [ ] 🧾 Documentation Update  
- [ ] 🔧 Other (please specify): ____________

---

## ✅ Checklist

- [x] I have performed a self-review of my code.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [ ] I have added or updated relevant documentation.  
- [x] My changes do not break any existing functionality.  
- [x] I have tested my changes locally and they work as expected.  
- [x] I have linked all relevant issues (if any).

---

## 💬 Additional Notes (Optional)

All updates were written natively within `style.css` using targeted selectors and media queries to safeguard structural integrity and maintain existing JavaScript mechanics without regression.


## Before

<img width="1416" height="796" alt="Screenshot 2026-05-17 at 11 50 32 PM" src="https://github.com/user-attachments/assets/16afa3e3-9bd1-4e8f-a003-451549e720f8" />


<img width="1425" height="819" alt="Screenshot 2026-05-17 at 11 50 54 PM" src="https://github.com/user-attachments/assets/c6c77b49-96c3-442a-a69e-c3cd31fd6a98" />




## After

<img width="1440" height="900" alt="Screenshot 2026-05-17 at 11 34 56 PM" src="https://github.com/user-attachments/assets/ad854590-d1f9-40fe-a5ff-851db1512988" />

<img width="1440" height="900" alt="Screenshot 2026-05-17 at 11 35 07 PM" src="https://github.com/user-attachments/assets/c013458d-d203-4164-8060-fd9550be81ce" />





