### PR TITLE
fix: restructure privacy clauses into accessible HTML5 description lists

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -142,7 +142,7 @@
   <body>
     <!-- Header -->
     <section id="header">
-      <a id="siteLogo" href="index.html"><img src="images/logo.png" alt="Cara Logo" /></a>
+      <a id="siteLogo" href="index.html"><img src="images/logo.png" alt="Cara Logo" width="130" height="40" /></a>
 
       <div>
         <ul id="navbar">
@@ -192,10 +192,10 @@
     </section>
 
     <!-- Policy Content -->
-    <div id="policy-page">
-      <a href="javascript:history.back()" class="back-btn">
+    <main id="policy-page">
+      <button onclick="javascript:history.back()" class="back-btn" aria-label="Go back to previous page" style="border: none; font-family: inherit; font-size: inherit;">
         <i class="ri-arrow-left-line"></i> Back
-      </a>
+      </button>
 
       <h1>Privacy Policy</h1>
       <p class="subtitle">Last Updated: May 2026</p>
@@ -205,80 +205,98 @@
         use, and protect your information when you use our website.
       </p>
 
-      <div class="policy-section">
-        <h2>📌 1. Information We Collect</h2>
-        <p>
-          We may collect personal information such as your name, email address, phone number,
-          shipping address, and payment details when you place an order or contact us.
-        </p>
-      </div>
-
-      <div class="policy-section">
-        <h2>⚡ 2. How We Use Your Information</h2>
-        <p>The information collected is used to:</p>
-        <ul>
-          <li>Process and deliver orders</li>
-          <li>Improve user experience</li>
-          <li>Provide customer support</li>
-          <li>Send updates and promotional offers</li>
-          <li>Maintain website security</li>
-        </ul>
-      </div>
-
-      <div class="policy-section">
-        <h2>🍪 3. Cookies</h2>
-        <p>
-          Our website may use cookies to improve browsing experience and analyze website traffic.
-          You can disable cookies through your browser settings if you prefer.
-        </p>
-      </div>
-
-      <div class="policy-section">
-        <h2>🔒 4. Data Protection</h2>
-        <p>
-          We implement security measures to protect your personal data from unauthorized access,
-          alteration, or disclosure.
-        </p>
-      </div>
-
-      <div class="policy-section">
-        <h2>🌐 5. Third-Party Services</h2>
-        <p>
-          We may use trusted third-party services such as payment gateways and analytics tools.
-          These services may collect information according to their own privacy policies.
-        </p>
-      </div>
-
-      <div class="policy-section">
-        <h2>🛡️ 6. Your Rights</h2>
-        <p>
-          You have the right to access, update, or request deletion of your personal information.
-          To make such requests, contact us using the details below.
-        </p>
-      </div>
-
-      <div class="policy-section">
-        <h2>📞 7. Contact Us</h2>
-        <p>If you have any questions regarding this Privacy Policy, please contact us at:</p>
-        <div class="contact-box">
-          <p><strong>Head Office</strong></p>
-          <p>56 Glassford Street, Glasgow G1 1UL, New York</p>
-          <p>contact@example.com</p>
-          <p>+1 (000) 123-7788</p>
-          <p>Monday to Saturday — 9:00 AM to 6:00 PM</p>
+      <dl class="policy-list">
+        <div class="policy-section">
+          <dt><h2>📌 1. Information We Collect</h2></dt>
+          <dd>
+            <p>
+              We may collect personal information such as your name, email address, phone number,
+              shipping address, and payment details when you place an order or contact us.
+            </p>
+          </dd>
         </div>
-      </div>
 
