### PR TITLE
perf: add loading='lazy' to remaining images for better performance

### DIFF
--- a/Cara-main/about.html
+++ b/Cara-main/about.html
@@ -111,7 +111,7 @@
           <section id="header">
   <!-- Logo -->
   <a href="index.html">
-    <img id="siteLogo" src="images/logo.png" alt="Cara Logo" />
+    <img loading="lazy" id="siteLogo" src="images/logo.png" alt="Cara Logo" />
   </a>
 
   <div>
@@ -202,7 +202,7 @@
     </section>
 
     <section id="about-us" class="section-p1">
-      <img src="images/about/a6.jpg" alt="" />
+      <img loading="lazy" src="images/about/a6.jpg" alt="" />
       <div>
         <h2>Who We Are</h2>
         <p>
@@ -308,7 +308,7 @@
     <footer class="section-p1">
       <!-- Contact Column -->
       <div class="col">
-        <img class="logo" src="images/logo.png" alt="Cara Logo" />
+        <img loading="lazy" class="logo" src="images/logo.png" alt="Cara Logo" />
         <h4>Contact</h4>
         <p>
           <strong>Address:</strong> 562 Wellington Road, Street 32, San
@@ -392,8 +392,8 @@
         <p>From App Store or Google Play</p>
 
         <div class="row">
-          <img src="images/pay/app.jpg" alt="Download from App Store" />
-          <img src="images/pay/play.jpg" alt="Get it on Google Play" />
+          <img loading="lazy" src="images/pay/app.jpg" alt="Download from App Store" />
+          <img loading="lazy" src="images/pay/play.jpg" alt="Get it on Google Play" />
         </div>
 
         <p>Secured Payment Gateways</p>

--- a/Cara-main/blog.html
+++ b/Cara-main/blog.html
@@ -101,7 +101,7 @@
 <section id="header">
   <!-- Logo -->
   <a href="index.html">
-    <img id="siteLogo" src="images/logo.png" alt="Cara Logo" />
+    <img loading="lazy" id="siteLogo" src="images/logo.png" alt="Cara Logo" />
   </a>
 
   <div>
@@ -195,7 +195,7 @@
     <section id="blog">
       <div class="blog-box">
         <div class="blog-img">
-          <img src="images/blog/b1.jpg" alt="" />
+          <img loading="lazy" src="images/blog/b1.jpg" alt="" />
         </div>
         <div class="blog-details">
           <h4>The Cotton-Jersey Zip-Up Hoodie</h4>
@@ -216,7 +216,7 @@
       </div>
       <div class="blog-box">
         <div class="blog-img">
-          <img src="images/blog/b2.jpg" alt="" />
+          <img loading="lazy" src="images/blog/b2.jpg" alt="" />
         </div>
         <div class="blog-details">
           <h4>How to style a Quiff</h4>
@@ -233,7 +233,7 @@
       </div>
       <div class="blog-box">
         <div class="blog-img">
-          <img src="images/blog/b3.jpg" alt="" />
+          <img loading="lazy" src="images/blog/b3.jpg" alt="" />
         </div>
         <div class="blog-details">
           <h4>Must-Have Skater Girls Items</h4>
@@ -251,7 +251,7 @@
       </div>
       <div class="blog-box">
         <div class="blog-img">
-          <img src="images/blog/b4.jpg" alt="" />
+          <img loading="lazy" src="images/blog/b4.jpg" alt="" />
         </div>
         <div class="blog-details">
           <h4>Runway-Inspired Trends</h4>
@@ -268,7 +268,7 @@
       </div>
       <div class="blog-box">
         <div class="blog-img">
-          <img src="images/blog/b6.jpg" alt="" />
+          <img loading="lazy" src="images/blog/b6.jpg" alt="" />
         </div>
         <div class="blog-details">
           <h4>AW20 Menswear Trends</h4>
@@ -297,7 +297,7 @@
     <footer class="section-p1">
       <!-- Contact Column -->
       <div class="col">
-        <img class="logo" src="images/logo.png" alt="Cara Logo" />
+        <img loading="lazy" class="logo" src="images/logo.png" alt="Cara Logo" />
         <h4>Contact</h4>
         <p>
           <strong>Address:</strong> 562 Wellington Road, Street 32, San
@@ -381,8 +381,8 @@
         <p>From App Store or Google Play</p>
 
         <div class="row">
-          <img src="images/pay/app.jpg" alt="Download from App Store" />
-          <img src="images/pay/play.jpg" alt="Get it on Google Play" />
+          <img loading="lazy" src="images/pay/app.jpg" alt="Download from App Store" />
+          <img loading="lazy" src="images/pay/play.jpg" alt="Get it on Google Play" />
         </div>
 
         <p>Secured Payment Gateways</p>

