### PR TITLE
Fix: CSS parser break causing quick view modal to display inline

### DIFF
--- a/style.css
+++ b/style.css
@@ -36001,6 +36001,7 @@ html {
 
 #feature {
     margin-top: 60px !important;
+}
 /* ============================================
    PRODUCT QUICK-VIEW MODAL AND OVERLAY STYLES
    ============================================ */


### PR DESCRIPTION
## Description

This PR fixes a critical UI bug where the product quick view modal was rendering statically and unstyled at the bottom of the page (below the footer).

Fixes: #2106 

**The cause:** 
A missing closing brace `}` in `style.css` for the `#feature` rule was causing the CSS parser to fail. This broke the subsequent parsing of the `.quickview-modal` class and related overlay styles, meaning the modal didn't receive its necessary `position: fixed`, `opacity: 0`, and `display` properties.

**The fix:** 
Added the missing `}` closing brace at the end of the `#feature` rule in `style.css`, restoring the CSS parsing. The quick view modal is now hidden by default and functions as intended when interacting with a product card.

## Changes Made
- Added missing `}` in `style.css` around line 36003.

## Related Issues
- Resolves the unstyled modal rendering bug below the footer.

## How to Test
1. Pull this branch and run the application locally.
2. Open `index.html` and scroll to the bottom of the page to verify the unstyled modal is no longer visible below the footer.
3. Click the "Quick View" button on any product card to verify the modal now displays correctly styled and positioned in the center of the viewport.

## Screenshots
Before: 
<img width="1919" height="727" alt="image" src="https://github.com/user-attachments/assets/763f8a1c-3e83-498e-a2f8-16730b3f462a" />
After:
<img width="1852" height="728" alt="image" src="https://github.com/user-attachments/assets/8abbc8f3-a7d6-4911-a74c-d0bb0f5aff07" />

