### PR TITLE
fix: resolve double camera preview and overlay layout issue

### DIFF
--- a/try-on.html
+++ b/try-on.html
@@ -16,7 +16,8 @@
     <script src="https://cdn.jsdelivr.net/npm/@mediapipe/drawing_utils/drawing_utils.js" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/@mediapipe/pose/pose.js" crossorigin="anonymous"></script>
 
-    <style>
+
+        <style>
         /* ============================================
            VIRTUAL TRY-ON PAGE STYLES
            ============================================ */
@@ -286,20 +287,18 @@
             box-shadow: none;
         }
 
-        /* ---- Right: AI Viewport ---- */
+        /* ---- Right Panel: AI Viewport Container ---- */
         .ai-viewport {
-            flex: 1.3;
-            background: var(--bg-secondary);
+            flex: 1.5; /* Isse video ki horizontal space left block ke same lagegi */
+            background: var(--card-bg);
             border-radius: 15px;
             border: 1px solid var(--border-color);
-            overflow: hidden;
-            position: relative;
+            padding: 30px;
             display: flex;
             flex-direction: column;
-            justify-content: center;
             align-items: center;
-            box-shadow: inset 0 0 20px rgba(0,0,0,0.05);
-            min-height: 500px;
+            box-shadow: 0 5px 15px var(--shadow);
+            position: relative;
         }
 
         .viewport-placeholder {
@@ -313,22 +312,37 @@
             color: var(--border-color);
         }
 
-        /* Hidden webcam video element */
-        #webcam-video {
-            display: none;
+        /* ---- Camera & Canvas Master Box ---- */
+        .video-wrapper {
+            position: relative;
+            width: 100%;       
+            max-width: 680px; /* Ab left box ke barabar mast look dega */
+            border-radius: 12px;
+            overflow: hidden;
+            aspect-ratio: 4 / 3; 
+            background: #000;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.15); 
         }
 
-        /* The main output canvas */
-        #output-canvas {
-            position: relative !important;
-            top: auto !important;
-            left: auto !important;
-            z-index: 1 !important;
-            pointer-events: auto !important;
-            width: 100%;
-            height: 100%;
-            object-fit: contain;
-            display: none;
+        /* Live camera video configuration */
+        .video-wrapper video {
+            width: 100% !important;
+            height: 100% !important;
+            object-fit: cover !important; 
+            display: block !important;
+            transform: scaleX(-1); /* Mirror view */
+        }
+
+        /* 🌟 Main Canvas (Absolute hokar video ke theek UPAR bethega) 🌟 */
+        .video-wrapper #output-canvas {
+            position: absolute !important;
+            top: 0 !important;
+            left: 0 !important;
+            width: 100% !important;
+            height: 100% !important;
+            object-fit: cover !important;
+            z-index: 10 !important; /* Isse dono merge ho jayenge, double nahi dikhega */
+            pointer-events: none;
         }
 
         /* Hidden image for uploads */
@@ -339,15 +353,15 @@
         /* ---- Body Info Badge ---- */
         .body-info {
             position: absolute;
-            top: 15px;
-            left: 15px;
+            top: 45px;
+            left: 45px;
             background: rgba(0,0,0,0.75);
             color: #fff;
             padding: 12px 16px;
             border-radius: 10px;
             font-size: 13px;
             line-height: 1.6;
-            z-index: 5;
+            z-index: 20;
             display: none;
             backdrop-filter: blur(10px);
             border: 1px solid rgba(255,255,255,0.1);
@@ -368,7 +382,7 @@
             align-items: center;
             background: rgba(0,0,0,0.8);
             color: white;
-            z-index: 10;
+            z-index: 30;
         }
 
         .scanner-line {
@@ -404,11 +418,11 @@
         /* ---- Share / Action Controls ---- */
         .share-controls {
             position: absolute;
-            bottom: 15px;
-            right: 15px;
+            bottom: 45px;
+            right: 45px;
             display: none;
             gap: 10px;
-            z-index: 5;
+            z-index: 20;
         }
 
         .share-btn {
@@ -455,6 +469,7 @@
                 max-height: none;
             }
         }
+
     </style>
 </head>
 <body>
@@ -555,15 +570,22 @@
             </div>
 
             <!-- Right: Viewport -->
-            <div class="ai-viewport">
+            <div class="ai-viewport preview-container">
                 <div class="viewport-placeholder" id="placeholder">
-                    <i class="ri-body-scan-line"></i>
+                    <i class="ri-body-scan-line">
+                    </i>
+                
                     <h3>Open your camera or upload a photo</h3>
                     <p style="font-size:14px; margin-top:8px;">We'll detect your body shape automatically</p>
                 </div>
 
                 <!-- Hidden webcam feed -->
-                <video id="webcam-video" autoplay playsinline></video>
+             <div class="video-wrapper">
+    <video id="webcam-video" autoplay playsinline></video>
+    <canvas id="output-canvas"></canvas>
+</div>
+
+<img id="uploaded-preview" src="" alt="">
 
                 <!-- Hidden uploaded image -->
                 <img id="uploaded-preview" src="" alt="">


### PR DESCRIPTION
Summary:
Fixed a UI layout issue on the Virtual Try-On page where the webcam video feed and the AI detection canvas were rendering as two separate, non-overlapping elements.

Changes:

Wrapped the #webcam-video and #output-canvas elements into a shared .video-wrapper container to ensure correct positioning.

Updated CSS rules to implement an absolute overlay for the canvas, ensuring it correctly aligns over the video feed.

Removed redundant CSS declarations that were causing layout conflicts.

Impact:
This ensures a seamless single-camera preview experience for the user and fixes the display duplication issue.
<img width="1640" height="558" alt="Screenshot (388)" src="https://github.com/user-attachments/assets/eb0d0e8b-63d8-465f-ba8b-78bd862a4b36" />
<img width="1760" height="957" alt="Screenshot (390)" src="https://github.com/user-attachments/assets/cde0f4e3-38d4-43cf-a768-8b04e45e0976" />

note:
Local development (127.0.0.1:5500) works perfectly as expected. If the issue persists on the live Vercel deployment, it is likely due to build cache—re-deploying with "no build cache" is recommended.

