### PR TITLE
fix: clear applied coupon from localStorage after successful checkout

### DIFF
--- a/Cara-main/checkout.js
+++ b/Cara-main/checkout.js
@@ -165,7 +165,7 @@ form.addEventListener("submit", function (e) {
   setTimeout(function () {
     // CLEAR CART AFTER SUCCESSFUL ORDER
     localStorage.removeItem("productsInCart");
-
+    localStorage.removeItem("appliedCoupon");
     // Re-enable button
     if (submitBtn) {
       submitBtn.classList.remove("btn-loading");


### PR DESCRIPTION

## 📋 Description

When an order is placed, `checkout.js` removes `productsInCart` from `localStorage` but never removes `appliedCoupon`. On the next visit, `app.js` reloads it with `localStorage.getItem('appliedCoupon')` and the discount is silently applied to the new cart — giving the user a free repeated discount without ever re-entering a coupon code.

---

## 🔗 Related Issues

Fixes #728

---

## 🛠️ Changes Made

- **`Cara-main/checkout.js` line 167:** Added `localStorage.removeItem('appliedCoupon')` alongside the existing cart removal

**Before:**
```js
localStorage.removeItem("productsInCart");
```

**After:**
```js
localStorage.removeItem("productsInCart");
localStorage.removeItem("appliedCoupon");
```

---

## ✅ Testing Done

- Applied coupon `CARA20`, completed checkout → coupon cleared, discount gone on next cart
- Applied coupon `WELCOME10`, completed checkout → same result
- Checkout without coupon → no change in behavior

---

## 🧩 Environment

- Browser: Chrome / Firefox
- OS: Windows 11
- No build tools — static HTML/CSS/JS site