### PR TITLE
fix: wrap singleProduct interactive details to prevent null DOM refer…

### DIFF
--- a/singleProduct.js
+++ b/singleProduct.js
@@ -11,7 +11,7 @@ const sizeRadios = document.querySelectorAll('.size-chart input[type="radio"]');
 
 // OPEN MODAL
 
-openBtn.addEventListener("click", () => {
+if (openBtn) openBtn.addEventListener("click", () => {
 
     modal.style.display = "flex";
 
@@ -20,7 +20,7 @@ openBtn.addEventListener("click", () => {
 
 // CLOSE MODAL
 
-closeBtn.addEventListener("click", () => {
+if (closeBtn) closeBtn.addEventListener("click", () => {
 
     modal.style.display = "none";
 


### PR DESCRIPTION
# Related Issue
Closes #1406 

# Summary
Wraps product details selectors inside existence checks, preventing ReferenceErrors on page variants without sizing buttons.

# Changes Made
- Added element checks for `openBtn` and `closeBtn` in `singleProduct.js`.

# Testing
- Verified sizing modal bindings interactively.
