### PR TITLE
fix: replace emojis with icons in terms

### DIFF
--- a/terms.html
+++ b/terms.html
@@ -236,7 +236,7 @@
       </p>
 
       <section class="terms-section">
-        <h2>📘 01. Acceptance of Terms</h2>
+        <h2><i class="fas fa-book"></i> 01. Acceptance of Terms</h2>
         <p>
           By accessing this website, you acknowledge that you have read,
           understood, and agreed to be bound by these terms and all applicable
@@ -258,7 +258,7 @@
       </section>
 
       <section class="terms-section">
-        <h2>🔐 03. User Accounts</h2>
+        <h2><i class="fas fa-lock"></i> 03. User Accounts</h2>
         <p>
           You are responsible for maintaining the confidentiality of your account
           credentials and for all activities performed under your account.
@@ -266,7 +266,7 @@
       </section>
 
       <section class="terms-section">
-        <h2>🎨 04. Intellectual Property</h2>
+        <h2><i class="fas fa-palette"></i> 04. Intellectual Property</h2>
         <p>
           All content, branding, logos, graphics, and website materials are the
           property of Cara and may not be copied, distributed, or reused without
@@ -275,7 +275,7 @@
       </section>
 
       <section class="terms-section">
-        <h2>🛡️ 05. Privacy Policy</h2>
+        <h2><i class="fas fa-shield-alt"></i> 05. Privacy Policy</h2>
         <p>
           Your use of the platform is also governed by our
           <a href="privacy.html" style="color: #088178;" aria-label="View our Privacy Policy">Privacy Policy</a>.
@@ -283,7 +283,7 @@
       </section>
 
       <section class="terms-section">
-        <h2>🌐 06. Third-Party Services</h2>
+        <h2><i class="fas fa-globe"></i> 06. Third-Party Services</h2>
         <p>
           Some features may include third-party integrations or external links.
           We are not responsible for the content or practices of those services.
@@ -299,7 +299,7 @@
       </section>
 
       <section class="terms-section">
-        <h2>🔄 08. Updates to Terms</h2>
+        <h2><i class="fas fa-sync"></i> 08. Updates to Terms</h2>
         <p>
           We reserve the right to modify or update these Terms &amp; Conditions.
           Continued use of the platform after changes constitutes acceptance of the updated terms.
@@ -315,7 +315,7 @@
       </section>
 
       <section class="terms-section">
-        <h2>📞 10. Contact</h2>
+        <h2><i class="fas fa-phone"></i> 10. Contact</h2>
         <p>
           If you have any questions regarding these Terms &amp; Conditions,
           contact us through our <a href="contact.html" style="color: #088178;" aria-label="Go to Contact page">Contact page</a>.


### PR DESCRIPTION
# Related Issue
Closes #1222 

# Summary
This PR replaces emojis in the Terms page section headers with FontAwesome icons.

# Changes Made
* Replaced various emojis with FontAwesome icons in `terms.html`

# Testing
* Verified the Terms page renders correctly in the browser.

# Checklist
* [x] Code follows project style
* [x] Tested locally
* [x] No unrelated changes included