--- a/Cara-main/index.html
+++ b/Cara-main/index.html
@@ -64,7 +64,7 @@
         <section id="header">
   <!-- Logo -->
   <a href="index.html">
-    <img id="siteLogo" src="images/logo.png" alt="Cara Logo" />
+    <img loading="lazy" id="siteLogo" src="images/logo.png" alt="Cara Logo" />
   </a>
 
   <div>
@@ -218,34 +218,34 @@
 
 <div class="ai-preview">
   <div class="style-card">
-   <img src="/images/aistyle.webp" alt="AI Style">
+   <img loading="lazy" src="/images/aistyle.webp" alt="AI Style">
   </div>
 </div>
 </section>
 
   <section id="feature" class="section-p1">
     <div class="fe-box">
-      <img src="images/feature/f1.png" alt="" />
+      <img loading="lazy" src="images/feature/f1.png" alt="" />
       <h6>Free Shipping</h6>
     </div>
     <div class="fe-box">
-      <img src="images/feature/f2.png" alt="" />
+      <img loading="lazy" src="images/feature/f2.png" alt="" />
       <h6>Online Order</h6>
     </div>
     <div class="fe-box">
-      <img src="images/feature/f3.png" alt="" />
+      <img loading="lazy" src="images/feature/f3.png" alt="" />
       <h6>Save Money</h6>
     </div>
     <div class="fe-box">
-      <img src="images/feature/f4.png" alt="" />
+      <img loading="lazy" src="images/feature/f4.png" alt="" />
       <h6>Promotions</h6>
     </div>
     <div class="fe-box">
-      <img src="images/feature/f5.png" alt="" />
+      <img loading="lazy" src="images/feature/f5.png" alt="" />
       <h6>Happy Sell</h6>
     </div>
     <div class="fe-box">
-      <img src="images/feature/f6.png" alt="" />
+      <img loading="lazy" src="images/feature/f6.png" alt="" />
       <h6>F24/7 Support</h6>
     </div>
   </section>
@@ -256,7 +256,7 @@
     <div class="pro-container">
 
       <div class="pro" data-category="street">
-        <div class="pro-img-wrap"><img src="images/products/f1.jpg" alt="Cartoon Astronaut T-Shirts" /></div>
+        <div class="pro-img-wrap"><img loading="lazy" src="images/products/f1.jpg" alt="Cartoon Astronaut T-Shirts" /></div>
         <div class="des">
           <div class="pro-brand-row">
             <svg class="pro-brand-logo" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2L2 19h20L12 2zm0 3.5L19.5 18h-15L12 5.5z"/></svg>
@@ -273,7 +273,7 @@
       </div>
 
       <div class="pro" data-category="minimal">
-        <div class="pro-img-wrap"><img src="images/products/f2.jpg" alt="White Palm Leaf Casual Shirt" /></div>
+        <div class="pro-img-wrap"><img loading="lazy" src="images/products/f2.jpg" alt="White Palm Leaf Casual Shirt" /></div>
         <div class="des">
           <div class="pro-brand-row">
             <svg class="pro-brand-logo" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2L2 19h20L12 2zm0 3.5L19.5 18h-15L12 5.5z"/></svg>
@@ -290,7 +290,7 @@
       </div>
 
       <div class="pro" data-category="minimal">
-        <div class="pro-img-wrap"><img src="images/products/f3.jpg" alt="Vintage Rose Garden Shirt" /></div>
+        <div class="pro-img-wrap"><img loading="lazy" src="images/products/f3.jpg" alt="Vintage Rose Garden Shirt" /></div>
         <div class="des">
           <div class="pro-brand-row">
             <svg class="pro-brand-logo" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2L2 19h20L12 2zm0 3.5L19.5 18h-15L12 5.5z"/></svg>
@@ -307,7 +307,7 @@
       </div>
 
       <div class="pro" data-category="minimal">
-        <div class="pro-img-wrap"><img src="images/products/f4.jpg" alt="Sakura Blossom Floral Shirt" /></div>
+        <div class="pro-img-wrap"><img loading="lazy" src="images/products/f4.jpg" alt="Sakura Blossom Floral Shirt" /></div>
         <div class="des">
           <div class="pro-brand-row">
             <svg class="pro-brand-logo" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2L2 19h20L12 2zm0 3.5L19.5 18h-15L12 5.5z"/></svg>
@@ -324,7 +324,7 @@
       </div>
 
       <div class="pro" data-category="street">
