### PR TITLE
fix: add submit handler to newsletter form to prevent page reload

### DIFF
--- a/Cara-main/app.js
+++ b/Cara-main/app.js
@@ -1039,3 +1039,13 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 });
+document.addEventListener('DOMContentLoaded', () => {
+  const newsletterForm = document.querySelector('.newsletter-form');
+  if (newsletterForm) {
+    newsletterForm.addEventListener('submit', function (e) {
+      e.preventDefault();
+      const email = this.querySelector('input[type="email"]').value.trim();
+      if (email) showToast('Thanks for subscribing!', 'success');
+    });
+  }
+});


### PR DESCRIPTION
# 📝 Pull Request

## 📋 Description

The newsletter "Sign Up" form in the footer of `index.html` has no JavaScript submit handler anywhere in the codebase. Clicking the button triggers a native HTML form submission which reloads the page. The user's email is silently discarded with zero feedback — no toast, no confirmation, nothing.

---

## 🔗 Related Issues

Fixes #667

---

## 🛠️ Changes Made

- **`Cara-main/app.js`:** Added a `submit` event listener for `.newsletter-form` that prevents the default reload and shows a success toast

**Added:**
```js
document.addEventListener('DOMContentLoaded', () => {
  const newsletterForm = document.querySelector('.newsletter-form');
  if (newsletterForm) {
    newsletterForm.addEventListener('submit', function (e) {
      e.preventDefault();
      const email = this.querySelector('input[type="email"]').value.trim();
      if (email) showToast('Thanks for subscribing!', 'success');
    });
  }
});
```

---

## ✅ Testing Done

- Entered email and clicked "Sign Up" → page does not reload, success toast appears
- Clicked "Sign Up" with empty field → browser validation prevents submission (field is `required`)

---

## 🧩 Environment

- Browser: Chrome / Firefox
- OS: Windows 11
- No build tools — static HTML/CSS/JS site