### PR TITLE
ci: add pull request size classification labeler workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,21 @@
+name: PR Size Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Size Labeler
+        uses: pascalgn/size-label-action@v0.4.3
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          sizes: |
+            XS: 0-20
+            S: 21-100
+            M: 101-500
+            L: 501-1000
+            XL: 1001-5000


### PR DESCRIPTION
Closes #1557 

# Summary
Implements a clean, standardized Pull Request size labeler using GitHub Actions to improve review logistics.

# Changes Made
- Created `.github/workflows/labeler.yml` with size bounds definition.
- Enabled automatic categorization for Synchronize and Opened events.

# Testing
- Tested Action syntax compliance.