### PR TITLE
fix: correct checkout submit button reference and originalHTML

### DIFF
--- a/checkout.js
+++ b/checkout.js
@@ -233,10 +233,13 @@ form.addEventListener("submit", function (e) {
     localStorage.removeItem("appliedCoupon");
     window.appliedCoupon = null;
 
-    btn.disabled = false;
-    btn.style.opacity = '';
-    btn.style.cursor = '';
-    btn.innerHTML = originalHTML;
+    if (submitBtn) {
+      submitBtn.classList.remove("btn-loading");
+      submitBtn.disabled = false;
+      submitBtn.style.opacity = "";
+      submitBtn.style.cursor = "";
+      submitBtn.innerHTML = originalHTML;
+    }
 
     form.reset();
 


### PR DESCRIPTION
# Related Issue
Closes #1402 

# Summary
Fixes a JavaScript ReferenceError on checkout form submission where the undefined `btn` variable was accessed.

# Changes Made
- Updated DOM reference in the validation handler of `checkout.js` to correctly target `submitBtn`.
- Properly preserved and restored `originalHTML` loading states.

# Testing
- Tested locally by submitting a valid checkout form and checking console errors.