-      <div class="policy-section">
-        <h2>🔄 8. Updates to This Policy</h2>
-        <p>
-          We may update this Privacy Policy from time to time. Changes will be posted on this page
-          with the updated effective date.
-        </p>
-      </div>
+        <div class="policy-section">
+          <dt><h2>⚡ 2. How We Use Your Information</h2></dt>
+          <dd>
+            <p>The information collected is used to:</p>
+            <ul>
+              <li>Process and deliver orders</li>
+              <li>Improve user experience</li>
+              <li>Provide customer support</li>
+              <li>Send updates and promotional offers</li>
+              <li>Maintain website security</li>
+            </ul>
+          </dd>
+        </div>
+
+        <div class="policy-section">
+          <dt><h2>🍪 3. Cookies</h2></dt>
+          <dd>
+            <p>
+              Our website may use cookies to improve browsing experience and analyze website traffic.
+              You can disable cookies through your browser settings if you prefer.
+            </p>
+          </dd>
+        </div>
+
+        <div class="policy-section">
+          <dt><h2>🔒 4. Data Protection</h2></dt>
+          <dd>
+            <p>
+              We implement security measures to protect your personal data from unauthorized access,
+              alteration, or disclosure.
+            </p>
+          </dd>
+        </div>
+
+        <div class="policy-section">
+          <dt><h2>🌐 5. Third-Party Services</h2></dt>
+          <dd>
+            <p>
+              We may use trusted third-party services such as payment gateways and analytics tools.
+              These services may collect information according to their own privacy policies.
+            </p>
+          </dd>
+        </div>
+
+        <div class="policy-section">
+          <dt><h2>🛡️ 6. Your Rights</h2></dt>
+          <dd>
+            <p>
+              You have the right to access, update, or request deletion of your personal information.
+              To make such requests, contact us using the details below.
+            </p>
+          </dd>
+        </div>
+
+        <div class="policy-section">
+          <dt><h2>📞 7. Contact Us</h2></dt>
+          <dd>
+            <p>If you have any questions regarding this Privacy Policy, please contact us at:</p>
+            <div class="contact-box">
+              <p><strong>Head Office</strong></p>
+              <p>56 Glassford Street, Glasgow G1 1UL, New York</p>
+              <p>contact@example.com</p>
+              <p>+1 (000) 123-7788</p>
+              <p>Monday to Saturday — 9:00 AM to 6:00 PM</p>
+            </div>
+          </dd>
+        </div>
+
+        <div class="policy-section">
+          <dt><h2>🔄 8. Updates to This Policy</h2></dt>
+          <dd>
+            <p>
+              We may update this Privacy Policy from time to time. Changes will be posted on this page
+              with the updated effective date.
+            </p>
+          </dd>
+        </div>
+      </dl>
 
       <div class="footer-note">Last Updated: May 2026</div>
-    </div>
+    </main>
 
     <!-- Back to Top -->
     <button id="backToTop" title="Back to Top" aria-label="Back to top">⬆</button>
@@ -287,7 +305,7 @@
     <!-- Footer -->
     <footer class="section-p1">
       <div class="col">
-        <img class="logo" src="images/logo.png" alt="Cara Logo" />
+        <img class="logo" src="images/logo.png" alt="Cara Logo" width="130" height="40" loading="lazy" />
         <h4>Contact</h4>
         <p><strong>Address:</strong> 562 Wellington Road, Street 32, San Francisco</p>
         <p><strong>Phone:</strong> +01 2222 365 / (+91) 01 2345 6789</p>
@@ -342,8 +360,8 @@
         <h4>Install App</h4>
         <p>From App Store or Google Play</p>
         <div class="row">
-          <img src="images/pay/app.jpg" alt="Download from App Store" />
-          <img src="images/pay/play.jpg" alt="Get it on Google Play" />
+          <img src="images/pay/app.jpg" alt="Download from App Store" width="180" height="54" loading="lazy" />
+          <img src="images/pay/play.jpg" alt="Get it on Google Play" width="180" height="54" loading="lazy" />
         </div>
         <p>Secured Payment Gateways</p>
         <div class="payment-icons">


### PR DESCRIPTION
### Summary
This PR restructures `privacy.html` to improve reading layouts for screen readers by:
- Transitioning privacy sections and legal definitions into highly accessible Description Lists (`<dl>`, `<dt>`, `<dd>`) to programmatically link policies to their respective terms.
- Converted the non-focusable back anchor into a standard `<button>`.
- Adding explicit sizes and native `loading="lazy"` to logos and app badges.

### Resolved Issues
Closes #1156 

### Verification Done
- Inspected the DOM using the Accessibility Tree. The `<dl>` relationship reads correctly.
