### PR TITLE
fix: replace placeholder example.com URLs in OG and Twitter meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,15 +27,22 @@
   <!-- Open Graph (OG) Tags for Social Sharing -->
   <meta property="og:title" content="E-commerce - Dark Theme Working" />
   <meta property="og:description" content="Shop the latest trends with our dark mode-enabled e-commerce experience." />
-  <meta property="og:image" content="https://example.com/images/preview.jpg" />
-  <meta property="og:url" content="https://example.com/" />
+  <meta
+      property="og:image"
+      content="https://cara-seven-ashen.vercel.app/images/logo.png"
+    />
+  <meta property="og:url" 
+  content="https://cara-seven-ashen.vercel.app/" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter Card Tags -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="E-commerce - Dark Theme Working" />
   <meta name="twitter:description" content="Dark theme e-commerce site with modern features." />
-  <meta name="twitter:image" content="https://example.com/images/preview.jpg" />
+  <meta
+      name="twitter:image"
+      content="https://cara-seven-ashen.vercel.app/images/logo.png"
+    />
   <meta name="twitter:site" content="@janavipandole" />
 
   <!-- Theme Color for Mobile Browser -->


### PR DESCRIPTION
## GSSoC Contribution
Fixes #361

## 📄 Description
The Open Graph and Twitter metadata tags in index.html contained placeholder example.com URLs. This PR replaces them with the actual deployed Cara website URL so that social media platforms generate accurate link previews.

## Changes Made:
- og:image: example.com/images/preview.jpg → cara-seven-ashen.vercel.app/images/logo.png

- og:url: example.com/ → cara-seven-ashen.vercel.app/

- twitter:image: example.com/images/preview.jpg → cara-seven-ashen.vercel.app/images/logo.png

## 🔗 Related Issues
This will auto-close the issue when merged:
Fixes https://github.com/janavipandole/Cara/issues/361

## 🧩 Type of Change
🐛 Bug Fix

## ✅ Checklist
- I have performed a self-review of my code.


- My changes do not break any existing functionality.
- I have tested my changes locally and they work as expected.