### PR TITLE
fix(products): render search text safely

### DIFF
--- a/products.js
+++ b/products.js
@@ -364,7 +364,9 @@ const products = [
  */
 function renderStars(baseRating, productId) {
   // Load user's saved rating if it exists, else use base rating
-  const savedRating = parseFloat(localStorage.getItem('userRating_' + productId));
+  const savedRating = parseFloat(
+    localStorage.getItem('userRating_' + productId)
+  );
   const displayRating = !isNaN(savedRating) ? savedRating : baseRating;
 
   const starDiv = document.createElement('div');
@@ -402,16 +404,18 @@ function renderStars(baseRating, productId) {
 
   // Reset highlight on mouse leave
   starDiv.addEventListener('mouseleave', () => {
-    const currentRating = parseFloat(localStorage.getItem('userRating_' + productId)) || baseRating;
+    const currentRating =
+      parseFloat(localStorage.getItem('userRating_' + productId)) || baseRating;
     updateStarDisplay(starDiv, currentRating);
   });
 
   // Numeric rating text
   const ratingText = document.createElement('span');
   ratingText.className = 'rating-value';
-  ratingText.textContent = displayRating % 1 === 0
-    ? displayRating.toFixed(1)
-    : displayRating.toString();
+  ratingText.textContent =
+    displayRating % 1 === 0
+      ? displayRating.toFixed(1)
+      : displayRating.toString();
   starDiv.appendChild(ratingText);
 
   return starDiv;
@@ -494,7 +498,10 @@ function getWishlist() {
 }
 
 function saveWishlist(wishlist) {
-  localStorage.setItem('wishlist', JSON.stringify(wishlist.map(normalizeWishlistItem)));
+  localStorage.setItem(
+    'wishlist',
+    JSON.stringify(wishlist.map(normalizeWishlistItem))
+  );
   if (typeof window.updateWishlistCount === 'function') {
     window.updateWishlistCount();
   }
@@ -512,7 +519,9 @@ function updateWishlistButtonState(button, isSaved) {
   button.setAttribute('aria-pressed', String(isSaved));
   button.setAttribute(
     'aria-label',
-    isSaved ? `Remove ${productName} from wishlist` : `Add ${productName} to wishlist`
+    isSaved
+      ? `Remove ${productName} from wishlist`
+      : `Add ${productName} to wishlist`
   );
   button.title = isSaved ? 'Remove from wishlist' : 'Add to wishlist';
   button.innerHTML = `<i class="${isSaved ? 'ri-heart-fill' : 'ri-heart-line'}" aria-hidden="true"></i>`;
@@ -525,9 +534,14 @@ function updateWishlistButtonState(button, isSaved) {
 }
 
 function syncWishlistButtons() {
-  document.querySelectorAll('.wishlist-btn[data-product-name]').forEach((button) => {
-    updateWishlistButtonState(button, isInWishlist(button.dataset.productName));
-  });
+  document
+    .querySelectorAll('.wishlist-btn[data-product-name]')
+    .forEach((button) => {
+      updateWishlistButtonState(
+        button,
+        isInWishlist(button.dataset.productName)
+      );
+    });
 }
 
 function toggleWishlistItem(product, button) {
@@ -537,10 +551,12 @@ function toggleWishlistItem(product, button) {
 
   if (exists) {
     wishlist = wishlist.filter((wishItem) => wishItem.name !== item.name);
-    if (typeof showToast === 'function') showToast(`${item.name} removed from wishlist`, 'info');
+    if (typeof showToast === 'function')
+      showToast(`${item.name} removed from wishlist`, 'info');
   } else {
     wishlist.push(item);
-    if (typeof showToast === 'function') showToast(`${item.name} added to wishlist`, 'success');
+    if (typeof showToast === 'function')
+      showToast(`${item.name} added to wishlist`, 'success');
   }
 
   saveWishlist(wishlist);
@@ -554,34 +570,53 @@ window.toggleWishlistItem = toggleWishlistItem;
 window.syncWishlistButtons = syncWishlistButtons;
 
 /**
- * Safely escapes HTML and highlights matched search query terms.
+ * Appends text with highlighted query matches without parsing it as HTML.
+ * @param {HTMLElement} target - Element that receives the rendered text
  * @param {string} text - The original text to display
  * @param {string} query - The search query term
- * @returns {string} - Highlighted HTML string
  */
-function highlightText(text, query) {
-  if (!text) return '';
-  // Return HTML-escaped text to prevent XSS
-  const escapedText = text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-    
-  if (!query || !query.trim()) {
-    return escapedText;
+function appendHighlightedText(target, text, query) {
+  const safeText = String(text || '');
+  const safeQuery = String(query || '').trim();
+
+  target.textContent = '';
+  if (!safeText || !safeQuery) {
+    target.textContent = safeText;
+    return;
   }
-  
-  const escapedQuery = query.trim().replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-  const regex = new RegExp(`(${escapedQuery})`, 'gi');
-  return escapedText.replace(regex, '<span class="highlight">$1</span>');
+
+  const lowerText = safeText.toLowerCase();
+  const lowerQuery = safeQuery.toLowerCase();
+  let cursor = 0;
+
+  while (cursor < safeText.length) {
+    const matchIndex = lowerText.indexOf(lowerQuery, cursor);
+    if (matchIndex === -1) {
+      target.appendChild(document.createTextNode(safeText.slice(cursor)));
+      break;
+    }
+
+    if (matchIndex > cursor) {
+      target.appendChild(
+        document.createTextNode(safeText.slice(cursor, matchIndex))
+      );
+    }
+
+    const highlight = document.createElement('span');
+    highlight.className = 'highlight';
+    highlight.textContent = safeText.slice(
+      matchIndex,
+      matchIndex + safeQuery.length
+    );
+    target.appendChild(highlight);
+    cursor = matchIndex + safeQuery.length;
+  }
 }
 
 function renderProducts(containerId, list, query = '') {
   const container = document.getElementById(containerId);
   if (!container) return;
-  
+
   if (query === '') {
     const searchInput = document.getElementById('searchInput');
     query = searchInput ? searchInput.value.trim() : '';
@@ -595,15 +630,30 @@ function renderProducts(containerId, list, query = '') {
     const searchInput = document.getElementById('searchInput');
     const searchTerm = searchInput ? searchInput.value : '';
 
-    container.innerHTML = `
-        <div id="no-results-message" style="width: 100%; text-align: center; padding: 60px 20px;">
-            <div class="no-results-content">
-                <i class="ri-search-line" style="font-size: 3rem; color: #888; margin-bottom: 15px; display: block;"></i>
-                <h3 style="font-size: 1.5rem; margin-bottom: 10px;">No matching products found</h3>
-                <p style="color: #666;">We couldn't find any products matching "${searchTerm}". Please try a different search term or change your category filter.</p>
-            </div>
-        </div>
-    `;
+    const message = document.createElement('div');
+    message.id = 'no-results-message';
+    message.style.cssText =
+      'width: 100%; text-align: center; padding: 60px 20px;';
+
+    const content = document.createElement('div');
+    content.className = 'no-results-content';
+
+    const icon = document.createElement('i');
+    icon.className = 'ri-search-line';
+    icon.style.cssText =
+      'font-size: 3rem; color: #888; margin-bottom: 15px; display: block;';
+
+    const heading = document.createElement('h3');
+    heading.style.cssText = 'font-size: 1.5rem; margin-bottom: 10px;';
+    heading.textContent = 'No matching products found';
+
+    const copy = document.createElement('p');
+    copy.style.color = '#666';
+    copy.textContent = `We couldn't find any products matching "${searchTerm}". Please try a different search term or change your category filter.`;
+
+    content.append(icon, heading, copy);
+    message.appendChild(content);
+    container.appendChild(message);
     return;
   }
 
@@ -672,16 +722,17 @@ function renderProducts(containerId, list, query = '') {
 
     const brandRow = document.createElement('div');
     brandRow.className = 'pro-brand-row';
-    brandRow.innerHTML = `
-      <svg class="pro-brand-logo" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-        <path d="M12 2L2 19h20L12 2zm0 3.5L19.5 18h-15L12 5.5z"/>
-      </svg>
-      <span>${highlightText(p.brand, query)}</span>
-    `;
+    brandRow.insertAdjacentHTML(
+      'beforeend',
+      '<svg class="pro-brand-logo" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2L2 19h20L12 2zm0 3.5L19.5 18h-15L12 5.5z"/></svg>'
+    );
+    const brandText = document.createElement('span');
+    appendHighlightedText(brandText, p.brand, query);
+    brandRow.appendChild(brandText);
     des.appendChild(brandRow);
 
     const nameH5 = document.createElement('h5');
-    nameH5.innerHTML = highlightText(p.name, query);
+    appendHighlightedText(nameH5, p.name, query);
     des.appendChild(nameH5);
 
     // Dynamic interactive star rating
@@ -804,9 +855,15 @@ function filterProducts() {
   const query = rawQuery.toLowerCase();
   const category = categorySelect ? categorySelect.value : 'all';
   const sortValue = sortSelect ? sortSelect.value : 'default';
-  const brandValue = brandSelect ? brandSelect.value.toLowerCase().trim() : 'all';
-  const colorValue = colorSelect ? colorSelect.value.toLowerCase().trim() : 'all';
-  const styleValue = styleSelect ? styleSelect.value.toLowerCase().trim() : 'all';
+  const brandValue = brandSelect
+    ? brandSelect.value.toLowerCase().trim()
+    : 'all';
+  const colorValue = colorSelect
+    ? colorSelect.value.toLowerCase().trim()
+    : 'all';
+  const styleValue = styleSelect
+    ? styleSelect.value.toLowerCase().trim()
+    : 'all';
 
   let filteredProducts = products.filter((product) => {
     const matchesCategory = category === 'all' || product.category === category;
@@ -822,9 +879,14 @@ function filterProducts() {
 
   // Apply brand/color/style filters
   filteredProducts = filteredProducts.filter((product) => {
-    const matchesBrand = brandValue === 'all' || product.brand.toLowerCase() === brandValue;
-    const matchesColor = colorValue === 'all' || (product.color && product.color.toLowerCase() === colorValue);
-    const matchesStyle = styleValue === 'all' || (product.style && product.style.toLowerCase() === styleValue);
+    const matchesBrand =
+      brandValue === 'all' || product.brand.toLowerCase() === brandValue;
+    const matchesColor =
+      colorValue === 'all' ||
+      (product.color && product.color.toLowerCase() === colorValue);
+    const matchesStyle =
+      styleValue === 'all' ||
+      (product.style && product.style.toLowerCase() === styleValue);
     return matchesBrand && matchesColor && matchesStyle;
   });
 
@@ -898,41 +960,41 @@ document.addEventListener('DOMContentLoaded', () => {
   syncWishlistButtons();
 });
 
- // --- GLOBAL TOAST NOTIFICATION HANDLER ---
+// --- GLOBAL TOAST NOTIFICATION HANDLER ---
 function showToast(message, type = 'success') {
-    // Check if container already exists, else create it
-    let container = document.getElementById('toast-container');
-    if (!container) {
-        container = document.createElement('div');
-        container.id = 'toast-container';
-        document.body.appendChild(container);
-    }
+  // Check if container already exists, else create it
+  let container = document.getElementById('toast-container');
+  if (!container) {
+    container = document.createElement('div');
+    container.id = 'toast-container';
+    document.body.appendChild(container);
+  }
 
-    // Create Toast element wrapper
-    const toast = document.createElement('div');
-    toast.className = `toast toast-${type}`;
+  // Create Toast element wrapper
+  const toast = document.createElement('div');
+  toast.className = `toast toast-${type}`;
 
-    // Select icon based on variant types
-    let icon = '🛒';
-    if (type === 'error') icon = '❌';
-    if (type === 'warning') icon = '⚠️';
-    if (type === 'info') icon = 'ℹ️';
+  // Select icon based on variant types
+  let icon = '🛒';
+  if (type === 'error') icon = '❌';
+  if (type === 'warning') icon = '⚠️';
+  if (type === 'info') icon = 'ℹ️';
 
-    // Build Toast inner body to match your existing CSS layout (.toast-icon, .toast-msg, .toast-close, .toast-progress)
-    toast.innerHTML = `
+  // Build Toast inner body to match your existing CSS layout (.toast-icon, .toast-msg, .toast-close, .toast-progress)
+  toast.innerHTML = `
         <div class="toast-icon">${icon}</div>
         <div class="toast-msg">${message}</div>
         <button class="toast-close" onclick="this.parentElement.remove()">&times;</button>
         <div class="toast-progress"></div>
     `;
 
-    container.appendChild(toast);
+  container.appendChild(toast);
 
-    // Auto-remove animation sequence handling (Matches CSS timers smoothly)
+  // Auto-remove animation sequence handling (Matches CSS timers smoothly)
+  setTimeout(() => {
+    toast.classList.add('toast-hiding');
     setTimeout(() => {
-        toast.classList.add('toast-hiding');
-        setTimeout(() => {
-            toast.remove();
-        }, 350); // Exact exit duration specified in .toast-hiding cubic-bezier curve
-    }, 3650); // Active visibility shelf life before auto dismissal
+      toast.remove();
+    }, 350); // Exact exit duration specified in .toast-hiding cubic-bezier curve
+  }, 3650); // Active visibility shelf life before auto dismissal
 }


### PR DESCRIPTION
## Summary
- replace dynamic product name/brand search highlighting with DOM text-node rendering
- build the no-results message with DOM APIs so the search term is displayed as text, not parsed as HTML
- preserve the existing highlight styling and product card behavior

Closes #1983

## Validation
- `node --check products.js`
- `npm_config_cache=/private/tmp/cara-npx-cache npx --yes prettier@3.5.2 --check products.js`
- `npm_config_cache=/private/tmp/cara-eslint-cache npx --yes eslint@9.21.0 --no-config-lookup --rule 'no-undef: off' --rule 'no-unused-vars: warn' products.js` (passes with one existing warning at `products.js:2` for `modalTemplate`)\n- `git diff --check`\n\nNote: full `npm ci` could not complete locally because the current lockfile fails integrity verification for `uri-js@4.4.1` (wanted hash differs from fetched tarball by one character), even after clearing the npm cache. I used isolated npx checks for the touched file instead.