### PR TITLE
docs: migrate bug report template to github issue forms YAML

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,35 @@
+name: Bug Report Form
+description: File a structured bug report to help us improve Cara
+title: "[BUG]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug! Please fill out the form below.
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is.
+      placeholder: Describe your issue here...
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Describe how to reproduce the bug.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Browser/OS Environment
+      placeholder: e.g., Chrome 120 on macOS Sonoma
+    validations:
+      required: false


### PR DESCRIPTION
# Related Issue
Closes #1588 

# Summary
Migrates the legacy bug report markdown document into a structured GitHub YAML Issue Form.

# Changes Made
- Added `.github/ISSUE_TEMPLATE/bug_report.yml` mapping structured fields.

# Testing
- Validated YAML schema compatibility using schema checkers.
