### PR TITLE
fix: replace emojis with icons in register

### DIFF
--- a/register.html
+++ b/register.html
@@ -107,7 +107,7 @@
 <section id="register-section">
   <div class="auth-card">
     <h2>Register</h2>
-    <p class="subtitle">Create your account 😊</p>
+    <p class="subtitle">Create your account <i class="fas fa-smile"></i></p>
 
     <form id="registerForm" novalidate>
 


### PR DESCRIPTION
# Related Issue
Closes #1220 

# Summary
This PR replaces the smile emoji in the register page with a FontAwesome icon.

# Changes Made
* Replaced `😊` with `<i class="fas fa-smile"></i>` in `register.html`

# Testing
* Verified the Register page renders correctly in the browser.

# Checklist
* [x] Code follows project style
* [x] Tested locally
* [x] No unrelated changes included
