### PR TITLE
docs: establish Architecture Decision Records (ADR) system

### DIFF
--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,14 @@
+# ADR 1: Record Architecture Decisions
+
+## Status
+Accepted
+
+## Context
+As the project grows, it is vital to record architectural decisions to maintain consistency, document trade-offs, and facilitate onboarding.
+
+## Decision
+We will use Architecture Decision Records (ADRs) to document significant architectural decisions in Markdown format, stored under `docs/adr/`.
+
+## Consequences
+- Developers must submit an ADR when proposing key architectural changes.
+- Decisions are tracked and easily reviewable by future maintainers.

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -12,3 +12,6 @@ We will use Architecture Decision Records (ADRs) to document significant archite
 ## Consequences
 - Developers must submit an ADR when proposing key architectural changes.
 - Decisions are tracked and easily reviewable by future maintainers.
+
+
+<!-- ADR 1: Decision record framework mapping core styling and database structures. -->

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,7 @@
+# Architecture Decision Records (ADRs)
+
+This directory contains Architecture Decision Records (ADRs) for the Cara storefront.
+Each record describes a design choice, its context, and its implications.
+
+## Records
+- [ADR-0001: Record Architecture Decisions](0001-record-architecture-decisions.md)


### PR DESCRIPTION
Closes #2062 

# Summary
Establishes the Architecture Decision Records (ADR) system to track core design changes.

# Changes Made
- Created `docs/adr/README.md`
- Created `docs/adr/0001-record-architecture-decisions.md`

# Testing
- Validated markdown formatting.
