### PR TITLE
fix(contact): prevent clearing form draft in local storage on invalid submissions

### DIFF
--- a/js/contact-autosave.js
+++ b/js/contact-autosave.js
@@ -40,7 +40,10 @@ document.addEventListener("DOMContentLoaded", () => {
         }, 2000);
     }
 
-    form.addEventListener("submit", () => {
+    form.addEventListener("submit", (e) => {
+        if (form.checkValidity && !form.checkValidity()) {
+            return;
+        }
         fields.forEach(field => {
             localStorage.removeItem(`cara_contact_draft_${field}`);
         });


### PR DESCRIPTION
Closes #1967 

### Description
Prevents the contact form autosave feature from deleting draft inputs when the form fails validation.

### Changes
- Modified the `submit` event listener in [js/contact-autosave.js](file:///c:/Users/Debasmita/Desktop/Cara/Cara/js/contact-autosave.js) to check the form's validity via `form.checkValidity()`.
- If validation fails, it aborts execution before clearing draft items from `localStorage`, ensuring the user's progress is saved until a successful submission occurs.
