### PR TITLE
feat: add local storage autosave persistence to contact form

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -948,6 +948,7 @@ if (yearEl) yearEl.textContent = new Date().getFullYear();
 <script>
   loadNavbar('contact');
 </script>
+<script src="js/contact-autosave.js" defer></script>
 </body>
 
 </html>

--- a/js/contact-autosave.js
+++ b/js/contact-autosave.js
@@ -1,0 +1,48 @@
+// Contact Form Autosave System
+document.addEventListener("DOMContentLoaded", () => {
+    const form = document.querySelector(".contact-form form") || document.querySelector("form");
+    if (!form) return;
+
+    const fields = ["name", "email", "subject", "message"];
+    const inputs = {};
+
+    fields.forEach(field => {
+        const el = form.querySelector(`[name="${field}"]`) || form.querySelector(`[type="${field}"]`) || document.getElementById(field);
+        if (el) {
+            inputs[field] = el;
+            // Load saved draft
+            const savedVal = localStorage.getItem(`cara_contact_draft_${field}`);
+            if (savedVal) {
+                el.value = savedVal;
+            }
+
+            // Save on input
+            el.addEventListener("input", () => {
+                localStorage.setItem(`cara_contact_draft_${field}`, el.value);
+                showAutosaveStatus();
+            });
+        }
+    });
+
+    // Create a visual indicator for draft state
+    const indicator = document.createElement("div");
+    indicator.id = "draft-indicator";
+    indicator.style.cssText = "font-size: 12px; color: #088178; font-style: italic; margin-top: 5px; opacity: 0; transition: opacity 0.3s;";
+    indicator.textContent = "Draft saved in browser local storage";
+    form.appendChild(indicator);
+
+    let statusTimeout;
+    function showAutosaveStatus() {
+        indicator.style.opacity = "1";
+        clearTimeout(statusTimeout);
+        statusTimeout = setTimeout(() => {
+            indicator.style.opacity = "0";
+        }, 2000);
+    }
+
+    form.addEventListener("submit", () => {
+        fields.forEach(field => {
+            localStorage.removeItem(`cara_contact_draft_${field}`);
+        });
+    });
+});


### PR DESCRIPTION
# Related Issue
Closes #1851 

# Summary
Saves partially filled contact details to LocalStorage to protect against page refreshes.

# Changes Made
- Created [contact-autosave.js](file:///c:/Users/babin/Desktop/ELUSoC/Cara/js/contact-autosave.js).
- Modified [contact.html](file:///c:/Users/babin/Desktop/ELUSoC/Cara/contact.html).
