### PR TITLE
Fix: show success popup after order placement in checkout form

### DIFF
--- a/checkout.js
+++ b/checkout.js
@@ -270,6 +270,7 @@ form.addEventListener("submit", function (e) {
 
     // HIDE CARD DETAILS AGAIN
     cardDetails.style.display = "none";
+    popup.classList.add("active");
 
     // Clear all validation states post-submit
     inputs.forEach((input) => {


### PR DESCRIPTION
## 📄 Description
The checkout form was broken — after placing an order, the success popup never appeared. The `setTimeout` callback in `checkout.js` was clearing the cart and resetting the form but was missing `popup.classList.add("active")` to actually show the success popup to the user.

---

## 🔗 Related Issues

Fixes #1280 

---

## 🌿 Type of Change

- [X] 🐛 Bug Fix
- [ ] ✨ New Feature
- [ ] ⚡ Enhancement / Optimization
- [ ] 🔴 Refactoring
- [ ] 📋 Documentation Update
- [ ] 🛠️ Other (please specify): ___________

---

## ✅ Checklist

- [X] Code follows project style guidelines
- [ ] Tests added/updated and passing
- [X] Responsive design verified on mobile/tablet/desktop
- [X] Accessibility checked (keyboard nav, screen readers)
- [X] Screenshots attached (if UI changes)
- [X] Self-review completed

---
