### PR TITLE
fix: guard single product image gallery elements and listeners

### DIFF
--- a/singleProduct.js
+++ b/singleProduct.js
@@ -11,7 +11,7 @@ const sizeRadios = document.querySelectorAll('.size-chart input[type="radio"]');
 
 // OPEN MODAL
 
-if (openBtn) openBtn.addEventListener("click", () => {
+if (openBtn && modal) openBtn.addEventListener("click", () => {
 
     modal.style.display = "flex";
 


### PR DESCRIPTION
# Related Issue
Closes #1837 

# Summary
Adds safety checks to DOM bindings in `singleProduct.js`.

# Changes Made
- Added element checks to `openBtn` and `closeBtn` bindings.

# Testing
- Verified no exceptions in console.
