### PR TITLE
feat: add dedicated print layout styling and printable button on terms

### DIFF
--- a/js/terms-print.js
+++ b/js/terms-print.js
@@ -1,0 +1,32 @@
+// Print-Friendly Terms Optimization
+document.addEventListener("DOMContentLoaded", () => {
+    const parentContainer = document.querySelector("section") || document.body;
+    
+    // Inject Print Button
+    const btn = document.createElement("button");
+    btn.innerHTML = `<i class="ri-printer-line"></i> Print / Save Terms as PDF`;
+    btn.style.cssText = "padding:10px 18px; background:#088178; color:white; border:none; border-radius:4px; font-weight:600; cursor:pointer; margin-bottom:20px; font-family:sans-serif;";
+    
+    parentContainer.parentNode.insertBefore(btn, parentContainer);
+
+    btn.addEventListener("click", () => {
+        window.print();
+    });
+
+    // Dynamically inject @media print styles
+    const style = document.createElement("style");
+    style.innerHTML = `
+        @media print {
+            header, footer, #header, #newsletter, .mobile, button {
+                display: none !important;
+            }
+            body {
+                background: white !important;
+                color: black !important;
+                font-size: 14px !important;
+                line-height: 1.6 !important;
+            }
+        }
+    `;
+    document.head.appendChild(style);
+});

--- a/terms.html
+++ b/terms.html
@@ -481,7 +481,8 @@
     <script id="Current-Year">
         document.getElementById("Current-Year").textContent = new Date().getFullYear();
     </script>
-  </body>
+  <script src="js/terms-print.js" defer></script>
+</body>
 </html>
 
 <!-- Accessibility and structural improvements -->


### PR DESCRIPTION
# Related Issue
Closes #1886 

# Summary
Adds a print-to-pdf layout button and print-media styles to the terms page.

# Changes Made
- Created `js/terms-print.js` containing media rule definitions and button.
- Appended helper scripts to `terms.html`.

# Testing
- Clicked print button, verified print preview layout hides headers/footers.
- Confirmed print styling defaults to readable fonts.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
