### PR TITLE
fix: resolve dual dark mode conflict between app.js and navbar.js

### DIFF
--- a/Cara-main/navbar.js
+++ b/Cara-main/navbar.js
@@ -55,13 +55,8 @@ function initDarkMode() {
   }
 
   function handleToggle() {
-    document.body.classList.toggle('dark');
-    const isDark = document.body.classList.contains('dark');
-    localStorage.setItem('theme', isDark ? 'dark' : 'light');
-    const next = isDark ? 'ri-sun-line' : 'ri-moon-line';
-    const prev = isDark ? 'ri-moon-line' : 'ri-sun-line';
-    if (themeIcon) themeIcon.classList.replace(prev, next);
-    if (themeIconMobile) themeIconMobile.classList.replace(prev, next);
+    toggleTheme(); //single source of truth from app.js
+    
   }
 
   if (themeToggle) themeToggle.addEventListener('click', handleToggle);


### PR DESCRIPTION
### 📋 PR Description


Closes #775

## 📋 Description

The dark mode toggle is broken on all pages that load the dynamic navbar.
`app.js` applies the theme by setting a `data-theme` attribute on the
`<html>` element, while `navbar.js` applies it by toggling a `dark` class
on `document.body`. Both scripts also read back the theme state from their
own system, so they are permanently out of sync. On any page loading both
files, toggling once applies the theme via one system; the second toggle
reads the wrong state from the other, leaving the page stuck in a broken
half-light / half-dark state.

---

## 🔗 Related Issues

Fixes #775

---

## 🛠️ Changes Made

- **`Cara-main/navbar.js`:** Removed the duplicate `handleToggle()`
  implementation and replaced it with a call to the shared `toggleTheme()`
  function defined in `app.js`

*Before:*
```js
// navbar.js
function handleToggle() {
     toggleTheme(); 
}
```
// single source of truth from app.js
*After:*
```js
// navbar.js
function handleToggle() {
    toggleTheme(); // single source of truth from app.js
}
```

---

## ✅ Testing Done

- Opened `index.html` → toggled dark mode on and off multiple times → theme switches correctly every time
- Reloaded the page → saved theme is restored from `localStorage` correctly
- Opened `shop.html`, `cart.html`, `about.html` → repeated toggle test → no mixed state on any page
- Confirmed zero `TypeError` or theme-related errors in the DevTools console

---

## 🧩 Environment

- Browser: Chrome / Firefox
- OS: Windows 11
- No build tools — static HTML/CSS/JS site

---

## 🔄 Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

---

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have tested my changes across major browsers/devices
- [x] My changes do not generate new console warnings or errors
- [x] This issue is already assigned to me




