### PR TITLE
fix: align forgot-password validation with registration strength policy

### DIFF
--- a/forgotPassword.js
+++ b/forgotPassword.js
@@ -33,8 +33,33 @@ form.addEventListener('submit', function (e) {
     return;
   }
 
-  if (!newPass || newPass.length < 6) {
-    showToast('Password must be at least 6 characters!', 'warning');
+  if (/\s/.test(newPass)) {
+    showToast('Password must not contain spaces.', 'warning');
+    return;
+  }
+
+  if (!newPass || newPass.length < 8) {
+    showToast('Password must be at least 8 characters long.', 'warning');
+    return;
+  }
+
+  if (!/[A-Z]/.test(newPass)) {
+    showToast('Password must contain at least one uppercase letter (A-Z).', 'warning');
+    return;
+  }
+
+  if (!/[a-z]/.test(newPass)) {
+    showToast('Password must contain at least one lowercase letter (a-z).', 'warning');
+    return;
+  }
+
+  if (!/[0-9]/.test(newPass)) {
+    showToast('Password must contain at least one number (0-9).', 'warning');
+    return;
+  }
+
+  if (!/[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/.test(newPass)) {
+    showToast('Password must contain at least one special character (e.g. @, #, $).', 'warning');
     return;
   }
 


### PR DESCRIPTION
Fixes #823

## Problem
Registration enforces a strict password policy (8+ chars, uppercase, lowercase, number, special char) but the forgot-password flow at \orgotPassword.js:36\ only checks \length >= 6\. A user can reset to \bc123\ which would never pass registration.

## Fix
Replaced the weak length check with the same validation chain used in \egister.js\ — checks for spaces, min 8 chars, uppercase, lowercase, digit, and special character. Error messages match what users see on the signup page.