### PR TITLE
fix: validate product existence and interaction type in feedback endpoint

### DIFF
--- a/backend/app/api/recommendation.py
+++ b/backend/app/api/recommendation.py
@@ -35,6 +35,9 @@ def recommend_outfit(req: schemas.RecommendationRequest, db: Session = Depends(g
 
 @router.post("/feedback")
 def track_feedback(interaction: schemas.InteractionCreate, db: Session = Depends(get_db)):
+    product = db.query(models.Product).filter(models.Product.id == interaction.product_id).first()
+    if not product:
+        raise HTTPException(status_code=404, detail="Product not found")
     new_interaction = models.Interaction(**interaction.dict())
     db.add(new_interaction)
     db.commit()

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -22,10 +22,17 @@ class Product(ProductBase):
     class Config:
         from_attributes = True
 
+class InteractionType(str, Enum):
+    view     = "view"
+    click    = "click"
+    wishlist = "wishlist"
+    cart     = "cart"
+    buy      = "buy"
+
 class InteractionCreate(BaseModel):
     user_id: str
     product_id: int
-    interaction_type: str
+    interaction_type: InteractionType
 
 class RecommendationRequest(BaseModel):
     product_id: int


### PR DESCRIPTION
# PR Description

## Summary of Changes
`POST /api/outfit/feedback` previously stored any `product_id` and any free-form `interaction_type` string without validation. This meant unknown products could be referenced (causing a raw FK database error instead of a clean 404) and arbitrary event names could pollute the interactions table, degrading recommendation quality.

This PR:
1. Adds an `InteractionType` enum (`view`, `click`, `wishlist`, `cart`, `buy`) and replaces the bare `str` field in `InteractionCreate` — Pydantic now rejects unknown types with `422`.
2. Adds a product-existence check in the feedback handler that returns `404` before inserting, preventing FK violations and orphaned rows.

## Related Issue
Fixes #2149

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Verification & Testing
### Local Verification
- [x] Built successfully locally
- [x] Console has zero errors or warnings

**Before fix:**
```bash
POST /api/outfit/feedback  {"user_id":"x","product_id":999999,"interaction_type":"anything"}
# HTTP 500 — unhandled DB FK violation
```

**After fix:**
```bash
POST /api/outfit/feedback  {"user_id":"x","product_id":999999,"interaction_type":"view"}
# HTTP 404 — {"detail": "Product not found"}

POST /api/outfit/feedback  {"user_id":"x","product_id":1,"interaction_type":"anything"}
# HTTP 422 — validation error: interaction_type must be one of view, click, wishlist, cart, buy
```

### Devices/Browsers Tested
- [x] Chrome (Desktop)

## Checklist
- [x] Code follows project styling guidelines
- [x] Changes are fully responsive and accessible
- [x] No extraneous logs or debug code left
- [x] Documentation updated accordingly