### PR TITLE
fix(a11y): resolve structural markup bugs in login form

### DIFF
--- a/login.html
+++ b/login.html
@@ -64,14 +64,14 @@
             <label for="loginEmail">
   Email Address <span class="required">*</span>
 </label>
-            <input type="email" id="loginEmail" name="email" required aria-required="true"input-field" placeholder="Enter your email address" autocomplete="email" required>
+            <input type="email" id="loginEmail" name="email" required aria-required="true" class="input-field" placeholder="Enter your email address" autocomplete="email">
         </div>
         
         <div class="input-group password-group" style="position: relative;">
             <label for="loginPassword">
   Password <span class="required">*</span>
 </label>
-            <input type="password" id="loginPassword" name="password" required aria-required="true"class="input-field" placeholder="••••••••" autocomplete="current-password" required style="padding-right: 45px; width: 100%;">
+            <input type="password" id="loginPassword" name="password" required aria-required="true" class="input-field" placeholder="••••••••" autocomplete="current-password" style="padding-right: 45px; width: 100%;">
             <button type="button" id="togglePassword" class="toggle_password" aria-label="Toggle password visibility" style="position: absolute; right: 10px; top: 38px; background: none; border: none; cursor: pointer; color: #666; font-size: 18px;">
                 <i class="ri-eye-line" id="toggleIcon"></i>
             </button>


### PR DESCRIPTION
Closes #1461.

**Fixes:**
- Fixed malformed aria-required and class attributes that were concatenated without spaces (e.g., aria-required=trueinput-field). This allows screen readers to correctly announce the required fields.
- Removed duplicate required attributes to maintain clean structural markup.