### PR TITLE
fix: correct class names in click guard for cart and buy-now buttons

### DIFF
--- a/Cara-main/app.js
+++ b/Cara-main/app.js
@@ -81,7 +81,7 @@ document.addEventListener("click", function (e) {
     if (!proCard) return;
 
     // Ignore clicks on cart icon or buy now button inside the card
-    if (e.target.closest(".cart") || e.target.closest(".buy-now-btn")) return;
+    if (e.target.closest(".pro-cart-btn") || e.target.closest(".pro-buy-btn")) return;
 
     const nameElement = proCard.querySelector("h5");
     const priceElement = proCard.querySelector("h4");


### PR DESCRIPTION
## 📋 Description

The global click listener in `app.js` is supposed to prevent navigation to `singleProduct.html` when the "Add to Cart" or "BUY NOW" buttons are clicked on a product card. However, the guard checks for `.cart` and `.buy-now-btn` while the actual class names assigned in `products.js` are `pro-cart-btn` and `pro-buy-btn`. The mismatch means the guard never fires — every click on those buttons falls through and navigates to the product detail page instead of adding the item to the cart.

---

## 🔗 Related Issues

Fixes #665

---

## 🛠️ Changes Made

- **`Cara-main/app.js` line 84:** Updated the click guard class selectors to match the actual class names used in `products.js`

**Before:**
```js
if (e.target.closest(".cart") || e.target.closest(".buy-now-btn")) return;
```

**After:**
```js
if (e.target.closest(".pro-cart-btn") || e.target.closest(".pro-buy-btn")) return;
```

---

## ✅ Testing Done

- Clicked "Add to Cart" on a product card → item added to cart, toast shown, no navigation
- Clicked "BUY NOW" on a product card → item added to cart, redirected to `checkout.html`
- Clicked on the product card body → navigates to `singleProduct.html` as expected

---

## 🧩 Environment

- Browser: Chrome / Firefox
- OS: Windows 11
- No build tools — static HTML/CSS/JS site