### PR TITLE
refactor: implement centralized pub-sub reactive state engine

### DIFF
--- a/app.js
+++ b/app.js
@@ -137,7 +137,7 @@ function formatCurrency(amount) {
 
 // Update cart count badge
 function updateCartCount() {
-    const cart       = JSON.parse(localStorage.getItem("productsInCart")) || [];
+    const cart       = window.StateStore ? window.StateStore.getState("cart") : (JSON.parse(localStorage.getItem("productsInCart")) || []);
     const totalItems = cart.reduce((sum, item) => sum + item.quantity, 0);
 
     const desktopCount = document.getElementById("desktopCartCount");
@@ -153,7 +153,13 @@ function updateCartCount() {
     }
 }
 
-document.addEventListener("DOMContentLoaded", updateCartCount);
+document.addEventListener("DOMContentLoaded", () => {
+    if (window.StateStore) {
+        window.StateStore.subscribe("cart", updateCartCount);
+    } else {
+        updateCartCount();
+    }
+});
 
 // Toggle empty-cart view
 function handleEmptyCartView() {
@@ -173,7 +179,7 @@ function handleEmptyCartView() {
 }
 
 function addToCart(productName, productPrice, productImage, quantity, size) {
-    let cart       = JSON.parse(localStorage.getItem("productsInCart")) || [];
+    let cart       = window.StateStore ? window.StateStore.getState("cart") : (JSON.parse(localStorage.getItem("productsInCart")) || []);
     let parsedQty  = parseInt(quantity);
     if (isNaN(parsedQty) || parsedQty < 1) parsedQty = 1;
 
@@ -197,7 +203,11 @@ function addToCart(productName, productPrice, productImage, quantity, size) {
         cart.push(item);
     }
 
-    localStorage.setItem("productsInCart", JSON.stringify(cart));
+    if (window.StateStore) {
+        window.StateStore.setState("cart", cart);
+    } else {
+        localStorage.setItem("productsInCart", JSON.stringify(cart));
+    }
     showToast(`${item.name} (Size: ${item.size}) added to cart!`, "success");
     updateCartCount();
 }
@@ -448,12 +458,16 @@ window.loadCart = function () {
 };
 
 window.changeQuantity = function (index, change) {
-    let cart = JSON.parse(localStorage.getItem("productsInCart")) || [];
+    let cart = window.StateStore ? window.StateStore.getState("cart") : (JSON.parse(localStorage.getItem("productsInCart")) || []);
     if (!cart[index]) return;
     let newQty = cart[index].quantity + change;
     if (newQty < 1) newQty = 1;
     cart[index].quantity = newQty;
-    localStorage.setItem("productsInCart", JSON.stringify(cart));
+    if (window.StateStore) {
+        window.StateStore.setState("cart", cart);
+    } else {
+        localStorage.setItem("productsInCart", JSON.stringify(cart));
+    }
     loadCart();
     updateCartCount();
 };
@@ -481,10 +495,14 @@ window.applyCoupon = function () {
 };
 
 window.removeItem = function (index) {
-    let cart        = JSON.parse(localStorage.getItem("productsInCart")) || [];
+    let cart = window.StateStore ? window.StateStore.getState("cart") : (JSON.parse(localStorage.getItem("productsInCart")) || []);
     const removedName = cart[index] ? cart[index].name : "Item";
     cart.splice(index, 1);
-    localStorage.setItem("productsInCart", JSON.stringify(cart));
+    if (window.StateStore) {
+        window.StateStore.setState("cart", cart);
+    } else {
+        localStorage.setItem("productsInCart", JSON.stringify(cart));
+    }
     loadCart();
     updateCartCount();
     showToast(`${removedName} removed from cart`, "error");

--- a/state.js
+++ b/state.js
@@ -1,0 +1,63 @@
+(function() {
+    class CentralStateStore {
+        constructor() {
+            this.state = {
+                cart: JSON.parse(localStorage.getItem("productsInCart")) || [],
+                wishlist: JSON.parse(localStorage.getItem("wishlist")) || [],
+                loggedInUser: JSON.parse(localStorage.getItem("loggedInUser")) || null
+            };
+            this.listeners = {};
+
+            // Listen for cross-tab updates
+            window.addEventListener('storage', (e) => {
+                if (e.key === "productsInCart") {
+                    this.state.cart = JSON.parse(e.newValue) || [];
+                    this.emit("cart", this.state.cart);
+                } else if (e.key === "wishlist") {
+                    this.state.wishlist = JSON.parse(e.newValue) || [];
+                    this.emit("wishlist", this.state.wishlist);
+                } else if (e.key === "loggedInUser") {
+                    this.state.loggedInUser = JSON.parse(e.newValue) || null;
+                    this.emit("auth", this.state.loggedInUser);
+                }
+            });
+        }
+
+        getState(key) {
+            return this.state[key];
+        }
+
+        setState(key, value) {
+            this.state[key] = value;
+            const storageKey = key === "cart" ? "productsInCart" : key;
+            localStorage.setItem(storageKey, JSON.stringify(value));
+            this.emit(key, value);
+        }
+
+        subscribe(key, listener) {
+            if (!this.listeners[key]) {
+                this.listeners[key] = [];
+            }
+            this.listeners[key].push(listener);
+            // Fire immediately with current value
+            listener(this.state[key]);
+            return () => {
+                this.listeners[key] = this.listeners[key].filter(l => l !== listener);
+            };
+        }
+
+        emit(key, value) {
+            if (this.listeners[key]) {
+                this.listeners[key].forEach(listener => {
+                    try {
+                        listener(value);
+                    } catch (e) {
+                        console.error(`Error in state listener for ${key}:`, e);
+                    }
+                });
+            }
+        }
+    }
+
+    window.StateStore = new CentralStateStore();
+})();


### PR DESCRIPTION
Closes #1529 

# Summary
Introduces a pub-sub based reactive state store that acts as a single source of truth for user cart count, wishlist count, and authentication state.

# Changes Made
- Created `state.js` with pub-sub event management.
- Integrated subscription hooks in `app.js` navigation updates.
- Added cross-tab storage synchronizer.
- Refactored cart modification handlers to work with the centralized StateStore.
