### PR TITLE
fix: resolve email input references in forgot password validations

### DIFF
--- a/forgotPassword.js
+++ b/forgotPassword.js
@@ -21,7 +21,8 @@ document.getElementById('toggleConfirmPass').addEventListener('click', function 
 });
 
 /* form submit */
-form.addEventListener('submit', function (e) {
+const form = document.getElementById('forgotForm');
+if (form) form.addEventListener('submit', function (e) {
   e.preventDefault();
 
   const email       = document.getElementById('forgotEmail').value.trim();


### PR DESCRIPTION
# Related Issue
Closes #1380 

# Summary
Resolves a JavaScript crash occurring when binding submit handlers to an undeclared `form` variable.

# Changes Made
- Defined and checked existence of `form` in `forgotPassword.js`.

# Testing
- Inspected the JS console on page load.
