### PR TITLE
fix: clear stale detectedLandmarks when new photo is uploaded in virt…

### DIFF
--- a/try-on.js
+++ b/try-on.js
@@ -158,6 +158,7 @@ function startLiveDetection() {
 window.capturePhoto=function() {
     if (!cameraStream) return;
 
+    detectedLandmarks = null; // clear stale landmarks before new capture
     // Capture current frame from the canvas
     const captureCanvas = document.createElement('canvas');
     captureCanvas.width = resultCanvas.width;
@@ -206,6 +207,7 @@ window.stopCamera=function() {
 uploadInput.addEventListener('change', function() {
     if (this.files && this.files[0]) {
         hasPhoto = true;
+        detectedLandmarks = null; // clear stale landmarks from previous photo
         uploadText.innerText = this.files[0].name;
 
         const reader = new FileReader();


### PR DESCRIPTION
## 👨‍💻 Program
This contribution is made under **GSSoC 2026**.
 
---
 
### 📌 Summary
Fixes a state management bug in `try-on.js` where `detectedLandmarks` from a previous photo persisted when a new photo was uploaded, causing the garment overlay to draw at the wrong body position. Setting `detectedLandmarks = null` on new uploads ensures fresh pose detection always runs.
 
---
 
### ❌ Problem
**File:** `try-on.js`
 
❌ `detectedLandmarks` holds old pose data after new photo uploaded  
❌ `useExistingLandmarks = true` skips re-detection on Generate  
❌ Garment drawn at previous photo's body position — misaligned  
 
---
 
### ✅ Solution
Set `detectedLandmarks = null` in both the file upload handler and `capturePhoto()`.
 
---
 
### 📝 Exact Line Change
**File:** `try-on.js` — upload handler
 
```diff
  uploadInput.addEventListener('change', function() {
      if (this.files && this.files[0]) {
          hasPhoto = true;
+         detectedLandmarks = null; // clear stale landmarks from previous photo
          uploadText.innerText = this.files[0].name;
```
 
**File:** `try-on.js` — `capturePhoto()`
 
```diff
  function capturePhoto() {
      if (!cameraStream) return;
+     detectedLandmarks = null; // clear stale landmarks before new capture
      const captureCanvas = document.createElement('canvas');
```
 
---
 
### 🔄 Before vs After
**Before:** Upload photo B after A → Generate → garment at photo A's position  
**After:** Upload photo B → Generate → fresh detection → garment correctly aligned
 
---
 
### 🧪 Testing
- Upload photo A → upload photo B → Generate → garment aligns to B ✅
- Webcam capture → Generate → correct alignment ✅
- Same photo twice → still works correctly ✅
---
---
 
### 🙌 Contributor Checklist
- [x] Code follows repository guidelines
- [x] Tested thoroughly
- [x] No breaking changes introduced
---
# Closes #821
 
---