### PR TITLE
fix: replace emojis with icons in wishlist

### DIFF
--- a/wishlist.html
+++ b/wishlist.html
@@ -91,7 +91,7 @@
         function renderWishlist() {
             wishlistContainer.innerHTML = '';
             if (wishlist.length === 0) {
-                wishlistContainer.innerHTML = '<p class="empty-message">Your wishlist is empty 💔</p>';
+                wishlistContainer.innerHTML = '<p class="empty-message">Your wishlist is empty <i class="fas fa-heart-broken"></i></p>';
             } else {
                 wishlist.forEach((product, index) => {
                     wishlistContainer.innerHTML += `


### PR DESCRIPTION
# Related Issue
Closes #1226 

# Summary
This PR replaces the broken heart emoji in the wishlist empty state with a FontAwesome icon.

# Changes Made
* Replaced `💔` with `<i class="fas fa-heart-broken"></i>` in `wishlist.html`

# Testing
* Verified the wishlist empty state renders correctly in the browser.

# Checklist
* [x] Code follows project style
* [x] Tested locally
* [x] No unrelated changes included
