### PR TITLE
[BUG] Dark mode toggle button is not working (#1362)

### DIFF
--- a/try-on.js
+++ b/try-on.js
@@ -752,14 +752,20 @@ const topBtn = document.getElementById("topBtn");
   });
 });
 
-const themeToggle = document.getElementById("themeToggle");
+document.addEventListener("click", function (e) {
+    const btn = e.target.closest("#themeToggle, #themeToggleMobile");
+    if (!btn) return;
 
-themeToggle?.addEventListener("click", () => {
-    const currentTheme = document.body.getAttribute("data-theme");
+    const html = document.documentElement;
+    const current = html.getAttribute("data-theme") || "light";
+    const next = current === "dark" ? "light" : "dark";
 
-    if (currentTheme === "dark") {
-        document.body.setAttribute("data-theme", "light");
-    } else {
-        document.body.setAttribute("data-theme", "dark");
-    }
+    html.setAttribute("data-theme", next);
+    localStorage.setItem("theme", next);
+
+    var icon = document.getElementById("themeIcon");
+    var iconM = document.getElementById("themeIconMobile");
+    var cls = next === "dark" ? "ri-sun-line" : "ri-moon-line";
+    if (icon) icon.className = cls;
+    if (iconM) iconM.className = cls;
 });


### PR DESCRIPTION
﻿Closes #1362

## Root Cause
The standalone theme toggle handler in 	ry-on.js was:
1. Setting data-theme on document.body instead of document.documentElement (the <html> root)
2. Not persisting the choice to localStorage
3. CSS selectors ([data-theme="dark"]) target the <html> element, so the toggle appeared to do nothing

## Fix
- Changed target to document.documentElement to match the app.js theme system
- Added localStorage.setItem("theme", next) for persistence
- Switched to event delegation (#themeToggle, #themeToggleMobile) consistent with app.js
- Added sun/moon icon class swap on toggle
