### PR TITLE
fix: prevent cart table overflow on mobile by allowing text wrapping

### DIFF
--- a/cart.css
+++ b/cart.css
@@ -100,8 +100,9 @@
             #cart table {
                 width: 100%;
                 border-collapse: collapse;
-                white-space: nowrap;
-                table-layout: fixed;
+                white-space: normal;
+                word-wrap: break-word;
+                table-layout: auto;
             }
 
             #cart table img {

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,6 +1,23 @@
-﻿Closes #1368
+﻿## Description
+Added Husky v9 with lint-staged to enforce ESLint fixes and Prettier formatting on every commit. Prevents formatting inconsistencies and syntax errors before they reach the repository.
 
-## Changes
-- Added @media (max-width: 1024px) breakpoint in shop.css for product grid with gap: 18px and padding: 20px 40px
-- Updated @media (max-width: 900px) with consistent .pro card internal padding
-- Creates smooth gap transition: 20px → 18px → 14px across screen sizes
+**Changes:**
+- Added husky and lint-staged to devDependencies
+- Added prepare script for Husky Git hooks
+- Created .husky/pre-commit hook running 
+px lint-staged
+- Configured lint-staged to run eslint --fix and prettier --write on staged .js and .css files
+
+Run 
+pm install && npm run prepare to initialize hooks.
+
+## Related Issue
+Fixes #1697
+
+## Type of Change
+- [ ] Bug fix
+- [x] New feature
+- [ ] Breaking change
+- [ ] Documentation update
+
+program: gssoc


### PR DESCRIPTION
Fixes #1839

## Problem
On mobile widths under 799px, \#cart table\ uses \white-space: nowrap\ and \	able-layout: fixed\, causing long product descriptions to overflow and force horizontal viewport scroll.

## Changes
In \cart.css\ under \@media (max-width: 799px)\:
- \white-space: nowrap\ → \white-space: normal\
- Added \word-wrap: break-word\ for long unbreakable strings
- \	able-layout: fixed\ → \	able-layout: auto\

## Testing
Verified cart table cells wrap text naturally on narrow viewports without breaking layout.