### PR TITLE
security: add strict content security policy in 404 page headers

### DIFF
--- a/404page.html
+++ b/404page.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net;" />
   <!-- Character Encoding -->
   <meta charset="UTF-8" />
 


### PR DESCRIPTION
Closes #1568 

# Summary
Protects 404 pages against unverified script sources.
