### PR TITLE
fix: redirect footer wishlist link to cart page

### DIFF
--- a/index.html
+++ b/index.html
@@ -593,7 +593,7 @@
             <h4>MY ACCOUNT</h4>
             <a href="login.html">Sign In</a>
             <a href="cart.html">View Cart</a>
-            <a href="#">My Wishlist</a>
+            <a href="cart.html">My Wishlist</a>
             <a href="cart.html">Track My Order</a>
             <a href="contact.html">Help</a>
         </div>


### PR DESCRIPTION
## 📄 Description

Updated the footer "My Wishlist" link to redirect users to `cart.html` instead of `about.html`. Since the project currently does not include a dedicated wishlist page, redirecting to the cart page provides a more relevant and user-friendly navigation experience.

---

## 🔗 Related Issues

Fixes #564

---

## 🖼️ Screenshots (if applicable)

N/A

---

## 🧩 Type of Change

- [x] 🐛 Bug Fix  
- [ ] ✨ New Feature  
- [ ] ⚡ Enhancement / Optimization  
- [ ] 🧰 Refactoring  
- [ ] 🧾 Documentation Update  

---

## ✅ Checklist

- [x] I have performed a self-review of my code.  
- [ ] I have commented my code, particularly in hard-to-understand areas.  
- [ ] I have added or updated relevant documentation.  
- [x] My changes do not break any existing functionality.  
- [x] I have tested my changes locally and they work as expected.  
- [x] I have linked all relevant issues (if any).

---

## 💬 Additional Notes (Optional)

This change improves navigation consistency by redirecting users to a more relevant shopping-related page until a dedicated wishlist page is implemented.