### PR TITLE
fix: apply same strong password policy to forgotPassword.js as in reg…

### DIFF
--- a/forgotPassword.js
+++ b/forgotPassword.js
@@ -33,10 +33,11 @@ form.addEventListener('submit', function (e) {
     return;
   }
 
-  if (!newPass || newPass.length < 6) {
-    showToast('Password must be at least 6 characters!', 'warning');
-    return;
-  }
+  const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&]).{8,}$/;
+    if (!newPass || !passwordRegex.test(newPass)) {
+       showToast('Password must have 8+ chars, 1 uppercase, 1 lowercase, 1 number, and 1 special character (@$!%*?&).', 'warning');
+        return;
+    }
 
   if (newPass !== confirmPass) {
     showToast('Passwords do not match!', 'warning');


### PR DESCRIPTION
## 👨‍💻 Program
This contribution is made under **GSSoC 2026**.
 
---
 
### 📌 Summary
Applies the same strong password `passwordRegex` from `register.js` to `forgotPassword.js`. Previously forgot-password only checked length >= 6, allowing users to reset to weaker passwords than registration required.
 
---
 
### ❌ Problem
**File:** `forgotPassword.js`
 
❌ Only checks `newPass.length < 6` — accepts weak passwords  
❌ `register.js` requires 8+ chars + uppercase + lowercase + number + special  
❌ Users can downgrade account security via password reset  
 
---
 
### ✅ Solution
Reuse the `passwordRegex` already defined in `register.js`.
 
---
 
### 📝 Exact Line Change
**File:** `forgotPassword.js`
 
```diff
- if (!newPass || newPass.length < 6) {
-     showToast('Password must be at least 6 characters!', 'warning');
-     return;
- }
 
+ const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&]).{8,}$/;
+ if (!newPass || !passwordRegex.test(newPass)) {
+     showToast('Password must have 8+ chars, 1 uppercase, 1 lowercase, 1 number, and 1 special character (@$!%*?&).', 'warning');
+     return;
+ }
```
 
---
 
### 🔄 Before vs After
**Before:** Reset to `abc123` → accepted  
**After:** Reset to `abc123` → rejected; `Secure@123` → accepted
 
---
 
### 🧪 Testing
- Weak password `abc123` → rejected with toast ✅
- No uppercase → rejected ✅
- Strong `Secure@123` → accepted ✅
- Policy matches registration exactly ✅
---
 
### 🙌 Contributor Checklist
- [x] Code follows repository guidelines
- [x] Tested thoroughly
- [x] No breaking changes introduced
---
# Closes #823
 
---