### PR TITLE
fix: remove extra space in Live Demo link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 **A modern, responsive e-commerce platform built with vanilla HTML, CSS, and JavaScript**
 
-## 🚀 [Live Demo] (https://cara-seven-ashen.vercel.app/ )
+## 🚀 [Live Demo](https://cara-seven-ashen.vercel.app/)
  [Report Bug](https://github.com/janavipandole/Cara/issues) 
  [Request Feature](https://github.com/janavipandole/Cara/issues)
 


### PR DESCRIPTION
## Description
Removed the extra space between ] and ( in the Live Demo 
link which was breaking the markdown hyperlink.

## Related Issue
Fixes #1200

## Type of change
- [x] Bug fix (docs)

## Screenshots
No UI changes - README fix only.