### PR TITLE
fix: strip rupee symbol before parseFloat in sort-by-price logic

### DIFF
--- a/Cara-main/app.js
+++ b/Cara-main/app.js
@@ -1026,8 +1026,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 productsToAppend = originalProducts;
             } else {
                 productsToAppend = [...originalProducts].sort((a, b) => {
-                    const priceA = parseFloat(a.querySelector('h4').innerText.replace('$', '').trim());
-                    const priceB = parseFloat(b.querySelector('h4').innerText.replace('$', '').trim());
+                    const priceA = parseFloat(a.querySelector('h4').innerText.replace(/[₹$,]/g, '').trim());
+                    const priceB = parseFloat(b.querySelector('h4').innerText.replace(/[₹$,]/g, '').trim());
 
                     if (sortValue === 'low-high') return priceA - priceB;
                     if (sortValue === 'high-low') return priceB - priceA;


### PR DESCRIPTION
# 📝 Pull Request 

## 📋 Description

The sort-by-price dropdown in `app.js` parses product prices by stripping the `$` symbol before calling `parseFloat()`. However, all product prices in the DOM are rendered with the `₹` symbol (e.g. `₹2,499`). Since `₹` is never stripped, `parseFloat('₹2,499')` returns `NaN`, making all comparisons invalid and the sort order never changes regardless of what option is selected.

---

## 🔗 Related Issues

Fixes #666

---

## 🛠️ Changes Made

- **`Cara-main/app.js` lines 1029–1030:** Updated regex to strip `₹`, `$`, and `,` before parsing

**Before:**
```js
const priceA = parseFloat(a.querySelector('h4').innerText.replace('$', '').trim());
const priceB = parseFloat(b.querySelector('h4').innerText.replace('$', '').trim());
```

**After:**
```js
const priceA = parseFloat(a.querySelector('h4').innerText.replace(/[₹$,]/g, '').trim());
const priceB = parseFloat(b.querySelector('h4').innerText.replace(/[₹$,]/g, '').trim());
```

---

## ✅ Testing Done

- Selected "Price: Low to High" → products reorder correctly from lowest to highest
- Selected "Price: High to Low" → products reorder correctly from highest to lowest
- Default sort → unchanged behavior

---

## 🧩 Environment

- Browser: Chrome / Firefox
- OS: Windows 11
- No build tools — static HTML/CSS/JS site