### PR TITLE
fix: resolve mobile overflow and text wrap in shopping cart

### DIFF
--- a/cart.css
+++ b/cart.css
@@ -100,8 +100,9 @@
             #cart table {
                 width: 100%;
                 border-collapse: collapse;
-                white-space: nowrap;
-                table-layout: fixed;
+                white-space: normal;
+                word-wrap: break-word;
+                table-layout: auto;
             }
 
             #cart table img {


### PR DESCRIPTION
# Related Issue
Closes #1839 

# Summary
Fixes cart table layout clipping on smaller viewports.

# Changes Made
- Modified `cart.css` to update layout rendering rules under max-width 799px.

# Testing
- Tested locally on mobile viewport sizes.
