### PR TITLE
[ENHANCEMENT] privacy-consent-manager (#1417)

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -123,6 +123,89 @@
         border-top: 1px solid var(--border-color, #e0e0e0);
       }
 
+      /* Cookie Consent Drawer */
+      #cookie-consent {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        background: var(--bg-secondary);
+        border-top: 2px solid #088178;
+        padding: 20px 32px;
+        display: none;
+        z-index: 10000;
+        box-shadow: 0 -8px 30px rgba(0, 0, 0, 0.1);
+      }
+
+      #cookie-consent.show {
+        display: block;
+        animation: slideUp 0.35s ease-out;
+      }
+
+      @keyframes slideUp {
+        from { transform: translateY(100%); opacity: 0; }
+        to   { transform: translateY(0);    opacity: 1; }
+      }
+
+      .cookie-inner {
+        max-width: 960px;
+        margin: 0 auto;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 24px;
+        flex-wrap: wrap;
+      }
+
+      .cookie-inner p {
+        margin: 0;
+        font-size: 14px;
+        color: var(--text-primary);
+        flex: 1;
+        min-width: 220px;
+        line-height: 1.7;
+      }
+
+      .cookie-inner p a {
+        color: #088178;
+        text-decoration: underline;
+      }
+
+      .cookie-actions {
+        display: flex;
+        gap: 10px;
+        flex-shrink: 0;
+      }
+
+      .cookie-btn {
+        border: none;
+        padding: 10px 22px;
+        border-radius: 4px;
+        font-size: 14px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: all 0.2s ease;
+      }
+
+      .cookie-btn-accept {
+        background: #088178;
+        color: #fff;
+      }
+
+      .cookie-btn-accept:hover {
+        background: #066b63;
+      }
+
+      .cookie-btn-reject {
+        background: transparent;
+        color: var(--text-primary);
+        border: 1px solid var(--border-color, #ccc);
+      }
+
+      .cookie-btn-reject:hover {
+        background: rgba(0, 0, 0, 0.05);
+      }
+
       @media (max-width: 768px) {
         #policy-page {
           padding: 30px 24px 40px;
@@ -134,6 +217,20 @@
 
         #policy-page .policy-section {
           padding: 18px 16px;
+        }
+
+        #cookie-consent {
+          padding: 16px;
+        }
+
+        .cookie-inner {
+          flex-direction: column;
+          text-align: center;
+        }
+
+        .cookie-actions {
+          width: 100%;
+          justify-content: center;
         }
       }
     </style>
@@ -217,7 +314,7 @@
         </div>
 
         <div class="policy-section">
-          <dt><h2>⚡ 2. How We Use Your Information</h2></dt>
+           <dt><h2><i class="fas fa-bolt"></i> 2. How We Use Your Information</h2></dt>
           <dd>
             <p>The information collected is used to:</p>
             <ul>
@@ -297,6 +394,21 @@
 
       <div class="footer-note">Last Updated: May 2026</div>
     </main>
+
+    <!-- Cookie Consent Drawer -->
+    <div id="cookie-consent" role="dialog" aria-label="Cookie consent">
+      <div class="cookie-inner">
+        <p>
+          <i class="fas fa-cookie-bite" style="margin-right: 6px; color: #088178;"></i>
+          We use cookies to improve your experience. By continuing, you agree to our
+          <a href="privacy.html">Privacy Policy</a>.
+        </p>
+        <div class="cookie-actions">
+          <button class="cookie-btn cookie-btn-reject" id="cookie-reject">Decline</button>
+          <button class="cookie-btn cookie-btn-accept" id="cookie-accept">Accept All</button>
+        </div>
+      </div>
+    </div>
 
     <!-- Back to Top -->
     <button id="backToTop" title="Back to Top" aria-label="Back to top">⬆</button>
@@ -393,7 +505,29 @@
 
     <div id="toast-container"></div>
     <script src="app.js"></script>
-            <script id="Current-Year">
+    <script>
+      (function initCookieConsent() {
+        var consent = localStorage.getItem('cara_cookie_consent');
+        if (consent) return;
+
+        var drawer = document.getElementById('cookie-consent');
+        var accept = document.getElementById('cookie-accept');
+        var reject = document.getElementById('cookie-reject');
+
+        drawer.classList.add('show');
+
+        accept.addEventListener('click', function () {
+          localStorage.setItem('cara_cookie_consent', 'accepted');
+          drawer.classList.remove('show');
+        });
+
+        reject.addEventListener('click', function () {
+          localStorage.setItem('cara_cookie_consent', 'rejected');
+          drawer.classList.remove('show');
+        });
+      })();
+    </script>
+    <script id="Current-Year">
         document.getElementById("Current-Year").textContent = new Date().getFullYear();
     </script>
   </body>


### PR DESCRIPTION
﻿Closes #1417

## Changes
- privacy.html: Replaced raw ⚡ emoji with FontAwesome a-bolt icon
- privacy.html: Added interactive Cookie & Privacy Preferences Consent Drawer
  - Slide-up drawer with acceptance animation
  - Accept All / Decline buttons
  - Preference saved to localStorage (cara_cookie_consent)
  - Only shows when no prior consent is stored
- Fully responsive and dark-mode aware
