### PR TITLE
fix: replace emojis with icons in forgot password

### DIFF
--- a/forgotPassword.html
+++ b/forgotPassword.html
@@ -43,7 +43,7 @@
             <h2>Forgot Password</h2>
 
             <p class="subtitle">
-                Enter your email to reset your password 🔒
+                Enter your email to reset your password <i class="fas fa-lock"></i>
             </p>
 
             <form id="forgotForm" novalidate>


### PR DESCRIPTION
# Related Issue
Closes #1214 

# Summary
This PR replaces the lock emoji in the forgot password page with a FontAwesome icon.

# Changes Made
* Replaced `🔒` with `<i class="fas fa-lock"></i>` in `forgotPassword.html`

# Testing
* Verified the Forgot Password page renders correctly in the browser.

# Checklist
* [x] Code follows project style
* [x] Tested locally
* [x] No unrelated changes included
