### PR TITLE
fix: set white text color on Explore More button for better contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -370,7 +370,7 @@
     <section id="banner" class="section-m1">
       <h4>Repair Services</h4>
       <h2>Up to <span>70% off</span> All t-Shirts & Accessories</h2>
-      <button class="normal"><a href="shop.html">Explore More</a></button>
+      <button class="normal"><a href="shop.html" style="color: #ffffff; text-decoration: none;">Explore More</a></button>
     </section>
 
   <section id="product1" class="section-p1">


### PR DESCRIPTION
 Description

The "Explore More" button on the hero/banner section had an anchor tag inside it that was inheriting the browser's default blue/purple link color. Since the button background is also blue, the text was nearly invisible and the button didn't stand out as a CTA at all. Fixed by explicitly setting color: #ffffff and text-decoration: none on the anchor tag.

 Related Issues
 Fixes #455 

 Screenshots 

Before
<img width="1600" height="620" alt="IMG-20260519-WA0017" src="https://github.com/user-attachments/assets/9fbfbf45-f5c5-4b4c-adf1-aff4b99a9984" />
After
<img width="903" height="274" alt="IMG-20260519-WA0016" src="https://github.com/user-attachments/assets/352a2d94-9d49-4e89-ae57-da267de62a43" />

Type of Change

 - 🐛 Bug Fix
 -⚡ Enhancement / Optimization

 ✅ Checklist

 I have performed a self-review of my code. 
 My changes do not break any existing functionality.
 I have tested my changes locally and they work as expected.
 I have linked all relevant issues (if any).

Additional Notes

This is a one-line fix but has a visible impact — the button is now clearly readable with white text on the blue background, improving both accessibility and user experience.

