### PR TITLE
fix: add missing name attributes to checkout form input fields

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -35,38 +35,44 @@
 
       <div class="input-group">
         <label>Full Name</label>
-        <input type="text" placeholder="Enter your full name" required>
+        <!-- Fix: Added name="fullName" so FormData API can collect this field's value on submit -->
+        <input type="text" name="fullName" placeholder="Enter your full name" required>
       </div>
 
       <div class="row">
 
         <div class="input-group">
           <label>Email Address</label>
-          <input type="email" placeholder="Enter your email" required>
+          <!-- Fix: Added name="email" so FormData API can collect this field's value on submit -->
+          <input type="email" name="email" placeholder="Enter your email" required>
         </div>
 
         <div class="input-group">
           <label>Phone Number</label>
-          <input type="tel" placeholder="Enter phone number" required>
+          <!-- Fix: Added name="phone" so FormData API can collect this field's value on submit -->
+          <input type="tel" name="phone" placeholder="Enter phone number" required>
         </div>
 
       </div>
 
       <div class="input-group">
         <label>Delivery Address</label>
-        <textarea placeholder="Enter full address" required></textarea>
+        <!-- Fix: Added name="address" so FormData API can collect this field's value on submit -->
+        <textarea name="address" placeholder="Enter full address" required></textarea>
       </div>
 
       <div class="row">
 
         <div class="input-group">
           <label>City</label>
-          <input type="text" placeholder="Enter city" required>
+          <!-- Fix: Added name="city" so FormData API can collect this field's value on submit -->
+          <input type="text" name="city" placeholder="Enter city" required>
         </div>
 
         <div class="input-group">
           <label>ZIP Code</label>
-          <input type="text" placeholder="ZIP Code" required>
+          <!-- Fix: Added name="zip" so FormData API can collect this field's value on submit -->
+          <input type="text" name="zip" placeholder="ZIP Code" required>
         </div>
 
       </div>


### PR DESCRIPTION
# 📝 Pull Request Template

## 📄 Description

All 6 input fields in checkout.html were missing the HTML name attribute. Without name, the browser's FormData API returns an empty object on form submit — meaning all user data (Full Name, Email, Phone, Address, City, ZIP Code) was silently lost and could never be sent to a backend.

This PR adds the correct name attributes to all 6 fields, along with inline comments explaining the fix.
---

## 🔗 Related Issues
The checkout form in `checkout.html` had a bug where all 6 input fields  (Full Name, Email, Phone, Address, City, ZIP Code) were missing the HTML `name` attribute. This caused the `FormData` API to return an empty object on form submission, silently losing all user-entered shipping data.  This PR fixes that bug by adding the correct `name` attribute to each field.


> Fixes #868 

---

## 🖼️ Screenshots (if applicable)

N/A — This fix adds missing `name` attributes to form fields. 
No UI/visual changes were made.

---

## 🧩 Type of Change

Select the type of change your PR introduces (check all that apply):

- [x] 🐛 Bug Fix  
- [ ] ✨ New Feature  
- [ ] ⚡ Enhancement / Optimization  
- [ ] 🧰 Refactoring  
- [ ] 🧾 Documentation Update  
- [ ] 🔧 Other (please specify): ____________

---

## ✅ Checklist

Before submitting your PR, please confirm the following:

- [x] I have performed a self-review of my code.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have added or updated relevant documentation.  
- [x] My changes do not break any existing functionality.  
- [x] I have tested my changes locally and they work as expected.  
- [ ] I have linked all relevant issues (if any).

---

## 💬 Additional Notes (Optional)

- Only the 6 shipping input fields were modified — no other code was touched.
- Card detail fields (`cardName`, `cardNumber`, `expiry`, `cvv`) already had 
  `id` attributes and were left completely unchanged.
- Each fixed field has an inline comment explaining why the `name` attribute 
  was added, making it easy for future contributors to understand the fix.
- This fix is fully backward compatible — no existing functionality is broken.