### PR TITLE
fix: replace emojis with icons in privacy policy

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -207,7 +207,7 @@
 
       <dl class="policy-list">
         <div class="policy-section">
-          <dt><h2>📌 1. Information We Collect</h2></dt>
+          <dt><h2><i class="fas fa-thumbtack"></i> 1. Information We Collect</h2></dt>
           <dd>
             <p>
               We may collect personal information such as your name, email address, phone number,
@@ -231,7 +231,7 @@
         </div>
 
         <div class="policy-section">
-          <dt><h2>🍪 3. Cookies</h2></dt>
+          <dt><h2><i class="fas fa-cookie"></i> 3. Cookies</h2></dt>
           <dd>
             <p>
               Our website may use cookies to improve browsing experience and analyze website traffic.
@@ -241,7 +241,7 @@
         </div>
 
         <div class="policy-section">
-          <dt><h2>🔒 4. Data Protection</h2></dt>
+          <dt><h2><i class="fas fa-lock"></i> 4. Data Protection</h2></dt>
           <dd>
             <p>
               We implement security measures to protect your personal data from unauthorized access,
@@ -251,7 +251,7 @@
         </div>
 
         <div class="policy-section">
-          <dt><h2>🌐 5. Third-Party Services</h2></dt>
+          <dt><h2><i class="fas fa-globe"></i> 5. Third-Party Services</h2></dt>
           <dd>
             <p>
               We may use trusted third-party services such as payment gateways and analytics tools.
@@ -261,7 +261,7 @@
         </div>
 
         <div class="policy-section">
-          <dt><h2>🛡️ 6. Your Rights</h2></dt>
+          <dt><h2><i class="fas fa-shield-alt"></i> 6. Your Rights</h2></dt>
           <dd>
             <p>
               You have the right to access, update, or request deletion of your personal information.
@@ -271,7 +271,7 @@
         </div>
 
         <div class="policy-section">
-          <dt><h2>📞 7. Contact Us</h2></dt>
+          <dt><h2><i class="fas fa-phone"></i> 7. Contact Us</h2></dt>
           <dd>
             <p>If you have any questions regarding this Privacy Policy, please contact us at:</p>
             <div class="contact-box">
@@ -285,7 +285,7 @@
         </div>
 
         <div class="policy-section">
-          <dt><h2>🔄 8. Updates to This Policy</h2></dt>
+          <dt><h2><i class="fas fa-sync"></i> 8. Updates to This Policy</h2></dt>
           <dd>
             <p>
               We may update this Privacy Policy from time to time. Changes will be posted on this page


### PR DESCRIPTION
# Related Issue
Closes #1216 

# Summary
This PR replaces emojis in the Privacy Policy section headers with FontAwesome icons.

# Changes Made
* Replaced various emojis with FontAwesome icons in `privacy.html`

# Testing
* Verified the Privacy Policy page renders correctly in the browser.

# Checklist
* [x] Code follows project style
* [x] Tested locally
* [x] No unrelated changes included
