### PR TITLE
fix: add 10-item limit guard per product in shopping cart

### DIFF
--- a/app.js
+++ b/app.js
@@ -297,8 +297,17 @@ function addToCart(productName, productPrice, productImage, quantity, size) {
 
     let existingItem = cart.find(p => p.name === item.name && p.size === item.size);
     if (existingItem) {
-        existingItem.quantity += item.quantity;
+        if (existingItem.quantity + item.quantity > 10) {
+            showToast("Cannot add more items. Max limit of 10 items per product size reached!", "warning");
+            existingItem.quantity = 10;
+        } else {
+            existingItem.quantity += item.quantity;
+        }
     } else {
+        if (item.quantity > 10) {
+            showToast("Quantity restricted to max 10 items per product.", "warning");
+            item.quantity = 10;
+        }
         cart.push(item);
     }
 
@@ -562,6 +571,10 @@ window.changeQuantity = function (index, change) {
     if (!cart[index]) return;
     let newQty = cart[index].quantity + change;
     if (newQty < 1) newQty = 1;
+    if (newQty > 10) {
+        showToast("Max limit of 10 items per product size reached!", "warning");
+        newQty = 10;
+    }
     cart[index].quantity = newQty;
     localStorage.setItem("productsInCart", JSON.stringify(cart));
     loadCart();


### PR DESCRIPTION
Closes #1722 

### Overview
Implements a strict quantity limit of 10 items per product size inside shopping cart actions, preventing layout overflows and improving general stability.

### Changes Made
- Modified `app.js`: Patched `addToCart` and `changeQuantity` to restrict adjustments above 10 and display a clean warnings toast.

### Verification Steps
1. Go to any product page and add 12 items.
2. Confirm toast alert warns about the limit and locks the cart count to 10.
