### PR TITLE
Fix: Add missing alt text to feature images and correct F24/7 typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,31 +202,32 @@
       </div>
     </div>
   </div>
-
+  <!-- Fix: Added descriptive alt text to all feature images for accessibility.
+     Also fixed typo: 'F24/7 Support' corrected to '24/7 Support' -->
   <section id="feature" class="section-p1">
     <div class="fe-box">
-      <img src="images/feature/f1.png" alt="" />
+      <img src="images/feature/f1.png" alt="Free Shipping" />
       <h6>Free Shipping</h6>
     </div>
     <div class="fe-box">
-      <img src="images/feature/f2.png" alt="" />
+      <img src="images/feature/f2.png" alt="Online Order" />
       <h6>Online Order</h6>
     </div>
     <div class="fe-box">
-      <img src="images/feature/f3.png" alt="" />
+      <img src="images/feature/f3.png" alt="Save Money" />
       <h6>Save Money</h6>
     </div>
     <div class="fe-box">
-      <img src="images/feature/f4.png" alt="" />
+      <img src="images/feature/f4.png" alt="Promotions" />
       <h6>Promotions</h6>
     </div>
     <div class="fe-box">
-      <img src="images/feature/f5.png" alt="" />
+      <img src="images/feature/f5.png" alt="Happy Sell" />
       <h6>Happy Sell</h6>
     </div>
     <div class="fe-box">
-      <img src="images/feature/f6.png" alt="" />
-      <h6>F24/7 Support</h6>
+      <img src="images/feature/f6.png" alt="24/7 Support" />
+      <h6>24/7 Support</h6>
     </div>
   </section>
 


### PR DESCRIPTION
## 📄 Description
This PR fixes two issues in the feature section of index.html:
1. Added descriptive alt text to all 6 feature images which 
   had empty alt="" attributes, improving accessibility for 
   screen readers.
2. Fixed a typo where '24/7 Support' was incorrectly written 
   as 'F24/7 Support'.

## 🔗 Related Issues
Fixes #

## 🖼️ Screenshots (if applicable)
No visual changes — alt text is not visible to sighted users.

## 🧩 Type of Change
- [x] 🐛 Bug Fix
- [x] ⚡ Enhancement / Optimization

## ✅ Checklist
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes do not break any existing functionality.
- [x] I have tested my changes locally and they work as expected.

## 💬 Additional Notes
The alt text for each image was matched to the h6 text 
directly below it in the same fe-box div.