### PR TITLE
ci: add automated PR labeler based on file path changes

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,17 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Auto Label PR
+        uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/labeler.yml


### PR DESCRIPTION
# Related Issue
Closes #1593 

# Summary
Configures automatically labeling of pull requests depending on affected files.

# Changes Made
- Added `.github/workflows/labeler.yml` triage workflow.

# Testing
- Validated configuration syntax against standard GitHub Actions properties.
