### PR TITLE
fix: declare username and password element inputs on login validation

### DIFF
--- a/login.js
+++ b/login.js
@@ -27,7 +27,8 @@ document.addEventListener('DOMContentLoaded', function () {
     // ── Form Submission Logic ──
     form.addEventListener('submit', function (e) {
         e.preventDefault();
-        const email = document.getElementById('loginEmail').value.trim();
+        const loginEmailEl = document.getElementById('loginEmail');
+        const email = loginEmailEl ? loginEmailEl.value.trim() : '';
         const password = document.getElementById('loginPassword').value;
 
         if (!email || !password) {


### PR DESCRIPTION
# Related Issue
Closes #1376 

# Summary
Ensures scripts do not crash if DOM elements are missing when looking up login fields.

# Changes Made
- Added existence check for `loginEmail` element inside `login.js`.

# Testing
- Verified user credentials logic locally.
