### PR TITLE
fix(linter): force auto carriage return formatting

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,8 +1,1 @@
-{
-  "semi": true,
-  "trailingComma": "es5",
-  "singleQuote": true,
-  "printWidth": 80,
-  "tabWidth": 2,
-  "useTabs": false
-}
+﻿{\n  "semi": true,\n  "trailingComma": "es5",\n  "singleQuote": true,\n  "printWidth": 80,\n  "tabWidth": 2,\n  "useTabs": false,\n  "endOfLine": "auto"\n}


### PR DESCRIPTION
Closes #1802 

### 📄 Description
Configures Prettier to standardize line-ending formatting by setting `endOfLine: "auto"`. This solves platform-specific Carriage Return (CRLF vs LF) linting anomalies that cause Windows developers' builds to fail automatic CI validations.

---

### 🧩 Type of Change
- [x] 🐛 Bug Fix  
- [x] 🔧 Other (Linter config integration)

---

### ✅ Checklist
- [x] Code follows project style guidelines  