### PR TITLE
Adjust margins spacing on Shop page card elements grid (#1368)

### DIFF
--- a/shop.css
+++ b/shop.css
@@ -651,6 +651,14 @@
     color: #e0245e;
 }
 
+@media (max-width: 1024px) {
+    #product1 .pro-container,
+    #shop-container {
+        gap: 18px;
+        padding: 20px 40px;
+    }
+}
+
 @media (max-width: 900px) {
     #product1 .pro-container,
     #shop-container {
@@ -660,6 +668,7 @@
     }
 
     #product1 .pro {
+        padding: 12px;
         padding-bottom: 64px;
         border-radius: 14px;
     }


### PR DESCRIPTION
﻿Closes #1368

## Changes
- Added @media (max-width: 1024px) breakpoint in shop.css for product grid with gap: 18px and padding: 20px 40px
- Updated @media (max-width: 900px) with consistent .pro card internal padding
- Creates smooth gap transition: 20px → 18px → 14px across screen sizes
