### PR TITLE
ci: add GitHub Action workflow for markdown style linting

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,26 @@
+name: Markdown Lint
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '**/*.md'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '**/*.md'
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Lint Markdown Files
+        uses: davidanson/markdownlint-cli2-action@v16
+        with:
+          globs: |
+            **/*.md
+            !node_modules
+            !.venv


### PR DESCRIPTION
Closes #1972 

### Description
Creates a new GitHub workflow configuration at [.github/workflows/markdown-lint.yml](file:///c:/Users/Debasmita/Desktop/Cara/Cara/.github/workflows/markdown-lint.yml) to automatically lint formatting guidelines in markdown files on pushes and PR triggers.
