### PR TITLE
  Center style quiz modal on screen                                                                                    

### DIFF
--- a/style.css
+++ b/style.css
@@ -35343,6 +35343,25 @@ button#share-cart-btn:hover {
 }
 .summary-label { font-size: 14px; font-weight: 600; color: var(--text-primary); }
 .summary-value { font-size: 18px; font-weight: 800; color: var(--accent); }
+
+#quiz-modal {
+    inset: 0;
+    width: 100vw;
+    height: 100vh;
+    min-height: 100vh;
+    padding: 0;
+    justify-content: center;
+    align-items: center;
+}
+
+#quiz-modal .modal-content {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    margin: 0;
+}
+
 .modal-footer {
     display: flex; justify-content: flex-end; gap: 12px;
     padding: 20px 24px;


### PR DESCRIPTION
 - Fixed the positioning of the style quiz modal.          
  - Updated #quiz-modal so it appears in the exact center of the viewport.
  - Prevented the modal from appearing near or attached to the header.

  Changes Made

  - Updated modal overlay sizing and alignment.
  - Applied fixed positioning to #quiz-modal .modal-content.
  - Used top: 50%, left: 50%, and transform: translate(-50%, -50%) to center the modal horizontally and vertically.

  File Changed

  - D:/GSSOC/Cara-main/style.css

  Testing

  - Verified that the quiz modal is no longer positioned near the upper-right/header area.
  - Confirmed that the modal content appears centered on the screen.

<img width="1919" height="1026" alt="Screenshot 2026-05-26 002119" src="https://github.com/user-attachments/assets/56ef2116-95f4-415d-b722-a2658f38f4a3" />
