### PR TITLE
fix: add null guard to register.js to prevent TypeError when form ele…

### DIFF
--- a/register.js
+++ b/register.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', function () {
     const form = document.getElementById('registerForm');
+    if (!form) return;
     form.addEventListener('submit', function (e) {
         e.preventDefault();
         const name = document.getElementById('registerUsername').value.trim();


### PR DESCRIPTION

## 👨‍💻 Program
This contribution is made under **GSSoC 2026**.
 
---
 
### 📌 Summary
Adds `if (!form) return;` to `register.js` after selecting `#registerForm`. This matches the defensive pattern already present in `login.js` and prevents a `TypeError` crash when the script is loaded on a page without the registration form.
 
---
 
### ❌ Problem
**File:** `register.js`
 
❌ `form.addEventListener(...)` called with no null check  
❌ `login.js` has the guard — `register.js` does not (inconsistency)  
❌ `TypeError` crash halts all JS on the affected page  
 
---
 
### ✅ Solution
Add `if (!form) return;` — a one-line fix.
 
---
 
### 📝 Exact Line Change
**File:** `register.js`
 
```diff
  const form = document.getElementById('registerForm');
+ if (!form) return;
  form.addEventListener('submit', function (e) {
```
 
---
 
### 🔄 Before vs After
**Before:** `register.js` on any non-register page → `TypeError` → JS halts  
**After:** `register.js` anywhere → silently exits if form missing
 
---
 
### 🧪 Testing
- `register.html` → registration works normally ✅
- Script added to `index.html` → no errors ✅
- Register end-to-end still works ✅
---
 
### 🙌 Contributor Checklist
- [x] Code follows repository guidelines
- [x] Tested thoroughly
- [x] No breaking changes introduced
---