### PR TITLE
feat: clean up unmatched list closing tags in cart HTML

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -308,7 +308,6 @@
           <a href="checkout.html" class="normal" style="text-decoration: none">
             Proceed to Checkout
           </a>
-        </ul>
       </div>
 
       <div class="mobile">


### PR DESCRIPTION
# Related Issue
Closes #1398 

# Summary
Removes a loose list tag `</ul>` in the coupon table checkout wrapper causing browser parsing inconsistencies.

# Changes Made
- Deleted unmatched `</ul>` from the checkout button block in `cart.html`.

# Testing
- Validated file markup.
