### PR TITLE
feat: add dedicated print layout styling and printable button on terms

### DIFF
--- a/js/terms-print.js
+++ b/js/terms-print.js
@@ -1,0 +1,32 @@
+// Print-Friendly Terms Optimization
+document.addEventListener("DOMContentLoaded", () => {
+    const parentContainer = document.querySelector("section") || document.body;
+    
+    // Inject Print Button
+    const btn = document.createElement("button");
+    btn.innerHTML = `<i class="ri-printer-line"></i> Print / Save Terms as PDF`;
+    btn.style.cssText = "padding:10px 18px; background:#088178; color:white; border:none; border-radius:4px; font-weight:600; cursor:pointer; margin-bottom:20px; font-family:sans-serif;";
+    
+    parentContainer.parentNode.insertBefore(btn, parentContainer);
+
+    btn.addEventListener("click", () => {
+        window.print();
+    });
+
+    // Dynamically inject @media print styles
+    const style = document.createElement("style");
+    style.innerHTML = `
+        @media print {
+            header, footer, #header, #newsletter, .mobile, button {
+                display: none !important;
+            }
+            body {
+                background: white !important;
+                color: black !important;
+                font-size: 14px !important;
+                line-height: 1.6 !important;
+            }
+        }
+    `;
+    document.head.appendChild(style);
+});

--- a/terms.html
+++ b/terms.html
@@ -481,7 +481,8 @@
     <script id="Current-Year">
         document.getElementById("Current-Year").textContent = new Date().getFullYear();
     </script>
-  </body>
+  <script src="js/terms-print.js" defer></script>
+</body>
 </html>
 
 <!-- Accessibility and structural improvements -->


### PR DESCRIPTION
# Related Issue
Closes #1867 

# Summary
Hides website menus, buttons, and footers when triggering terms document printing.

# Changes Made
- Created [terms-print.js](file:///c:/Users/babin/Desktop/ELUSoC/Cara/js/terms-print.js).
- Modified [terms.html](file:///c:/Users/babin/Desktop/ELUSoC/Cara/terms.html).
