### PR TITLE
fix: wrap 404 error page contents in a main landmark and set asset sizes

### DIFF
--- a/404page.html
+++ b/404page.html
@@ -175,7 +175,7 @@
   <!-- ── HEADER ── -->
   <section id="header">
     <a href="index.html">
-      <img loading="lazy" id="siteLogo" src="images/logo.png" alt="Cara Logo" />
+      <img loading="lazy" id="siteLogo" src="images/logo.png" alt="Cara Logo" width="130" height="40" />
     </a>
     <div id="navbar-container"></div>
     <div id="mobile">
@@ -187,6 +187,7 @@
   </section>
 
   <!-- ── 404 SECTION ── -->
+  <main id="main-content">
   <section id="not-found">
 
     <i class="ri-map-pin-line not-found-icon"></i>
@@ -218,12 +219,13 @@
     </div>
 
   </section>
+  </main>
 
   <!-- ── FOOTER ── -->
   <footer class="main-footer">
     <div class="footer-top">
       <div class="footer-logo-box">
-        <img class="footer-logo" src="images/logo.png" alt="Cara Logo" />
+        <img class="footer-logo" src="images/logo.png" alt="Cara Logo" width="110" height="34" loading="lazy" />
       </div>
       <div class="footer-socials">
         <a href="https://x.com/JanaviPandole" target="_blank" rel="noopener noreferrer"><i class="fab fa-twitter"></i></a>


### PR DESCRIPTION
### Summary
This PR improves document structures and performance on `404page.html` by:
- Enclosing error details and navigation buttons within a semantic `<main id="main-content">` landmark.
- Adding explicit sizes (`width` and `height`) and `loading="lazy"` parameters to both header and footer logo images to prevent layout shifts.

### Resolved Issues
Closes #1152

### Verification Done
- Verified landmarks tree shows `<main>` structure.
- Layout shifts (CLS) resolved.
