### PR TITLE
ux: add visual validation styling to size selection on product details

### DIFF
--- a/singleProduct.js
+++ b/singleProduct.js
@@ -61,3 +61,58 @@ sizeRadios.forEach((radio) => {
     });
 
 });
+
+// OVERRIDE ADD TO CART AND BUY NOW FOR SIZE VALIDATION
+if (sizeDropdown) {
+  const originalAddToCart = window.handleAddToCart;
+  window.handleAddToCart = function() {
+    if (sizeDropdown.value === "Select Size" || sizeDropdown.value === "") {
+      sizeDropdown.style.border = "2px solid #ef4444";
+      sizeDropdown.style.borderRadius = "4px";
+      
+      let errLabel = document.getElementById("size-error-label");
+      if (!errLabel) {
+        errLabel = document.createElement("span");
+        errLabel.id = "size-error-label";
+        errLabel.style.cssText = "color:#ef4444; font-size:12px; font-weight:700; display:block; margin-top:5px;";
+        errLabel.textContent = "Please select a size before adding to cart!";
+        sizeDropdown.parentNode.appendChild(errLabel);
+      }
+      if (typeof showToast === 'function') {
+        showToast("Please select a size before adding to cart!", "warning");
+      }
+      return;
+    }
+    if (originalAddToCart) originalAddToCart();
+  };
+
+  const originalBuyNow = window.handleBuyNow;
+  window.handleBuyNow = function() {
+    if (sizeDropdown.value === "Select Size" || sizeDropdown.value === "") {
+      sizeDropdown.style.border = "2px solid #ef4444";
+      sizeDropdown.style.borderRadius = "4px";
+      
+      let errLabel = document.getElementById("size-error-label");
+      if (!errLabel) {
+        errLabel = document.createElement("span");
+        errLabel.id = "size-error-label";
+        errLabel.style.cssText = "color:#ef4444; font-size:12px; font-weight:700; display:block; margin-top:5px;";
+        errLabel.textContent = "Please select a size before proceeding!";
+        sizeDropdown.parentNode.appendChild(errLabel);
+      }
+      if (typeof showToast === 'function') {
+        showToast("Please select a size before proceeding!", "warning");
+      }
+      return;
+    }
+    if (originalBuyNow) originalBuyNow();
+  };
+
+  sizeDropdown.addEventListener("change", () => {
+    if (sizeDropdown.value !== "Select Size" && sizeDropdown.value !== "") {
+      sizeDropdown.style.border = "";
+      const errLabel = document.getElementById("size-error-label");
+      if (errLabel) errLabel.remove();
+    }
+  });
+}


### PR DESCRIPTION
Closes #1951 

### Description
Implements visual feedback constraints on size selection inside [singleProduct.js](file:///c:/Users/Debasmita/Desktop/Cara/Cara/singleProduct.js).

### Changes
- Intercepts add-to-cart/buy-now clicks when size is unselected.
- Applies red borders to the dropdown.
- Appends a red inline helper warning label.
- Automatically clears visual warnings once a selection changes.
