### PR TITLE
Enhancement: Add "Empty Cart" state with call-to-action (Fixes #1001)

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -23,6 +23,7 @@
   <meta name="twitter:site" content="@janavipandole" />
   <meta name="theme-color" content="#000000" />
   <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="empty-cart.css" />
   <link href="https://cdn.jsdelivr.net/npm/remixicon@4.5.0/fonts/remixicon.css" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css"
     integrity="sha512-Kc323vGBEqzTmouAECnVceyQqyqdsSiqLQISBL29aUW4U/M7pSPA/gEUZQqv1cwx4OnYxTxve5UMg5GT6L4JJg=="
@@ -229,6 +230,13 @@
         <p>Review and manage your selected items</p>
       </section>
 
+      <div id="empty-cart-state">
+        <i class="ri-shopping-cart-line empty-cart-icon"></i>
+        <h2>Your cart is empty</h2>
+        <p>Looks like you haven't added anything to your cart yet.</p>
+        <a href="shop.html" class="btn-continue-shopping">Continue Shopping</a>
+      </div>
+
       <section id="cart" class="section-p1">
 
         <!-- Column headers aligned to the 5-column cart-item-row grid -->
@@ -398,6 +406,7 @@
   </div>
 
   <script src="app.js"></script>
+  <script src="empty-cart.js"></script>
   <script>
     document.getElementById("Current-Year").textContent = new Date().getFullYear();
   </script>

--- a/empty-cart.css
+++ b/empty-cart.css
@@ -1,0 +1,79 @@
+/* Empty Cart State Styles */
+#empty-cart-state {
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 60px 20px;
+    background-color: #f9f9f9;
+    border-radius: 8px;
+    margin: 40px auto;
+    max-width: 600px;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.05);
+}
+
+body.dark-mode #empty-cart-state {
+    background-color: #1a1a1a;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.3);
+}
+
+.empty-cart-icon {
+    font-size: 80px;
+    color: #ccc;
+    margin-bottom: 20px;
+    animation: bounce 2s infinite;
+}
+
+body.dark-mode .empty-cart-icon {
+    color: #444;
+}
+
+#empty-cart-state h2 {
+    font-size: 28px;
+    color: #222;
+    margin-bottom: 10px;
+}
+
+body.dark-mode #empty-cart-state h2 {
+    color: #f1f1f1;
+}
+
+#empty-cart-state p {
+    font-size: 16px;
+    color: #666;
+    margin-bottom: 30px;
+}
+
+body.dark-mode #empty-cart-state p {
+    color: #aaa;
+}
+
+.btn-continue-shopping {
+    background-color: #088178;
+    color: #fff;
+    padding: 14px 30px;
+    border-radius: 4px;
+    text-decoration: none;
+    font-size: 16px;
+    font-weight: 600;
+    transition: background-color 0.3s ease;
+}
+
+.btn-continue-shopping:hover {
+    background-color: #066b63;
+    color: #fff;
+}
+
+/* Bounce Animation */
+@keyframes bounce {
+    0%, 20%, 50%, 80%, 100% {
+        transform: translateY(0);
+    }
+    40% {
+        transform: translateY(-20px);
+    }
+    60% {
+        transform: translateY(-10px);
+    }
+}

--- a/empty-cart.js
+++ b/empty-cart.js
@@ -1,0 +1,27 @@
+document.addEventListener('DOMContentLoaded', () => {
+    // Override the existing handleEmptyCartView in app.js
+    window.handleEmptyCartView = function() {
+        const cart = JSON.parse(localStorage.getItem('productsInCart')) || [];
+        const cartMain = document.querySelector('.cartmain');
+        const cartGrid = document.getElementById('cart');
+        const cartAdd = document.getElementById('cart-add');
+        const emptyContainer = document.getElementById('empty-cart-state');
+
+        if (window.location.pathname.includes('cart.html')) {
+            if (cart.length === 0) {
+                if (cartGrid) cartGrid.style.display = 'none';
+                if (cartAdd) cartAdd.style.display = 'none';
+                if (emptyContainer) emptyContainer.style.display = 'flex';
+            } else {
+                if (cartGrid) cartGrid.style.display = '';
+                if (cartAdd) cartAdd.style.display = ''; 
+                if (emptyContainer) emptyContainer.style.display = 'none';
+            }
+        }
+    };
+
+    // Call it initially
+    if (typeof handleEmptyCartView === 'function') {
+        handleEmptyCartView();
+    }
+});


### PR DESCRIPTION
## Problem
When a user had no items in the cart, the cart page either showed a broken layout or just empty column headers without any friendly guidance to return to shopping.

## Solution
Added a styled empty cart state inside `cart.html` as requested in issue #1001.

### Changes Included:
- **Empty State UI**: Displays a bouncing cart icon, a "Your cart is empty" message, and a prominent "Continue Shopping" button.
- **Dynamic Toggling**: Added `empty-cart.js` to check `localStorage` and seamlessly hide the cart table and totals, showing the empty state instead when there are 0 items.
- **Dark Mode Support**: The new empty cart state is fully integrated with the existing light/dark theme system.
- **Clean Structure**: Created dedicated `empty-cart.css` and `empty-cart.js` files to keep the codebase organized.

Closes #1001
