### PR TITLE
fix: standardize footer copyright year to 2026 across all templates

### DIFF
--- a/about.html
+++ b/about.html
@@ -449,7 +449,7 @@
       <!-- Copyright -->
       <div class="copyright">
         <p>
-          &copy; Cara <span class="Current-Year"></span>. All rights reserved. |
+          © Cara 2026. All rights reserved. |
           <a href="license.html" style="color: #088178"> MIT License </a>
         </p>
       </div>

--- a/blog-aw20-menswear.html
+++ b/blog-aw20-menswear.html
@@ -422,7 +422,7 @@
       <!-- Copyright -->
       <div class="copyright">
         <p>
-          &copy; Cara <span class="Current-Year"></span>. All rights reserved. |
+          © Cara 2026. All rights reserved. |
           <a href="license.html" style="color: #088178"> MIT License </a>
         </p>
       </div>

--- a/blog-cotton-jersey-hoodie.html
+++ b/blog-cotton-jersey-hoodie.html
@@ -430,7 +430,7 @@
       <!-- Copyright -->
       <div class="copyright">
         <p>
-          &copy; Cara <span class="Current-Year"></span>. All rights reserved. |
+          © Cara 2026. All rights reserved. |
           <a href="license.html" style="color: #088178"> MIT License </a>
         </p>
       </div>

--- a/blog-quiff-styling.html
+++ b/blog-quiff-styling.html
@@ -414,7 +414,7 @@
       <!-- Copyright -->
       <div class="copyright">
         <p>
-          &copy; Cara <span class="Current-Year"></span>. All rights reserved. |
+          © Cara 2026. All rights reserved. |
           <a href="license.html" style="color: #088178"> MIT License </a>
         </p>
       </div>

--- a/blog-runway-trends.html
+++ b/blog-runway-trends.html
@@ -411,7 +411,7 @@
       <!-- Copyright -->
       <div class="copyright">
         <p>
-          &copy; Cara <span class="Current-Year"></span>. All rights reserved. |
+          © Cara 2026. All rights reserved. |
           <a href="license.html" style="color: #088178"> MIT License </a>
         </p>
       </div>

--- a/blog-skater-girls.html
+++ b/blog-skater-girls.html
@@ -418,7 +418,7 @@
       <!-- Copyright -->
       <div class="copyright">
         <p>
-          &copy; Cara <span class="Current-Year"></span>. All rights reserved. |
+          © Cara 2026. All rights reserved. |
           <a href="license.html" style="color: #088178"> MIT License </a>
         </p>
       </div>

--- a/blog.html
+++ b/blog.html
@@ -447,7 +447,7 @@
       <!-- Copyright -->
       <div class="copyright">
         <p>
-          &copy; Cara <span class="Current-Year"></span>. All rights reserved. |
+          © Cara 2026. All rights reserved. |
           <a href="license.html" style="color: #088178"> MIT License </a>
         </p>
       </div>

--- a/cart.html
+++ b/cart.html
@@ -230,7 +230,7 @@
           <img src="images/pay/pay.png" alt="">
         </div>
         <div class="copyright">
-          <p> &copy; Cara <span id="Current-Year"></span> . All rights reserved. | <a href="license.html"
+          <p> © Cara 2026. All rights reserved. | <a href="license.html"
               style="color: #088178;">MIT License</a>
           </p>
         </div>

--- a/community.html
+++ b/community.html
@@ -498,7 +498,7 @@
     <!-- Copyright -->
     <div class="copyright">
       <p>
-        © Cara 2025. All rights reserved. |
+        © Cara 2026. All rights reserved. |
         <a href="license.html" style="color: #088178"> MIT License </a>
       </p>
     </div>

