### PR TITLE
fix: center theme toggle icon in mobile navbar below 540px

### DIFF
--- a/global.css
+++ b/global.css
@@ -2267,6 +2267,20 @@ footer .copyright {
    MOBILE SMALL (≤ 477px)
    ============================================ */
 
+            /* ============================================
+   MOBILE MID (≤ 540px)
+   ============================================ */
+
+            @media (max-width: 540px) {
+                .mobile {
+                    justify-content: center;
+                }
+
+                .mobile i {
+                    padding-left: 14px;
+                }
+            }
+
             @media (max-width: 477px) {
                 #header {
                     padding: 10px 16px;
@@ -3455,7 +3469,7 @@ footer .copyright {
                 color: #ccc;
                 }
 
-                /* Dark mode � empty stars */
+                /* Dark mode � empty stars */
                 body.dark .star i.ri-star-line {
                 color: #555;
                 }

--- a/style.css
+++ b/style.css
@@ -36585,3 +36585,12 @@ html {
   background: #f3fffd !important;
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
 }
+
+@media (max-width: 540px) {
+  .mobile {
+    justify-content: center;
+  }
+  .mobile i {
+    padding-left: 14px;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the theme toggle icon being pushed off-center inside the navbar element on viewport widths below 540px.

### Changes
- Added \@media (max-width: 540px)\ breakpoint in both \global.css\ and \style.css\
- Added \justify-content: center\ to \.mobile\ container for proper alignment
- Adjusted \.mobile i\ padding to prevent off-center positioning

Closes #1812