### PR TITLE
fix: stop image flickering caused by repeated hover triggers

### DIFF
--- a/app.js
+++ b/app.js
@@ -807,12 +807,14 @@ document.addEventListener('DOMContentLoaded', () => {
         const scrollObserver = new IntersectionObserver((entries) => {
             entries.forEach(entry => {
                 if (entry.isIntersecting) {
-                    // Open the cards smoothly when scrolling into view
                     cardContainer.classList.add('open');
-                    if (statusText) statusText.innerText = "Click to collapse";
-                } else {
-                    cardContainer.classList.remove('open');
-                    if (statusText) statusText.innerText = "Click to expand";
+                
+                    if (statusText) {
+                        statusText.innerText = "Click to collapse";
+                    }
+                
+                    // Stop observing after opening once
+                    scrollObserver.unobserve(featureSection);
                 }
             });
         }, observerOptions);


### PR DESCRIPTION
# 📝 Pull Request Template

## 📄 Description
Fixed the image flickering issue caused by repeated animation triggering on hover/scroll interaction. Updated the `IntersectionObserver` logic to prevent continuous toggling of the `open` class, resulting in smoother and more stable image transitions.


---

## 🔗 Related Issues



> Fixes #402 

---

## 🖼️ Screenshots 


https://github.com/user-attachments/assets/21709716-036d-4b88-a3b4-78c614bfb9d2

---

## ✅ Result

Images now transition smoothly without rapidly flickering when interacting with the section.