### PR TITLE
fix(community): add missing upload success container to prevent crash

### DIFF
--- a/community.html
+++ b/community.html
@@ -331,6 +331,9 @@
         </div>
         <input type="file" id="community-upload" accept="image/*">
     </label>
+    <div id="upload-success" style="display:none; color: #088178; font-weight: 600; margin-top: 15px; text-align: center; font-size: 15px;">
+        <i class="ri-checkbox-circle-line" style="vertical-align: middle; font-size: 18px; margin-right: 5px;"></i>Poster uploaded successfully! Pending review.
+    </div>
 </section>
 
     <section id="gallery">


### PR DESCRIPTION
Closes #1965 

### Description
Resolves the `TypeError` occurring in [community.html](file:///c:/Users/Debasmita/Desktop/Cara/Cara/community.html) during file upload by adding the missing `#upload-success` message container.

### Changes
- Added the `#upload-success` message block under the file upload box, styled with HSL teal colors and checkbox icons.
- Verified that file selection now displays a smooth validation notice instead of crashing the page.
