### PR TITLE
Fix cart page layout on larger screens #793

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -47,6 +47,17 @@
       margin: 0 auto;
     }
 
+    @media (min-width: 768px) {
+      #cart-add {
+        display: flex;
+        justify-content: flex-end;
+      }
+      .subtotal {
+        width: 100%;
+        max-width: 450px;
+      }
+    }
+
     /* Align the .cart-header labels with the actual cart-item-row grid.
        cart-item-row uses a 5-column grid on desktop:
        [Product 3.5fr] [Price 1fr] [Qty 1.5fr] [Subtotal 1.2fr] [Remove 0.5fr]


### PR DESCRIPTION
# 📝 Pull Request Template

## 📄 Description

This PR fixes the issue where the cart page layout misaligns and breaks on larger desktop screens. 

Previously, the layout would shift awkwardly, leaving a massive blank space on the left side of the screen while pushing the cart content to the right. To resolve this cart misaligning issue:
1. CSS media queries (`@media (min-width: 768px)`) were added to properly structure the cart layout on desktop screens.
2. Flexbox alignment (`justify-content: flex-end`) and maximum width constraints were applied to the `#cart-add` and `.subtotal` containers so that the entire Cart section, including the Cart Totals, remains perfectly centered and aligned.

---

## 🔗 Related Issues

Fixes #793

---

## 🖼️ Screenshots (if applicable)

NA
---

## 🧩 Type of Change

- [x] 🐛 Bug Fix  
- [ ] ✨ New Feature  
- [x] ⚡ Enhancement / Optimization  
- [ ] 🧰 Refactoring  
- [ ] 🧾 Documentation Update  
- [ ] 🔧 Other (please specify): ____________

---

## ✅ Checklist

- [x] I have performed a self-review of my code.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have added or updated relevant documentation.  
- [x] My changes do not break any existing functionality.  
- [x] I have tested my changes locally and they work as expected.  
- [x] I have linked all relevant issues (if any).
