### PR TITLE
fix: define usernameInput and emailInput variables in register page validation

### DIFF
--- a/register.js
+++ b/register.js
@@ -1,4 +1,6 @@
 const registerForm = document.getElementById("registerForm");
+const usernameInput = document.getElementById("registerUsername");
+const emailInput = document.getElementById("registerEmail");
 
 registerForm.addEventListener("submit", function (e) {
   e.preventDefault();


### PR DESCRIPTION
# Related Issue
Closes #1372 

# Summary
Fixes ReferenceError crashes where `usernameInput` and `emailInput` variables were accessed in validation feedback but were never declared.

# Changes Made
- Declared input elements in `register.js`.

# Testing
- Triggered registration validation errors and verified error outlines applied correctly.
