### PR TITLE
fix: align icons inline with feature headings using flex layout on About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -244,51 +244,51 @@
     <section id="interactive-feature-wrapper">
       <div class="animation-container" id="cardContainer">
         <div class="sub-card card-l1">
-          <div class="icon">🛒</div>
-          <div>
-            <h3>Free Shipping</h3>
-            <p>On all standard regional custom retail updates.</p>
+          <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
+               <div class="icon">🛒</div>
+               <h3>Free Shipping</h3>
           </div>
+          <p>On all standard regional custom retail updates.</p>
         </div>
 
         <div class="sub-card card-l2">
-          <div class="icon">👤</div>
-          <div>
-            <h3>Online Order</h3>
-            <p>Quick dynamic electronic checkout confirmation system.</p>
-          </div>
+        <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
+             <div class="icon">👤</div>
+             <h3>Online Order</h3>
+        </div>
+        <p>Quick dynamic electronic checkout confirmation system.</p>
         </div>
 
         <div class="sub-card card-l3">
-          <div class="icon">⚙️</div>
-          <div>
+        <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
+            <div class="icon">⚙️</div>
             <h3>Save Money</h3>
-            <p>Incentive cashback loops on every wholesale purchase.</p>
-          </div>
+        </div>
+        <p>Incentive cashback loops on every wholesale purchase.</p>
         </div>
 
         <div class="sub-card card-r1">
-          <div class="icon">⭐</div>
-          <div>
+        <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
+            <div class="icon">⭐</div>
             <h3>Promotions</h3>
-            <p>Unlock seasonal drops & holiday campaign vouchers.</p>
-          </div>
+        </div>
+        <p>Unlock seasonal drops & holiday campaign vouchers.</p>
         </div>
 
         <div class="sub-card card-r2">
-          <div class="icon">🚀</div>
-          <div>
+        <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
+            <div class="icon">🚀</div>
             <h3>Happy Sell</h3>
-            <p>Premium matching customer success feedback loops.</p>
-          </div>
+        </div>
+        <p>Premium matching customer success feedback loops.</p>
         </div>
 
         <div class="sub-card card-r3">
-          <div class="icon">🌍</div>
-          <div>
+        <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
+            <div class="icon">🌍</div>
             <h3>24/7 Support</h3>
-            <p>Global infrastructure desk agents always responsive.</p>
-          </div>
+        </div>
+        <p>Global infrastructure desk agents always responsive.</p>
         </div>
 
         <div class="brand-card" id="brandCard">

--- a/index.html
+++ b/index.html
@@ -370,7 +370,7 @@
     <section id="banner" class="section-m1">
       <h4>Repair Services</h4>
       <h2>Up to <span>70% off</span> All t-Shirts & Accessories</h2>
-      <button class="normal"><a href="shop.html">Explore More</a></button>
+      <button class="normal"><a href="shop.html" style="color: #ffffff; text-decoration: none;">Explore More</a></button>
     </section>
 
   <section id="product1" class="section-p1">

--- a/style.css
+++ b/style.css
@@ -5340,7 +5340,7 @@ footer .copyright {
                 /* Complements existing soft light backdrops */
                 position: relative;
                 overflow: hidden;
-                padding: 40px 0;
+                padding: 40px 20px;
             }
 
             .animation-container {
@@ -5413,7 +5413,7 @@ footer .copyright {
             .sub-card {
                 position: absolute;
                 width: 260px;
-                padding: 16px;
+                padding: 24px;
                 background: #ffffff;
                 border: 1px solid #cce7e6;
                 /* Clean, light framing border color */
@@ -5443,6 +5443,10 @@ footer .copyright {
 
             .sub-card .icon {
                 font-size: 1.8rem;
+                margin-right: 8px;
+                display: inline-flex;
+                align-items: center;
+                vertical-align: middle;
             }
 
             .sub-card h3 {


### PR DESCRIPTION
Description

The feature section on the About page had icons sitting directly on top of or bleeding into the heading text labels (Free Shipping,  Online Order, Save Money, etc.) with no spacing between them. This made the section look cramped and broken. Fixed by  wrapping each icon and heading in a flex container with gap: 8px so they sit inline and properly aligned.

Related Issues
Fixes #453 

Type of Change

 -🐛 Bug Fix
 -⚡ Enhancement / Optimization

 Checklist

 I have performed a self-review of my code.
 My changes do not break any existing functionality.
 I have tested my changes locally and they work as expected.
 I have linked all relevant issues .

Additional Notes 

Changes were made in both about.html (flex wrapper around icon and heading) and style.css (updated icon spacing). All 6 feature cards — Free Shipping, Online Order, Save Money, Promotions, Happy Sell, and 24/7 Support — have been fixed.