### PR TITLE
fix(GSSoC 2026): Update outdated demo dates to 2026 in track order page

### DIFF
--- a/track-order.html
+++ b/track-order.html
@@ -139,7 +139,7 @@
               type="text"
               id="orderId"
               name="orderId"
-              placeholder="e.g. CARA-20251234"
+              placeholder="e.g. CARA-20261234"
               required
               autocomplete="off"
             />
@@ -170,7 +170,7 @@
         <!-- Demo hint -->
         <div class="demo-hint">
           <i class="ri-information-line"></i>
-          <span>Demo: Use Order ID <strong>CARA-20251234</strong> with any email to see a sample result.</span>
+          <span>Demo: Use Order ID <strong>CARA-20261234</strong> with any email to see a sample result.</span>
         </div>
       </div>
 
@@ -181,7 +181,7 @@
         <div class="result-header">
           <div class="order-meta">
             <span class="order-id-label">Order ID</span>
-            <strong id="resultOrderId">CARA-20251234</strong>
+            <strong id="resultOrderId">CARA-20261234</strong>
           </div>
           <div class="order-status-badge" id="statusBadge">
             <i class="ri-truck-line"></i>
@@ -195,7 +195,7 @@
             <i class="ri-calendar-line"></i>
             <div>
               <span class="detail-label">Order Date</span>
-              <span class="detail-value" id="orderDate">May 14, 2025</span>
+              <span class="detail-value" id="orderDate">May 14, 2026</span>
             </div>
           </div>
           <div class="detail-item">
@@ -216,7 +216,7 @@
             <i class="ri-map-pin-2-line"></i>
             <div>
               <span class="detail-label">Est. Delivery</span>
-              <span class="detail-value" id="estDelivery">May 20, 2025</span>
+              <span class="detail-value" id="estDelivery">May 20, 2026</span>
             </div>
           </div>
         </div>
@@ -233,7 +233,7 @@
               <div class="step-content">
                 <h4>Order Placed</h4>
                 <p>Your order has been confirmed and is being processed.</p>
-                <time>May 14, 2025 — 10:32 AM</time>
+                <time>May 14, 2026 — 10:32 AM</time>
               </div>
             </div>
 
@@ -244,7 +244,7 @@
               <div class="step-content">
                 <h4>Order Packed</h4>
                 <p>Your items have been packed and are ready for pickup.</p>
-                <time>May 15, 2025 — 2:14 PM</time>
+                <time>May 15, 2026 — 2:14 PM</time>
               </div>
             </div>
 
@@ -255,7 +255,7 @@
               <div class="step-content">
                 <h4>Shipped</h4>
                 <p>Your package has been handed off to FedEx Express.</p>
-                <time>May 16, 2025 — 9:05 AM</time>
+                <time>May 16, 2026 — 9:05 AM</time>
               </div>
             </div>
 
@@ -266,7 +266,7 @@
               <div class="step-content">
                 <h4>In Transit</h4>
                 <p>Your package is on its way — currently in Chicago, IL.</p>
-                <time>May 18, 2025 — 6:45 AM</time>
+                <time>May 18, 2026 — 6:45 AM</time>
               </div>
             </div>
 
@@ -277,7 +277,7 @@
               <div class="step-content">
                 <h4>Delivered</h4>
                 <p>Your package will be delivered to your door.</p>
-                <time>Expected: May 20, 2025</time>
+                <time>Expected: May 20, 2026</time>
               </div>
             </div>
 
@@ -348,7 +348,7 @@
             <i class="ri-add-line"></i>
           </div>
           <div class="faq-answer">
-            Your Order ID (e.g. CARA-20251234) is included in the confirmation
+            Your Order ID (e.g. CARA-20261234) is included in the confirmation
             email sent to you immediately after placing your order. You can also
             find it in your account under <strong>My Orders</strong>.
           </div>

--- a/track-order.js
+++ b/track-order.js
@@ -14,12 +14,12 @@ if (copyrightYearEl) {
 // In a real app this would be a backend API call.
 // We use a demo entry so reviewers can test the UI immediately.
 const MOCK_ORDERS = {
-  "CARA-20251234": {
-    id: "CARA-20251234",
-    date: "May 14, 2025",
+  "CARA-20261234": {
+    id: "CARA-20261234",
+    date: "May 14, 2026",
     carrier: "FedEx Express",
     trackingNo: "7489 2091 3847",
-    estDelivery: "May 20, 2025",
+    estDelivery: "May 20, 2026",
     status: "In Transit",          // "Processing" | "Packed" | "Shipped" | "In Transit" | "Delivered"
     currentStep: "transit",        // ordered | packed | shipped | transit | delivered
     location: "Chicago, IL",
@@ -41,11 +41,11 @@ const MOCK_ORDERS = {
     ],
     total: "$234.00",
     timeline: {
-      ordered: { done: true,  date: "May 14, 2025 — 10:32 AM", note: "Your order has been confirmed and is being processed." },
-      packed:  { done: true,  date: "May 15, 2025 — 2:14 PM",  note: "Your items have been packed and are ready for pickup." },
-      shipped: { done: true,  date: "May 16, 2025 — 9:05 AM",  note: "Your package has been handed off to FedEx Express." },
-      transit: { done: false, date: "May 18, 2025 — 6:45 AM",  note: "Your package is on its way — currently in Chicago, IL.", active: true },
-      delivered:{ done: false,date: "Expected: May 20, 2025",   note: "Your package will be delivered to your door." },
+      ordered: { done: true,  date: "May 14, 2026 — 10:32 AM", note: "Your order has been confirmed and is being processed." },
+      packed:  { done: true,  date: "May 15, 2026 — 2:14 PM",  note: "Your items have been packed and are ready for pickup." },
+      shipped: { done: true,  date: "May 16, 2026 — 9:05 AM",  note: "Your package has been handed off to FedEx Express." },
+      transit: { done: false, date: "May 18, 2026 — 6:45 AM",  note: "Your package is on its way — currently in Chicago, IL.", active: true },
+      delivered:{ done: false,date: "Expected: May 20, 2026",   note: "Your package will be delivered to your door." },
     },
   },
 };


### PR DESCRIPTION
### Goal Description
This PR resolves issue #428 as part of GSSoC 2026. The Track Order demo page (`track-order.html`) previously displayed outdated hardcoded dates from 2025 (e.g., May 14, 2025). This update replaces those outdated mock timestamps with current, realistic 2026 dates to prevent user confusion and maintain a polished, professional demo experience.

### Proposed Changes
- Updated `MOCK_ORDERS` data inside `track-order.js`:
  - Changed `CARA-20251234` demo order ID to `CARA-20261234`.
  - Changed demo order date from `May 14, 2025` to `May 14, 2026`.
  - Changed estimated delivery date from `May 20, 2025` to `May 20, 2026`.
  - Updated all corresponding timeline entries (`ordered`, `packed`, `shipped`, `transit`, `delivered`) to reflect realistic 2026 timestamps.
- Updated `track-order.html` placeholder, demo hint, result order ID, and FAQ text to reflect the new 2026 order ID and dates.

### Verification Plan
- [x] Verified `CARA-20261234` tracking ID search correctly renders the new 2026 timeline dates.
- [x] Confirmed no console errors or broken UI elements during order lookup.

Closes #428