### PR TITLE
fix: correct broken delivery information link reference in footer

### DIFF
--- a/license.html
+++ b/license.html
@@ -200,7 +200,7 @@
         <div class="col">
             <h4>About</h4>
             <a href="about.html">About us</a>
-         <a href="deliver.html">Delivery Information</a>
+         <a href="delivery.html">Delivery Information</a>
             <a href="#">Privacy Policy</a>
             <a href="#">Terms & Conditions</a>
             <a href="contact.html">Contact Us</a>


### PR DESCRIPTION
# Related Issue
Closes #1843 

# Summary
Fixes footer link target destination inside licensing page.

# Changes Made
- Changed footer href to the correct page name.

# Testing
- Handled clicking flow test locally.