--- a/contact.html
+++ b/contact.html
@@ -843,7 +843,7 @@ footer .copyright {
       <!-- Copyright -->
       <div class="copyright">
         <p>
-          &copy; Cara <span class="Current-Year"></span>. All rights reserved. |
+          © Cara 2026. All rights reserved. |
           <a href="license.html" style="color: #088178"> MIT License </a>
         </p>
       </div>

--- a/crazy-deals.html
+++ b/crazy-deals.html
@@ -427,7 +427,7 @@
     </div>
 
     <div class="footer-bottom">
-      <p class="copyright">&copy; Cara 2026. All rights reserved.</p>
+      <p class="copyright">© Cara 2026. All rights reserved.</p>
       <div class="footer-legal-links">
         <a href="license.html" class="license-link">MIT License</a>
       </div>

--- a/delivery.html
+++ b/delivery.html
@@ -652,7 +652,7 @@
 
     </div>
     <div class="footer-bottom">
-      <p>© Cara 2025. All rights reserved. | <a href="license.html">MIT License</a></p>
+      <p>© Cara 2026. All rights reserved. | <a href="license.html">MIT License</a></p>
     </div>
   </footer>
 

--- a/index.html
+++ b/index.html
@@ -604,7 +604,7 @@
             </div>
 
     <div class="footer-bottom">
-        <p class="copyright">&copy; Cara 2026. All rights reserved.</p>
+        <p class="copyright">© Cara 2026. All rights reserved.</p>
         <div class="footer-legal-links">
             <a href="license.html" class="license-link">MIT License</a>
         </div>

--- a/license.html
+++ b/license.html
@@ -230,7 +230,7 @@
             </div>
         </div>
         <div class="copyright">
-            <p>© Cara <span class="Current-Year"></span>. All rights reserved. | <a href="license.html" style="color: #088178;">MIT License</a></p>
+            <p>© Cara 2026. All rights reserved. | <a href="license.html" style="color: #088178;">MIT License</a></p>
         </div>
     </footer>
 

--- a/privacy.html
+++ b/privacy.html
@@ -367,7 +367,7 @@
 
       <div class="copyright">
         <p>
-          &copy; Cara <span id="Current-Year"></span>span> All rights reserved. |
+          © Cara 2026. All rights reserved.. |
           <a href="license.html" style="color: #088178"> MIT License </a>
         </p>
       </div>

--- a/promotions.html
+++ b/promotions.html
@@ -553,7 +553,7 @@
       <!-- Copyright -->
       <div class="copyright">
         <p>
-          © Cara 2025. All rights reserved. |
+          © Cara 2026. All rights reserved. |
           <a href="license.html" style="color: #088178"> MIT License </a>
         </p>
       </div>

--- a/singleProduct.html
+++ b/singleProduct.html
@@ -287,7 +287,7 @@
       <!-- Copyright -->
       <div class="copyright">
         <p>
-          &copy; Cara <span class="Current-Year"></span>. All rights reserved. |
+          © Cara 2026. All rights reserved. |
           <a href="license.html" style="color: #088178"> MIT License </a>
         </p>
       </div>

--- a/terms.html
+++ b/terms.html
@@ -412,7 +412,7 @@
 
       <div class="copyright">
         <p>
-          &copy; Cara <span id="Current-Year"></span> All rights reserved. |
+          © Cara 2026. All rights reserved. |
           <a href="license.html" style="color: #088178"> MIT License </a>
         </p>
       </div>

--- a/track-order.html
+++ b/track-order.html
@@ -537,7 +537,7 @@
       <!-- Copyright -->
       <div class="copyright">
         <p>
-          &copy; Cara <span id="copyrightYear"></span>. All rights reserved. |
+          © Cara 2026. All rights reserved. |
           <a href="license.html" style="color: #088178"> MIT License </a>
         </p>
       </div>

--- a/try-on.html
+++ b/try-on.html
@@ -840,7 +840,7 @@
     <!-- Copyright -->
     <div class="copyright">
       <p>
-        © Cara 2025. All rights reserved. |
+        © Cara 2026. All rights reserved. |
         <a href="license.html" style="color: #088178"> MIT License </a>
       </p>
     </div>

--- a/winter-collection.html
+++ b/winter-collection.html
@@ -415,7 +415,7 @@
     </div>
 
     <div class="footer-bottom">
-      <p class="copyright">&copy; Cara 2026. All rights reserved.</p>
+      <p class="copyright">© Cara 2026. All rights reserved.</p>
       <div class="footer-legal-links">
         <a href="license.html" class="license-link">MIT License</a>
       </div>


### PR DESCRIPTION
This PR resolves Issue #701.

It addresses the corresponding bug in compliance with GSSoC rules.