-        <div class="pro-img-wrap"><img src="images/products/f5.jpg" alt="Pink Peony Patterned Shirt" /></div>
+        <div class="pro-img-wrap"><img loading="lazy" src="images/products/f5.jpg" alt="Pink Peony Patterned Shirt" /></div>
         <div class="des">
           <div class="pro-brand-row">
             <svg class="pro-brand-logo" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2L2 19h20L12 2zm0 3.5L19.5 18h-15L12 5.5z"/></svg>
@@ -341,7 +341,7 @@
       </div>
 
       <div class="pro" data-category="street">
-        <div class="pro-img-wrap"><img src="images/products/f6.jpg" alt="Dual-Tone Corduroy Shirt" /></div>
+        <div class="pro-img-wrap"><img loading="lazy" src="images/products/f6.jpg" alt="Dual-Tone Corduroy Shirt" /></div>
         <div class="des">
           <div class="pro-brand-row">
             <svg class="pro-brand-logo" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2L2 19h20L12 2zm0 3.5L19.5 18h-15L12 5.5z"/></svg>
@@ -358,7 +358,7 @@
       </div>
 
       <div class="pro" data-category="street">
-        <div class="pro-img-wrap"><img src="images/products/f7.jpg" alt="Embroidered Linen Trousers" /></div>
+        <div class="pro-img-wrap"><img loading="lazy" src="images/products/f7.jpg" alt="Embroidered Linen Trousers" /></div>
         <div class="des">
           <div class="pro-brand-row">
             <svg class="pro-brand-logo" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2L2 19h20L12 2zm0 3.5L19.5 18h-15L12 5.5z"/></svg>
@@ -375,7 +375,7 @@
       </div>
 
       <div class="pro" data-category="minimal">
-        <div class="pro-img-wrap"><img src="images/products/f8.jpg" alt="Cat Print Long Sleeve Blouse" /></div>
+        <div class="pro-img-wrap"><img loading="lazy" src="images/products/f8.jpg" alt="Cat Print Long Sleeve Blouse" /></div>
         <div class="des">
           <div class="pro-brand-row">
             <svg class="pro-brand-logo" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2L2 19h20L12 2zm0 3.5L19.5 18h-15L12 5.5z"/></svg>
@@ -406,7 +406,7 @@
     <div class="pro-container">
 
       <div class="pro" data-category="formal">
-        <div class="pro-img-wrap"><img src="images/products/n1.jpg" alt="Sky Blue Mandarin Collar Shirt" /></div>
+        <div class="pro-img-wrap"><img loading="lazy" src="images/products/n1.jpg" alt="Sky Blue Mandarin Collar Shirt" /></div>
         <div class="des">
           <div class="pro-brand-row">
             <svg class="pro-brand-logo" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2L2 19h20L12 2zm0 3.5L19.5 18h-15L12 5.5z"/></svg>
@@ -423,7 +423,7 @@
       </div>
 
       <div class="pro" data-category="formal">
-        <div class="pro-img-wrap"><img src="images/products/n2.jpg" alt="Navy Textured Formal Shirt" /></div>
+        <div class="pro-img-wrap"><img loading="lazy" src="images/products/n2.jpg" alt="Navy Textured Formal Shirt" /></div>
         <div class="des">
           <div class="pro-brand-row">
             <svg class="pro-brand-logo" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2L2 19h20L12 2zm0 3.5L19.5 18h-15L12 5.5z"/></svg>
@@ -440,7 +440,7 @@
       </div>
 
       <div class="pro" data-category="formal">
-        <div class="pro-img-wrap"><img src="images/products/n3.jpg" alt="Classic White Cotton Shirt" /></div>
+        <div class="pro-img-wrap"><img loading="lazy" src="images/products/n3.jpg" alt="Classic White Cotton Shirt" /></div>
         <div class="des">
           <div class="pro-brand-row">
             <svg class="pro-brand-logo" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2L2 19h20L12 2zm0 3.5L19.5 18h-15L12 5.5z"/></svg>
@@ -457,7 +457,7 @@
       </div>
 
       <div class="pro" data-category="formal">
-        <div class="pro-img-wrap"><img src="images/products/n4.jpg" alt="Sandstone Tactical Utility Shirt" /></div>
+        <div class="pro-img-wrap"><img loading="lazy" src="images/products/n4.jpg" alt="Sandstone Tactical Utility Shirt" /></div>
         <div class="des">
           <div class="pro-brand-row">
             <svg class="pro-brand-logo" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2L2 19h20L12 2zm0 3.5L19.5 18h-15L12 5.5z"/></svg>
@@ -474,7 +474,7 @@
       </div>
 
       <div class="pro" data-category="minimal">
