### PR TITLE
feat(shop): implement persistent search history UI

### DIFF
--- a/js/search-history.js
+++ b/js/search-history.js
@@ -81,3 +81,5 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     });
 });
+
+// Local storage parser populating clickable search history suggestion bubbles.

--- a/shop.html
+++ b/shop.html
@@ -76,6 +76,48 @@
 
   <!-- SEARCH -->
   <div class="search-container">
+    <div id="recent-searches-box" style="margin-top: 10px; font-size: 14px; display: none;">
+      <span>Recent Searches: </span>
+      <span id="recent-searches-list"></span>
+      <button id="clear-searches-btn" style="background: none; border: none; color: #088178; cursor: pointer; text-decoration: underline; margin-left: 10px;">Clear</button>
+    </div>
+    
+    <script>
+    document.addEventListener("DOMContentLoaded", () => {
+      const searchInput = document.getElementById("searchInput");
+      const searchBtn = document.getElementById("searchBtn");
+      const listContainer = document.getElementById("recent-searches-list");
+      const box = document.getElementById("recent-searches-box");
+      const clearBtn = document.getElementById("clear-searches-btn");
+
+      const updateList = () => {
+        const searches = JSON.parse(localStorage.getItem("recentSearches") || "[]");
+        if (searches.length === 0) {
+          box.style.display = "none";
+          return;
+        }
+        box.style.display = "block";
+        listContainer.innerHTML = searches.map(s => `<span style="background: #e2e8f0; padding: 2px 6px; border-radius: 4px; margin-right: 5px; cursor: pointer;" onclick="document.getElementById('searchInput').value='${s}'; document.getElementById('searchBtn').click();">${s}</span>`).join("");
+      };
+
+      searchBtn.addEventListener("click", () => {
+        const query = searchInput.value.trim();
+        if (query) {
+          let searches = JSON.parse(localStorage.getItem("recentSearches") || "[]");
+          searches = [query, ...searches.filter(s => s !== query)].slice(0, 5);
+          localStorage.setItem("recentSearches", JSON.stringify(searches));
+          updateList();
+        }
+      });
+
+      clearBtn.addEventListener("click", () => {
+        localStorage.removeItem("recentSearches");
+        updateList();
+      });
+
+      updateList();
+    });
+    </script>
     <div class="search-box">
       <input type="text" id="searchInput" placeholder="Search products..." />
       <button id="searchBtn">


### PR DESCRIPTION
Closes #2004


# Summary
Adds a persistent recent search indicator list that updates on search triggers.

# Changes Made
- Embedded recent search tags and interactive scripts in `shop.html`
- Implemented storage management functions to clear history logs

# Testing
- Typed search queries and verified pills render correctly.
- Confirmed history persists on tab refresh.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] Responsive design verified
