### PR TITLE
security: fix XSS in showToast() by using textContent instead of inne…

### DIFF
--- a/app.js
+++ b/app.js
@@ -253,12 +253,27 @@ function showToast(message, type) {
 
     // Build toast element
     var toast = document.createElement('div');
-    toast.className = 'toast toast-' + type;
-    toast.innerHTML =
-        '<i class="fa-solid ' + (icons[type] || icons.success) + ' toast-icon"></i>' +
-        '<span class="toast-msg">' + message + '</span>' +
-        '<button class="toast-close" aria-label="Close notification">&times;</button>' +
-        '<div class="toast-progress"></div>';
+     toast.className = 'toast toast-' + type;
+
+    var icon = document.createElement('i');
+     icon.className = 'fa-solid ' + (icons[type] || icons.success) + ' toast-icon';
+
+    var msg = document.createElement('span');
+     msg.className = 'toast-msg';
+     msg.textContent = message; // ✅ safe — no HTML injection
+
+    var closeBtn = document.createElement('button');
+     closeBtn.className = 'toast-close';
+     closeBtn.setAttribute('aria-label', 'Close notification');
+     closeBtn.textContent = '×';
+
+    var progress = document.createElement('div');
+     progress.className = 'toast-progress';
+
+     toast.appendChild(icon);
+     toast.appendChild(msg);
+     toast.appendChild(closeBtn);
+     toast.appendChild(progress);
 
     // Close button handler
     toast.querySelector('.toast-close').addEventListener('click', function() {


### PR DESCRIPTION
## 👨‍💻 Program
This contribution is made under **GSSoC 2026**.
 
---
 
### 📌 Summary
Fixes a potential XSS vulnerability in `showToast()` in `app.js` by replacing `innerHTML` concatenation with safe DOM construction. The message is now set via `textContent`, preventing HTML/script injection.
 
---
 
### ❌ Problem
**File:** `app.js`
 
❌ `toast.innerHTML = '...' + message + '...'` — unsafe concatenation  
❌ `showToast('<img src=x onerror=alert(1)>')` → XSS fires  
❌ Any future user-controlled input reaching showToast becomes exploitable  
 
---
 
### ✅ Solution
Build toast elements individually using `createElement` and set the message via `textContent`.
 
---
 
### 📝 Exact Line Change
**File:** `app.js` — `showToast()` function
 
```diff
- var toast = document.createElement('div');
- toast.className = 'toast toast-' + type;
- toast.innerHTML =
-     '<i class="fa-solid ' + (icons[type] || icons.success) + ' toast-icon"></i>' +
-     '<span class="toast-msg">' + message + '</span>' +
-     '<button class="toast-close" aria-label="Close notification">&times;</button>' +
-     '<div class="toast-progress"></div>';
 
+ var toast = document.createElement('div');
+ toast.className = 'toast toast-' + type;
+
+ var icon = document.createElement('i');
+ icon.className = 'fa-solid ' + (icons[type] || icons.success) + ' toast-icon';
+
+ var msg = document.createElement('span');
+ msg.className = 'toast-msg';
+ msg.textContent = message; // ✅ safe — no HTML injection
+
+ var closeBtn = document.createElement('button');
+ closeBtn.className = 'toast-close';
+ closeBtn.setAttribute('aria-label', 'Close notification');
+ closeBtn.textContent = '×';
+
+ var progress = document.createElement('div');
+ progress.className = 'toast-progress';
+
+ toast.appendChild(icon);
+ toast.appendChild(msg);
+ toast.appendChild(closeBtn);
+ toast.appendChild(progress);
```
 
---
 
### 🔄 Before vs After
**Before:** `showToast('<img src=x onerror=alert(1)>')` → XSS alert fires  
**After:** Same call → text displayed literally, no script executes
 
---
 
### 🧪 Testing
- `showToast('Added to cart!', 'success')` → normal toast ✅
- `showToast('<script>alert(1)</script>')` → shown as literal text ✅
- All existing toast calls (cart, coupon, checkout) work as before ✅
---
---
 
### 🙌 Contributor Checklist
- [x] Code follows repository guidelines
- [x] Tested thoroughly
- [x] No breaking changes introduced
---
# Closes #824
 ---