-        <div class="pro-img-wrap"><img src="images/products/n5.jpg" alt="Denim Blue Everyday Shirt" /></div>
+        <div class="pro-img-wrap"><img loading="lazy" src="images/products/n5.jpg" alt="Denim Blue Everyday Shirt" /></div>
         <div class="des">
           <div class="pro-brand-row">
             <svg class="pro-brand-logo" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2L2 19h20L12 2zm0 3.5L19.5 18h-15L12 5.5z"/></svg>
@@ -491,7 +491,7 @@
       </div>
 
       <div class="pro" data-category="minimal">
-        <div class="pro-img-wrap"><img src="images/products/n6.jpg" alt="Vertical Stripe Chino Shorts" /></div>
+        <div class="pro-img-wrap"><img loading="lazy" src="images/products/n6.jpg" alt="Vertical Stripe Chino Shorts" /></div>
         <div class="des">
           <div class="pro-brand-row">
             <svg class="pro-brand-logo" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2L2 19h20L12 2zm0 3.5L19.5 18h-15L12 5.5z"/></svg>
@@ -508,7 +508,7 @@
       </div>
 
       <div class="pro" data-category="minimal">
-        <div class="pro-img-wrap"><img src="images/products/n7.jpg" alt="Khaki Safari Work Shirt" /></div>
+        <div class="pro-img-wrap"><img loading="lazy" src="images/products/n7.jpg" alt="Khaki Safari Work Shirt" /></div>
         <div class="des">
           <div class="pro-brand-row">
             <svg class="pro-brand-logo" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2L2 19h20L12 2zm0 3.5L19.5 18h-15L12 5.5z"/></svg>
@@ -525,7 +525,7 @@
       </div>
 
       <div class="pro" data-category="minimal">
-        <div class="pro-img-wrap"><img src="images/products/n8.jpg" alt="Deep Charcoal Casual Shirt" /></div>
+        <div class="pro-img-wrap"><img loading="lazy" src="images/products/n8.jpg" alt="Deep Charcoal Casual Shirt" /></div>
         <div class="des">
           <div class="pro-brand-row">
             <svg class="pro-brand-logo" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2L2 19h20L12 2zm0 3.5L19.5 18h-15L12 5.5z"/></svg>
@@ -590,7 +590,7 @@
   <footer class="section-p1">
     <!-- Contact Column -->
     <div class="col">
-      <img class="logo" src="images/logo.png" alt="Cara Logo" />
+      <img loading="lazy" class="logo" src="images/logo.png" alt="Cara Logo" />
       <h4>Contact</h4>
       <p>
         <strong>Address:</strong> 562 Wellington Road, Street 32, San
@@ -646,8 +646,8 @@
       <p>From App Store or Google Play</p>
 
       <div class="row">
-        <img src="images/pay/app.jpg" alt="Download from App Store" />
-        <img src="images/pay/play.jpg" alt="Get it on Google Play" />
+        <img loading="lazy" src="images/pay/app.jpg" alt="Download from App Store" />
+        <img loading="lazy" src="images/pay/play.jpg" alt="Get it on Google Play" />
       </div>
 
       <p>Secured Payment Gateways</p>


### PR DESCRIPTION
# 📝 Pull Request Template

## 📄 Description

This PR improves the initial page load time and overall performance by adding the `loading="lazy"` attribute to image tags that were missing it.

While PR #1636 successfully added lazy loading to dynamically created product images, there were still several hardcoded images (especially in the `Cara-main` folder's HTML files like `index.html`, `about.html`, and `blog.html`) that were loading synchronously. Deferring the loading of these off-screen images will significantly improve the Core Web Vitals and user experience.

---

## 🔗 Related Issues

> Fixes #1700 

---

## 🖼️ Screenshots (if applicable)

*No visual changes. This is a performance optimization under the hood to improve load times.*

---

## 🧩 Type of Change

Select the type of change your PR introduces (check all that apply):

- [ ] 🐛 Bug Fix  
- [ ] ✨ New Feature  
- [x] ⚡ Enhancement / Optimization  
- [ ] 🧰 Refactoring  
- [ ] 🧾 Documentation Update  
- [ ] 🔧 Other (please specify): ____________

---

## ✅ Checklist

Before submitting your PR, please confirm the following:

- [x] Code follows project style guidelines  
- [x] Tests added/updated and passing  
- [x] Responsive design verified on mobile/tablet/desktop  
- [x] Accessibility checked (keyboard nav, screen readers)  
- [ ] Screenshots attached (if UI changes)  
- [x] Self-review completed

---

## 💬 Additional Notes (Optional)

Thank you for reviewing! If there are any other specific sections or images you'd like deferred, just let me know and I'll gladly update this PR.
