### PR TITLE
enhancement: wrap virtual try-on page in main landmark and resolve skipped headings

### DIFF
--- a/try-on.html
+++ b/try-on.html
@@ -634,6 +634,7 @@
             <i class="fas fa-outdent" id="bar"></i>
             </div> -->
         <!-- </section> -->
+    <main>
     <section id="try-on-section">
 
         <!-- Step Progress -->
@@ -661,7 +662,7 @@
                 <p>Use your camera or upload a photo. Our AI detects your body shape and fits the clothing on you.</p>
                 
                 <!-- Step 1: Input Mode -->
-                <h4>1. Choose Input</h4>
+                <h3>1. Choose Input</h3>
                 <div class="mode-toggle">
                     <button class="mode-btn active" id="btn-camera" onclick="switchMode('camera')">
                         <i class="ri-camera-line"></i> Camera
@@ -694,7 +695,7 @@
                 </div>
 
                 <!-- Step 2: Outfit -->
-                <h4>2. Select Outfit</h4>
+                <h3>2. Select Outfit</h3>
                 <div class="clothing-list" id="clothing-list">
                     <!-- Populated by JS from products array -->
                 </div>
@@ -747,6 +748,7 @@
             </div>
         </div>
     </section>
+    </main>
 
     <footer class="section-p1">
     <!-- Contact Column -->


### PR DESCRIPTION
### Summary
This PR improves the document structure and accessibility of `try-on.html` by:
- Wrapping the central try-on section inside a semantic `<main>` landmark.
- Correcting heading skips by converting `<h4>1. Choose Input</h4>` and `<h4>2. Select Outfit</h4>` to `<h3>` elements to establish a sequential outline.

### Resolved Issues
Closes #1164 

### Verification Done
- Verified heading hierarchy using HTML5 outline analyzers.
- Verified screen reader landmarks navigation.
