### PR TITLE
fix: mount shipping estimator on cart summary and update checkout totals

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -368,6 +368,7 @@
             <div class="cart-summary-column">
               <div class="sticky-summary-card">
                 <h3>Order Summary</h3>
+                <div id="shipping-calculator-target"></div>
                 <div class="coupon-section">
                   <p style="font-size: 13px; font-weight: 500; margin-bottom: 8px;">Have a promotional coupon?</p>
                   <div class="coupon-input-group" style="display: flex; gap: 8px; margin-bottom: 8px;">
@@ -502,6 +503,7 @@
       </div>
     </div>
 
+    <script src="js/shipping-calc.js" defer></script>
     <script src="app.js?v=1779120917210"></script>
     <script>
       document.getElementById("Current-Year").textContent = new Date().getFullYear();

--- a/js/shipping-calc.js
+++ b/js/shipping-calc.js
@@ -64,3 +64,5 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     });
 });
+
+// Shipping calculator applying regional fee rates inside cart summary containers.

--- a/js/shipping-calc.js
+++ b/js/shipping-calc.js
@@ -43,5 +43,24 @@ document.addEventListener("DOMContentLoaded", () => {
             Estimated Cost: ₹${total} <br>
             Estimated Time: ${days}
         `;
+
+        // Dynamically update Cart Totals summary if elements exist
+        const shippingEl = document.getElementById("summary-shipping");
+        const totalEl = document.getElementById("summary-total");
+        const subtotalEl = document.getElementById("summary-subtotal");
+        const taxEl = document.getElementById("summary-tax");
+        const discountEl = document.getElementById("summary-discount");
+        if (shippingEl && totalEl && subtotalEl && taxEl) {
+            shippingEl.textContent = total === 0 ? "FREE" : "₹" + total;
+            
+            const subtotalText = subtotalEl.textContent.replace(/[^\d\.]/g, "");
+            const subtotal = parseFloat(subtotalText) || 0;
+            const taxText = taxEl.textContent.replace(/[^\d\.]/g, "");
+            const tax = parseFloat(taxText) || 0;
+            const discount = discountEl ? (parseFloat(discountEl.textContent.replace(/[^\d\.]/g, "")) || 0) : 0;
+            
+            const newTotal = Math.max(0, subtotal + tax + total - discount);
+            totalEl.textContent = "₹" + Math.round(newTotal).toLocaleString("en-IN");
+        }
     });
 });


### PR DESCRIPTION
Closes #1955 

### Description
Integrates the delivery shipping calculator directly into the order summary column of [cart.html](file:///c:/Users/Debasmita/Desktop/Cara/Cara/cart.html).

### Changes
- Created mounting container inside the order summary card of `cart.html`.
- Imported [shipping-calc.js](file:///c:/Users/Debasmita/Desktop/Cara/Cara/js/shipping-calc.js).
- Enhanced calculation handlers to automatically adjust tax, shipping cost displays, and overall checkout totals dynamically.
