### PR TITLE
fix: apply semantic section tags and target link labels on Terms Page

### DIFF
--- a/terms.html
+++ b/terms.html
@@ -129,7 +129,7 @@
     <section id="header">
   <!-- Logo -->
   <a href="index.html">
-    <img id="siteLogo" src="images/logo.png" alt="Cara Logo" />
+    <img id="siteLogo" src="images/logo.png" alt="Cara Logo" width="130" height="40" />
   </a>
 
   <div>
@@ -221,10 +221,10 @@
     </section>
 
     <!-- Terms Content -->
-    <div id="terms-page">
-      <a href="javascript:history.back()" class="back-btn">
+    <main id="terms-page">
+      <button onclick="javascript:history.back()" class="back-btn" aria-label="Go back to previous page" style="border: none; font-family: inherit; font-size: inherit;">
         <i class="ri-arrow-left-line"></i> Back
-      </a>
+      </button>
 
       <h1>Terms &amp; Conditions</h1>
       <p class="subtitle">Last Updated — May 2026</p>
@@ -235,16 +235,16 @@
         our services.
       </p>
 
-      <div class="terms-section">
+      <section class="terms-section">
         <h2>📘 01. Acceptance of Terms</h2>
         <p>
           By accessing this website, you acknowledge that you have read,
           understood, and agreed to be bound by these terms and all applicable
           laws and regulations.
         </p>
-      </div>
+      </section>
 
-      <div class="terms-section">
+      <section class="terms-section">
         <h2>⚡ 02. Use of the Platform</h2>
         <p>
           Users must use the platform responsibly and lawfully. Any misuse,
@@ -255,75 +255,75 @@
           <li>Do not misuse platform resources or services.</li>
           <li>Respect all users and community standards.</li>
         </ul>
-      </div>
+      </section>
 
-      <div class="terms-section">
+      <section class="terms-section">
         <h2>🔐 03. User Accounts</h2>
         <p>
           You are responsible for maintaining the confidentiality of your account
           credentials and for all activities performed under your account.
         </p>
-      </div>
+      </section>
 
-      <div class="terms-section">
+      <section class="terms-section">
         <h2>🎨 04. Intellectual Property</h2>
         <p>
           All content, branding, logos, graphics, and website materials are the
           property of Cara and may not be copied, distributed, or reused without
           permission.
         </p>
-      </div>
+      </section>
 
-      <div class="terms-section">
+      <section class="terms-section">
         <h2>🛡️ 05. Privacy Policy</h2>
         <p>
           Your use of the platform is also governed by our
-          <a href="privacy.html" style="color: #088178;">Privacy Policy</a>.
+          <a href="privacy.html" style="color: #088178;" aria-label="View our Privacy Policy">Privacy Policy</a>.
         </p>
-      </div>
+      </section>
 
-      <div class="terms-section">
+      <section class="terms-section">
         <h2>🌐 06. Third-Party Services</h2>
         <p>
           Some features may include third-party integrations or external links.
           We are not responsible for the content or practices of those services.
         </p>
-      </div>
+      </section>
 
-      <div class="terms-section">
+      <section class="terms-section">
         <h2>⚖️ 07. Limitation of Liability</h2>
         <p>
           Cara shall not be held liable for any direct, indirect, or incidental
           damages arising from the use of the platform.
         </p>
-      </div>
+      </section>
 
-      <div class="terms-section">
+      <section class="terms-section">
         <h2>🔄 08. Updates to Terms</h2>
         <p>
           We reserve the right to modify or update these Terms &amp; Conditions.
           Continued use of the platform after changes constitutes acceptance of the updated terms.
         </p>
-      </div>
+      </section>
 
-      <div class="terms-section">
+      <section class="terms-section">
         <h2>⛔ 09. Termination</h2>
         <p>
           We may suspend or terminate access to the platform for users who
           violate these terms.
         </p>
-      </div>
+      </section>
 
-      <div class="terms-section">
+      <section class="terms-section">
         <h2>📞 10. Contact</h2>
         <p>
           If you have any questions regarding these Terms &amp; Conditions,
-          contact us through our <a href="contact.html" style="color: #088178;">Contact page</a>.
+          contact us through our <a href="contact.html" style="color: #088178;" aria-label="Go to Contact page">Contact page</a>.
         </p>
-      </div>
+      </section>
 
       <div class="footer-note">&copy; 2026 Cara — All Rights Reserved</div>
-    </div>
+    </main>
 
     <!-- Back to Top -->
     <button id="backToTop" title="Back to Top" aria-label="Back to top">⬆</button>
@@ -332,7 +332,7 @@
     <!-- Footer -->
     <footer class="section-p1">
       <div class="col">
-        <img class="logo" src="images/logo.png" alt="Cara Logo" />
+        <img class="logo" src="images/logo.png" alt="Cara Logo" width="130" height="40" loading="lazy" />
         <h4>Contact</h4>
         <p><strong>Address:</strong> 562 Wellington Road, Street 32, San Francisco</p>
         <p><strong>Phone:</strong> +01 2222 365 / (+91) 01 2345 6789</p>
@@ -387,8 +387,8 @@
         <h4>Install App</h4>
         <p>From App Store or Google Play</p>
         <div class="row">
-          <img src="images/pay/app.jpg" alt="Download from App Store" />
-          <img src="images/pay/play.jpg" alt="Get it on Google Play" />
+          <img src="images/pay/app.jpg" alt="Download from App Store" width="180" height="54" loading="lazy" />
+          <img src="images/pay/play.jpg" alt="Get it on Google Play" width="180" height="54" loading="lazy" />
         </div>
         <p>Secured Payment Gateways</p>
         <div class="payment-icons">


### PR DESCRIPTION
### Summary
This PR resolves accessibility gaps on `terms.html` by:
- Transitioning raw content blocks into semantic `<section>` sections.
- Adding clear navigation descriptions and label pointers to back buttons and inline links (e.g., `aria-label="View our Privacy Policy"`).
- Defining explicit dimensions (`width`, `height`, and `loading="lazy"`) for site logos and app store images.

### Resolved Issues
Closes #1154 

### Verification Done
- Audited document landmarks and confirm heading structure is sequential.
- Verified image dimensions to confirm zero layout shift.
