### PR TITLE
fix: add margin-top to cart page to prevent header overlap

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -104,7 +104,7 @@
     </div>
   </section>
 
-  <div id="cart-content-wrapper">
+  <div id="cart-content-wrapper" style="margin-top: 100px;">
     <div class="cartmain">
       <section id="page-header">
         <h2>Your Cart</h2>


### PR DESCRIPTION
the empty cart preview is already fixed but also i see one small issue there so i fix that 

## Additional Fix Added ✅

I've also fixed the **header overlap issue** on the cart page:

**Problem:** "Your Cart" text was touching/overlapping the navigation bar
**Solution:** Added `margin-top: 100px` to `#cart-content-wrapper`

**Before:** Text colliding with navbar
**After:** Proper spacing below navigation



**Files changed:** `cart.html` (inline style)

Ready for final review! 🚀