### PR TITLE
fix: prevent XSS in showToast by using textContent instead of innerHTML

### DIFF
--- a/Cara-main/app.js
+++ b/Cara-main/app.js
@@ -274,9 +274,10 @@ function showToast(message, type) {
     toast.className = 'toast toast-' + type;
     toast.innerHTML =
         '<i class="fa-solid ' + (icons[type] || icons.success) + ' toast-icon"></i>' +
-        '<span class="toast-msg">' + message + '</span>' +
+        '<span class="toast-msg"></span>' +
         '<button class="toast-close" aria-label="Close notification">&times;</button>' +
         '<div class="toast-progress"></div>';
+    toast.querySelector('.toast-msg').textContent = message;
 
     // Close button handler
     toast.querySelector('.toast-close').addEventListener('click', function() {

--- a/Cara-main/cara.html
+++ b/Cara-main/cara.html
@@ -818,10 +818,11 @@
       const toast = document.createElement('div');
       toast.className = `toast toast-${type}`;
       toast.innerHTML = `
-        <span class="toast-msg">${message}</span>
+        <span class="toast-msg"></span>
         <button class="toast-close" aria-label="Close notification">&times;</button>
         <div class="toast-progress"></div>
       `;
+      toast.querySelector('.toast-msg').textContent = message;
       toast.querySelector('.toast-close').addEventListener('click', () => {
         dismissToast(toast);
       });

--- a/app.js
+++ b/app.js
@@ -256,9 +256,10 @@ function showToast(message, type) {
     toast.className = 'toast toast-' + type;
     toast.innerHTML =
         '<i class="fa-solid ' + (icons[type] || icons.success) + ' toast-icon"></i>' +
-        '<span class="toast-msg">' + message + '</span>' +
+        '<span class="toast-msg"></span>' +
         '<button class="toast-close" aria-label="Close notification">&times;</button>' +
         '<div class="toast-progress"></div>';
+    toast.querySelector('.toast-msg').textContent = message;
 
     // Close button handler
     toast.querySelector('.toast-close').addEventListener('click', function() {
@@ -1436,11 +1437,10 @@ function showToast(message, type) {
     '<i class="fa-solid ' +
     (icons[type] || icons.success) +
     ' toast-icon"></i>' +
-    '<span class="toast-msg">' +
-    message +
-    '</span>' +
+    '<span class="toast-msg"></span>' +
     '<button class="toast-close" aria-label="Close notification">&times;</button>' +
     '<div class="toast-progress"></div>';
+  toast.querySelector('.toast-msg').textContent = message;
 
   // Close button handler
   toast.querySelector('.toast-close').addEventListener('click', function () {

--- a/cara.html
+++ b/cara.html
@@ -818,10 +818,11 @@
       const toast = document.createElement('div');
       toast.className = `toast toast-${type}`;
       toast.innerHTML = `
-        <span class="toast-msg">${message}</span>
+        <span class="toast-msg"></span>
         <button class="toast-close" aria-label="Close notification">&times;</button>
         <div class="toast-progress"></div>
       `;
+      toast.querySelector('.toast-msg').textContent = message;
       toast.querySelector('.toast-close').addEventListener('click', () => {
         dismissToast(toast);
       });


### PR DESCRIPTION
Fixes #824

## Problem
All `showToast` function definitions (`app.js`, `cara.html`, `Cara-main/app.js`, `Cara-main/cara.html`) build the toast HTML by directly concatenating the `message` parameter into `innerHTML`:

```js
'<span class="toast-msg">' + message + '</span>'
```

Calling `showToast('<img src=x onerror=alert(1)>')` fires an XSS alert.

## Fix
- Set the message span via `.textContent` instead of interpolating it into `innerHTML`
- The static icon and close button HTML remain in `innerHTML` since they're hardcoded strings
- Applied to all 4 `showToast` definitions across the codebase