### PR TITLE
security: integrate content security policy headers inside main page template

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,9 @@
   <!-- Character Encoding -->
   <meta charset="UTF-8" />
 
+  <!-- Content Security Policy (CSP) for Frontend Security -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://fonts.googleapis.com; font-src 'self' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://fonts.gstatic.com; img-src 'self' data: https://www.animatedimages.org https://cara-seven-ashen.vercel.app;" />
+
   <!-- Resource Hints -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
Closes #1915 

# Summary
Adds a Content Security Policy (CSP) meta tag to secure the homepage against script injection, cross-site scripting (XSS), and third-party script vulnerabilities.

# Changes Made
- Added a secure CSP tag within the head section of `index.html`.
- Configured safe-source directives for local resources, fonts, and approved CDNs.

# Testing
- Monitored browser console outputs to ensure CSP rules do not block legitimate storefront styles or assets.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered
