### PR TITLE
fix: clear appliedCoupon from localStorage after successful checkout

### DIFF
--- a/checkout.js
+++ b/checkout.js
@@ -165,6 +165,8 @@ form.addEventListener("submit", function (e) {
   setTimeout(function () {
     // CLEAR CART AFTER SUCCESSFUL ORDER
     localStorage.removeItem("productsInCart");
+    localStorage.removeItem("appliedCoupon");
+    window.appliedCoupon = null;
 
     // Re-enable button
     if (submitBtn) {


### PR DESCRIPTION
### 👨‍💻 Program
This contribution is made under **GSSoC 2026**.
 
---
 
### 📌 Summary
Adds `localStorage.removeItem('appliedCoupon')` to the checkout success handler in `checkout.js`. Previously, the cart was cleared on order completion but the coupon code persisted, causing it to auto-apply a 10–20% discount to every future cart indefinitely.
 
---
 
### ❌ Problem
 
**File:** `checkout.js` — order success handler
 
❌ `productsInCart` cleared on checkout ✅  
❌ `appliedCoupon` never cleared ❌ — persists forever  
❌ Every future order automatically gets the discount without entering a code  
❌ Direct financial loss — unearned discounts on all future purchases  
 
---
 
### ✅ Solution
 
Clear `appliedCoupon` from localStorage alongside the cart in the checkout success handler. Also reset `window.appliedCoupon` in-memory.
 
---
 
### 📝 Exact Line Change
 
**File:** `checkout.js` — inside `setTimeout` success callback
 
```diff
  // CLEAR CART AFTER SUCCESSFUL ORDER
  localStorage.removeItem("productsInCart");
+ localStorage.removeItem("appliedCoupon");
+ window.appliedCoupon = null;
```
 
---
 
### 🔄 Before vs After
 
#### Before: Complete order → revisit cart → CARA20 20% discount already applied automatically
#### After: Complete order → revisit cart → no discount, user must enter a code to apply one
 
---
 
### 🧪 Testing
 
- Apply `CARA20` → checkout → complete order ✅
- Add new products to cart → go to `cart.html` ✅
- Confirm no coupon is pre-applied ✅
- `localStorage.getItem('appliedCoupon')` returns `null` after checkout ✅
- Manually entering `CARA20` again still works ✅
---
 
### 🙌 Contributor Checklist
 
- [x] Code follows repository guidelines
- [x] Tested thoroughly
- [x] No breaking changes introduced
---
 
# Closes #815
 
---