### PR TITLE
bug: fix duplicated body and html tag templates in Blog page

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -506,7 +506,3 @@
 
 </body>
 </html>
-
-</body>
-
-</html>


### PR DESCRIPTION
# Related Issue
Closes #1390 

# Summary
Removes accidental duplicate code tags from the footer boilerplate sections.

# Changes Made
- Removed trailing duplicate `</body>` and `</html>` blocks in `blog.html`.

# Testing
- Opened the page locally and verified syntax validation.
