### PR TITLE
fix: prevent privilege escalation via role field in registration

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -63,7 +63,7 @@ def register(request: Request, payload: UserRegister, db: Session = Depends(get_
         username        = payload.username,
         email           = payload.email,
         hashed_password = pwd.hash(payload.password),
-        role            = payload.role,
+        role            = "USER",
     )
     db.add(user)
     db.commit()

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -44,7 +44,6 @@ class UserRegister(BaseModel):
     username: str
     email:    EmailStr
     password: str
-    role:     RoleEnum = RoleEnum.USER
 
 
 class UserLogin(BaseModel):

--- a/register.js
+++ b/register.js
@@ -16,8 +16,6 @@ document.addEventListener("DOMContentLoaded", () => {
         const password = document.getElementById("registerPassword")?.value.trim();
         const confirmPassword = document.getElementById("confirmPassword")?.value.trim();
 
-        const role = document.querySelector('input[name="registerRole"]:checked')?.value || "USER";
-
         const messageBox = document.getElementById("formMessage");
 
         // basic validation
@@ -47,8 +45,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 body: JSON.stringify({
                     username,
                     email,
-                    password,
-                    role
+                    password
                 })
             });
 


### PR DESCRIPTION
# PR Description

## Summary of Changes
The public registration endpoint accepted a `role` field from the client and stored it directly, allowing any user to self-assign `ADMIN` privileges by crafting a request with `"role": "ADMIN"`. This PR removes `role` from the `UserRegister` schema and hard-codes `role="USER"` in the register handler. The corresponding frontend fetch call in `register.js` is cleaned up to no longer send the field.

## Related Issue
Fixes #2145

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Verification & Testing
### Local Verification
- [x] Built successfully locally
- [x] Console has zero errors or warnings

**Manual test:**
```bash
# Before fix — this would return role: ADMIN
curl -X POST /api/auth/register \
  -H "Content-Type: application/json" \
  -d '{"username":"x","email":"x@x.com","password":"password123","role":"ADMIN"}'

# After fix — role field is ignored; user is always created as USER
# Sending "role":"ADMIN" now has no effect; the field is stripped at schema level
```

### Devices/Browsers Tested
- [x] Chrome (Desktop)

## Checklist
- [x] Code follows project styling guidelines
- [x] Changes are fully responsive and accessible
- [x] No extraneous logs or debug code left
- [x] Documentation updated accordingly