### PR TITLE
feat(blog): add social sharing buttons to blog feed cards

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -230,6 +230,12 @@
           >
             CONTINUE READING
           </a>
+          <div class="blog-share" style="margin-top: 15px; display: flex; gap: 10px; align-items: center;">
+            <span style="font-size: 13px; font-weight: 700; color: #777;">Share:</span>
+            <a href="https://twitter.com/intent/tweet?text=Check out this blog post: The Cotton-Jersey Zip-Up Hoodie&url=https://cara-seven-ashen.vercel.app/blog-cotton-jersey-hoodie.html" target="_blank" rel="noopener noreferrer" aria-label="Share on X" style="color: #088178; font-size: 14px;"><i class="fa-brands fa-x-twitter"></i></a>
+            <a href="https://www.facebook.com/sharer/sharer.php?u=https://cara-seven-ashen.vercel.app/blog-cotton-jersey-hoodie.html" target="_blank" rel="noopener noreferrer" aria-label="Share on Facebook" style="color: #088178; font-size: 14px;"><i class="fab fa-facebook-f"></i></a>
+            <a href="https://pinterest.com/pin/create/button/?url=https://cara-seven-ashen.vercel.app/blog-cotton-jersey-hoodie.html" target="_blank" rel="noopener noreferrer" aria-label="Share on Pinterest" style="color: #088178; font-size: 14px;"><i class="fab fa-pinterest"></i></a>
+          </div>
         </div>
         <h1>13/01</h1>
       </div>
@@ -247,6 +253,12 @@
           <a href="blog-quiff-styling.html" class="read-more"
             >CONTINUE READING</a
           >
+          <div class="blog-share" style="margin-top: 15px; display: flex; gap: 10px; align-items: center;">
+            <span style="font-size: 13px; font-weight: 700; color: #777;">Share:</span>
+            <a href="https://twitter.com/intent/tweet?text=Check out this blog post: How to style a Quiff&url=https://cara-seven-ashen.vercel.app/blog-quiff-styling.html" target="_blank" rel="noopener noreferrer" aria-label="Share on X" style="color: #088178; font-size: 14px;"><i class="fa-brands fa-x-twitter"></i></a>
+            <a href="https://www.facebook.com/sharer/sharer.php?u=https://cara-seven-ashen.vercel.app/blog-quiff-styling.html" target="_blank" rel="noopener noreferrer" aria-label="Share on Facebook" style="color: #088178; font-size: 14px;"><i class="fab fa-facebook-f"></i></a>
+            <a href="https://pinterest.com/pin/create/button/?url=https://cara-seven-ashen.vercel.app/blog-quiff-styling.html" target="_blank" rel="noopener noreferrer" aria-label="Share on Pinterest" style="color: #088178; font-size: 14px;"><i class="fab fa-pinterest"></i></a>
+          </div>
         </div>
         <h1>13/04</h1>
       </div>
@@ -265,6 +277,12 @@
           <a href="blog-skater-girls.html" class="read-more"
             >CONTINUE READING</a
           >
+          <div class="blog-share" style="margin-top: 15px; display: flex; gap: 10px; align-items: center;">
+            <span style="font-size: 13px; font-weight: 700; color: #777;">Share:</span>
+            <a href="https://twitter.com/intent/tweet?text=Check out this blog post: Must-Have Skater Girls Items&url=https://cara-seven-ashen.vercel.app/blog-skater-girls.html" target="_blank" rel="noopener noreferrer" aria-label="Share on X" style="color: #088178; font-size: 14px;"><i class="fa-brands fa-x-twitter"></i></a>
+            <a href="https://www.facebook.com/sharer/sharer.php?u=https://cara-seven-ashen.vercel.app/blog-skater-girls.html" target="_blank" rel="noopener noreferrer" aria-label="Share on Facebook" style="color: #088178; font-size: 14px;"><i class="fab fa-facebook-f"></i></a>
+            <a href="https://pinterest.com/pin/create/button/?url=https://cara-seven-ashen.vercel.app/blog-skater-girls.html" target="_blank" rel="noopener noreferrer" aria-label="Share on Pinterest" style="color: #088178; font-size: 14px;"><i class="fab fa-pinterest"></i></a>
+          </div>
         </div>
         <h1>12/01</h1>
       </div>
@@ -282,6 +300,12 @@
           <a href="blog-runway-trends.html" class="read-more"
             >CONTINUE READING</a
           >
+          <div class="blog-share" style="margin-top: 15px; display: flex; gap: 10px; align-items: center;">
+            <span style="font-size: 13px; font-weight: 700; color: #777;">Share:</span>
+            <a href="https://twitter.com/intent/tweet?text=Check out this blog post: Runway-Inspired Trends&url=https://cara-seven-ashen.vercel.app/blog-runway-trends.html" target="_blank" rel="noopener noreferrer" aria-label="Share on X" style="color: #088178; font-size: 14px;"><i class="fa-brands fa-x-twitter"></i></a>
+            <a href="https://www.facebook.com/sharer/sharer.php?u=https://cara-seven-ashen.vercel.app/blog-runway-trends.html" target="_blank" rel="noopener noreferrer" aria-label="Share on Facebook" style="color: #088178; font-size: 14px;"><i class="fab fa-facebook-f"></i></a>
+            <a href="https://pinterest.com/pin/create/button/?url=https://cara-seven-ashen.vercel.app/blog-runway-trends.html" target="_blank" rel="noopener noreferrer" aria-label="Share on Pinterest" style="color: #088178; font-size: 14px;"><i class="fab fa-pinterest"></i></a>
+          </div>
         </div>
         <h1>16/01</h1>
       </div>
@@ -299,6 +323,12 @@
           <a href="blog-aw20-menswear.html" class="read-more"
             >CONTINUE READING</a
           >
+          <div class="blog-share" style="margin-top: 15px; display: flex; gap: 10px; align-items: center;">
+            <span style="font-size: 13px; font-weight: 700; color: #777;">Share:</span>
+            <a href="https://twitter.com/intent/tweet?text=Check out this blog post: AW20 Menswear Trends&url=https://cara-seven-ashen.vercel.app/blog-aw20-menswear.html" target="_blank" rel="noopener noreferrer" aria-label="Share on X" style="color: #088178; font-size: 14px;"><i class="fa-brands fa-x-twitter"></i></a>
+            <a href="https://www.facebook.com/sharer/sharer.php?u=https://cara-seven-ashen.vercel.app/blog-aw20-menswear.html" target="_blank" rel="noopener noreferrer" aria-label="Share on Facebook" style="color: #088178; font-size: 14px;"><i class="fab fa-facebook-f"></i></a>
+            <a href="https://pinterest.com/pin/create/button/?url=https://cara-seven-ashen.vercel.app/blog-aw20-menswear.html" target="_blank" rel="noopener noreferrer" aria-label="Share on Pinterest" style="color: #088178; font-size: 14px;"><i class="fab fa-pinterest"></i></a>
+          </div>
         </div>
         <h1>10/01</h1>
       </div>


### PR DESCRIPTION
Closes #1961 

### Description
Integrates social sharing grids with appropriate SVG icon anchors for all blog articles in [blog.html](file:///c:/Users/Debasmita/Desktop/Cara/Cara/blog.html).

### Changes
- Added a sharing widget under each blog entry link pointing to X/Twitter, Facebook, and Pinterest intent links.
- Styled links to match the primary theme color.
