### PR TITLE
fix: raise descriptive RuntimeError when SECRET_KEY is missing at startup

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,3 +4,7 @@
 
 # For SQLite (default fallback):
 # DATABASE_URL=sqlite:///./cara.db
+
+# Secret key used for signing JWTs — required, server will not start without it.
+# Generate one with: python -c "import secrets; print(secrets.token_hex(32))"
+SECRET_KEY=your-secret-key-here

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -10,7 +10,12 @@ from app import models
 from app.schemas import UserRegister, UserLogin, Token, UserOut
 from app.limiter import limiter
 
-SECRET_KEY = os.environ["SECRET_KEY"] #set it in .env 
+SECRET_KEY = os.environ.get("SECRET_KEY")
+if not SECRET_KEY:
+    raise RuntimeError(
+        "SECRET_KEY environment variable is not set. "
+        "Add SECRET_KEY=<your-secret> to your .env file before starting the server."
+    )
 ALGORITHM  = "HS256"
 TOKEN_DAYS = 7
 


### PR DESCRIPTION
# PR Description

## Summary of Changes
`auth.py` was loading `SECRET_KEY` via `os.environ["SECRET_KEY"]` at module import time. A missing variable caused a raw `KeyError` before FastAPI could initialise, leaving contributors with no useful guidance. This PR replaces that with `os.environ.get()` and an explicit `RuntimeError` that names the missing variable and tells the developer exactly how to fix it. `.env.example` is also updated to document `SECRET_KEY` with a one-liner to generate a secure value.

## Related Issue
Fixes #2146

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Verification & Testing
### Local Verification
- [x] Built successfully locally
- [x] Console has zero errors or warnings

**Before fix — starting without SECRET_KEY:**
```
KeyError: 'SECRET_KEY'
  File ".../backend/app/api/auth.py", line 13, in <module>
```

**After fix:**
```
RuntimeError: SECRET_KEY environment variable is not set.
Add SECRET_KEY=<your-secret> to your .env file before starting the server.
```

### Devices/Browsers Tested
- [x] Chrome (Desktop)

## Checklist
- [x] Code follows project styling guidelines
- [x] Changes are fully responsive and accessible
- [x] No extraneous logs or debug code left
- [x] Documentation updated accordingly