### PR TITLE
accessibility: bind form input error tooltips via aria-describedby properties

### DIFF
--- a/js/describedby-tooltips.js
+++ b/js/describedby-tooltips.js
@@ -1,0 +1,15 @@
+// Accessible field descriptions tooltips
+document.addEventListener("DOMContentLoaded", () => {
+    const inputs = document.querySelectorAll("input[required]");
+    inputs.forEach((input, index) => {
+        const descId = `field-desc-${index}`;
+        input.setAttribute("aria-describedby", descId);
+
+        const tooltip = document.createElement("span");
+        tooltip.id = descId;
+        tooltip.className = "sr-tooltip";
+        tooltip.textContent = "Required field input.";
+        tooltip.style.cssText = "position:absolute; left:-9999px; width:1px; height:1px; overflow:hidden;";
+        input.parentNode.appendChild(tooltip);
+    });
+});

--- a/register.html
+++ b/register.html
@@ -283,5 +283,6 @@
 
 <script src="js/register-interests.js" defer></script>
 <script src="js/simple-captcha.js" defer></script>
+<script src="js/describedby-tooltips.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
# Related Issue
Closes #2205 

# Summary
Implements screen-reader-friendly helper tooltips by binding them to input fields.

# Changes Made
- Added [describedby-tooltips.js](file:///c:/Users/babin/Desktop/ELUSoC/Cara/js/describedby-tooltips.js).
- Updated fields in [register.html](file:///c:/Users/babin/Desktop/ELUSoC/Cara/register.html).

# Testing
- Tested using NVDA screen reader voice output.

# Checklist
- [x] Code follows project standards
