### PR TITLE
feat(nav): animated underline for navbar links

### DIFF
--- a/global.css
+++ b/global.css
@@ -353,14 +353,29 @@ button.white .ripple-effect {
     display: none;
 }
 
-#navbar li a.active::after {
+#navbar li:not(.nav-icon) a::after {
     content: '';
-    width: 100%;
-    height: 2px;
-    background: var(--accent);
     position: absolute;
+    left: 0;
     bottom: -4px;
-    left: 2px;
+    height: 2px;
+    width: 0%;
+    background: var(--accent);
+    transition: width 260ms cubic-bezier(.2,.8,.2,1);
+    will-change: width;
+}
+
+/* expand underline on hover or when link is active */
+#navbar li:not(.nav-icon) a:hover::after,
+#navbar li:not(.nav-icon) a.active::after {
+    width: 100%;
+}
+
+/* Respect users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+    #navbar li:not(.nav-icon) a::after {
+        transition: none;
+    }
 }
 
 /* ============================================

--- a/style.css
+++ b/style.css
@@ -586,14 +586,28 @@ button.white .ripple-effect {
     display: none;
 }
 
-#navbar li a.active::after {
+#navbar li:not(.nav-icon) a::after {
     content: '';
-    width: 100%;
-    height: 2px;
-    background: var(--accent);
     position: absolute;
+    left: 0;
     bottom: -4px;
-    left: 2px;
+    height: 2px;
+    width: 0%;
+    background: var(--accent);
+    transition: width 260ms cubic-bezier(.2,.8,.2,1);
+    will-change: width;
+}
+
+/* expand underline on hover or when link is active */
+#navbar li:not(.nav-icon) a:hover::after,
+#navbar li:not(.nav-icon) a.active::after {
+    width: 100%;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    #navbar li:not(.nav-icon) a::after {
+        transition: none;
+    }
 }
 
 /* ============================================


### PR DESCRIPTION
## 📄 Description

Adds a lightweight CSS-only animated underline for navbar links using ::after and a width transition. Replaces the previous static .active::after rule so the underline animates left→right on hover and appears for active links. Respects prefers-reduced-motion and targets non-icon links for consistent behavior across themes.

---

## 🔗 Related Issues

> Fixes #870 

---

## 🖼️ Screenshots (if applicable)

If your changes include UI updates or visual changes, add screenshots or GIFs here.

---

## 🧩 Type of Change

<img width="1920" height="1080" alt="Screenshot (127)" src="https://github.com/user-attachments/assets/07773443-1391-4a50-8c9b-aab42c60ca00" />

- [ ] 🐛 Bug Fix  
- [x ] ✨ New Feature  
- [ x] ⚡ Enhancement / Optimization  
- [ ] 🧰 Refactoring  
- [ ] 🧾 Documentation Update  
- [ ] 🔧 Other (please specify): ____________

---

## ✅ Checklist

Before submitting your PR, please confirm the following:

- [x ] I have performed a self-review of my code.  
- [x ] I have commented my code, particularly in hard-to-understand areas.  
- [x ] I have added or updated relevant documentation.  
- [ x] My changes do not break any existing functionality.  
- [ x] I have tested my changes locally and they work as expected.  
- [ x] I have linked all relevant issues (if any).

---

## 💬 Additional Notes (Optional)

Branch: feature/navbar-animated-underline
Commit: feat(nav): animated underline for navbar links
