### PR TITLE
Fix CSS syntax error in single product button hover styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -1944,6 +1944,8 @@ footer .copyright {
     transform: translateY(-2px);
     box-shadow: 0 6px 20px rgba(8, 129, 120, 0.4);
     background: var(--accent-hover, #066b63);
+}
+
 .normals {
     margin: 10px;
     text-decoration: none;


### PR DESCRIPTION
Fixed a CSS syntax issue in the single product details section where the `.normals` class was accidentally placed inside the hover block. This improves stylesheet validity and prevents styling conflicts.