### PR TITLE
Fix/Quantity Selector buttons UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -265,8 +265,23 @@ window.updateQty = function (change) {
         let currentValue = parseInt(qtyInput.value);
         if (isNaN(currentValue)) currentValue = 1;
         let newValue = currentValue + change;
+        
+        // Clamp quantity between 1 and 99
         if (newValue < 1) newValue = 1;
+        if (newValue > 99) newValue = 99;
+        
         qtyInput.value = newValue;
+
+        // Dynamically update minus and plus button disabled states
+        const minusBtn = document.querySelector('.qty-btn.minus');
+        const plusBtn = document.querySelector('.qty-btn.plus');
+        
+        if (minusBtn) {
+            minusBtn.disabled = (newValue <= 1);
+        }
+        if (plusBtn) {
+            plusBtn.disabled = (newValue >= 99);
+        }
     }
 }
 
@@ -1445,8 +1460,23 @@ window.updateQty = function (change) {
     let currentValue = parseInt(qtyInput.value);
     if (isNaN(currentValue)) currentValue = 1;
     let newValue = currentValue + change;
+    
+    // Clamp quantity between 1 and 99
     if (newValue < 1) newValue = 1;
+    if (newValue > 99) newValue = 99;
+    
     qtyInput.value = newValue;
+
+    // Dynamically update minus and plus button disabled states
+    const minusBtn = document.querySelector('.qty-btn.minus');
+    const plusBtn = document.querySelector('.qty-btn.plus');
+    
+    if (minusBtn) {
+      minusBtn.disabled = (newValue <= 1);
+    }
+    if (plusBtn) {
+      plusBtn.disabled = (newValue >= 99);
+    }
   }
 };
 

--- a/singleProduct.css
+++ b/singleProduct.css
@@ -123,6 +123,12 @@
     transform: scale(0.95);
 }
 
+#pro-details .quantity-selector .qty-btn:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
 #pro-details .single-pro-details .quantity-selector input {
     width: 50px;
     height: 38px;

--- a/singleProduct.html
+++ b/singleProduct.html
@@ -113,7 +113,7 @@
             </select>
             <div class="cart-action-group">
                 <div class="quantity-selector">
-                    <button type="button" class="qty-btn minus" onclick="updateQty(-1)" aria-label="Decrease quantity">
+                    <button type="button" class="qty-btn minus" onclick="updateQty(-1)" aria-label="Decrease quantity" disabled>
                         <i class="fa-solid fa-minus"></i>
                     </button>
                     <input id="product-quantity" type="number" value="1" min="1" readonly title="Product quantity" aria-label="Product quantity">
@@ -122,8 +122,8 @@
                     </button>
                 </div>
                 <button class="normal" onclick="handleAddToCart()">Add to Cart</button>
-                <button class="normal" style="background: #088178; color: white; margin-left: 10px;" onclick="handleBuyNow()">Buy Now</button>
-                <button class="normal" style="background: var(--accent); color: white; margin-left: 10px;" onclick="window.location.href='try-on.html'">Try it On Virtually!</button>
+                <button class="normal" style="background: #088178; color: white;" onclick="handleBuyNow()">Buy Now</button>
+                <button class="normal" style="background: var(--accent); color: white;" onclick="window.location.href='try-on.html'">Try it On Virtually!</button>
             </div>
             <h4>Product Details</h4>
             <p>Lorem ipsum, dolor sit amet consectetur adipisicing elit. Officia tenetur, exercitationem velit maxime


### PR DESCRIPTION
## 📄 Description

This PR resolves the vertical stacking bug where the quantity selector's `+` and `-` buttons were rendered on top of each other, throwing the entire product details page out of alignment (Issue #331).

### Background & changes
* **Why it was broken:** The `.quantity-selector` widget and `.qty-btn` buttons had zero styles defined in the stylesheet. Because of this, the browser fell back to styling the buttons as big blocks using generic single-product styles, stacking them vertically on top of the input.
* **The syntax issue:** I also found and patched a missing closing bracket `}` in `style.css` on the `button.normal:hover` rule which was breaking style rendering down the line.
*  I styled `.quantity-selector` to act as a sleek, unified, horizontal pill container (50px tall to match the rest of the buttons) with custom transparent buttons and hover animations.
* **Spacing cleanup:** I turned `.cart-action-group` into a clean flexbox row with a 12px gap. I also removed a hardcoded inline `margin-left` from the "Try it On Virtually!" button in `singleProduct.html` so the spacing between all three items is perfectly identical and consistent. Added `flex-wrap: wrap` to make sure it looks great on mobile viewports too.

---

## 🔗 Related Issues

Fixes #331

---

## 🖼️ Screenshots (if applicable)

### Before

<img width="565" height="542" alt="image" src="https://github.com/user-attachments/assets/f63c0ae3-b751-4375-ae96-aeaf1ba39d2b" />


### After

<img width="445" height="431" alt="image" src="https://github.com/user-attachments/assets/e062b13c-ab00-4418-8e1a-1d7555e97868" />


---

## 🧩 Type of Change

- [x] 🐛 Bug Fix  
- [ ] ✨ New Feature  
- [ ] ⚡ Enhancement / Optimization  
- [ ] 🧰 Refactoring  
- [ ] 🧾 Documentation Update  
- [ ] 🔧 Other (please specify): ____________

---

## ✅ Checklist

Before submitting your PR, please confirm the following:

- [x] I have performed a self-review of my code.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have added or updated relevant documentation.  
- [x] My changes do not break any existing functionality.  
- [x] I have tested my changes locally and they work as expected.  
- [x] I have linked all relevant issues (if any).

## Note:
This PR is created after request from @janavipandole to create a new PR after resolving merge conflicts