### PR TITLE
fix: remove overflow hidden clipping product card images

### DIFF
--- a/style.css
+++ b/style.css
@@ -1787,7 +1787,6 @@ footer .copyright {
     position: relative;
     background-color: var(--card-bg);
     border: 1px solid var(--border-color);
-    overflow: hidden;
 }
 
 #product1 .pro:hover {
@@ -8992,7 +8991,6 @@ footer .copyright {
     position: relative;
     background-color: var(--card-bg);
     border: 1px solid var(--border-color);
-    overflow: hidden;
 }
 
 #product1 .pro:hover {
@@ -15783,7 +15781,6 @@ footer .copyright {
     position: relative;
     background-color: var(--card-bg);
     border: 1px solid var(--border-color);
-    overflow: hidden;
 }
 
 #product1 .pro:hover {
@@ -22939,7 +22936,6 @@ footer .copyright {
     position: relative;
     background-color: var(--card-bg);
     border: 1px solid var(--border-color);
-    overflow: hidden;
 }
 
 #product1 .pro:hover {
@@ -29730,7 +29726,6 @@ footer .copyright {
     position: relative;
     background-color: var(--card-bg);
     border: 1px solid var(--border-color);
-    overflow: hidden;
 }
 
 #product1 .pro:hover {


### PR DESCRIPTION
## Description
Fixes #994

The `overflow: hidden` on `#product1 .pro` in `style.css` was 
clipping the top of all product card images in the featured 
product carousel/grid.

## Changes Made
- Removed `overflow: hidden` from `#product1 .pro` in `style.css`
- `.pro-img-wrap` already handles its own overflow, so this was unnecessary

## Type of Change
- [x] Bug fix

---
> Contribution made under GSSoC 2026 