### PR TITLE
feat: add created_at timestamp to Interaction model

### DIFF
--- a/backend/alembic/versions/a1b2c3d4e5f6_add_created_at_to_interactions.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_created_at_to_interactions.py
@@ -1,0 +1,41 @@
+"""add created_at to interactions
+
+Revision ID: a1b2c3d4e5f6
+Revises: 2fe393eac288
+Create Date: 2026-06-12 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a1b2c3d4e5f6'
+down_revision: Union[str, Sequence[str], None] = '2fe393eac288'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'interactions',
+        sa.Column(
+            'created_at',
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        )
+    )
+    op.create_index(
+        op.f('ix_interactions_created_at'),
+        'interactions',
+        ['created_at'],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_interactions_created_at'), table_name='interactions')
+    op.drop_column('interactions', 'created_at')

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -24,7 +24,8 @@ class Interaction(Base):
     user_id = Column(String, index=True) # IP or generic session id
     product_id = Column(Integer, ForeignKey("products.id"))
     interaction_type = Column(String) # click, view, buy
-    
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False, index=True)
+
     product = relationship("Product")
 
 


### PR DESCRIPTION
## 📄 Description

Adds a `created_at` UTC timestamp column to the `Interaction` model, matching the pattern already established by the `User` model in the same file. Includes a new Alembic migration to apply the schema change to existing databases without data loss.

**Changes:**
- `backend/app/models.py`: `created_at` column added to `Interaction` — `nullable=False`, indexed for query performance, auto-set to `datetime.now(timezone.utc)`
- `backend/alembic/versions/a1b2c3d4e5f6_add_created_at_to_interactions.py`: new migration with `server_default=sa.func.now()` so existing rows get a valid timestamp on upgrade; `downgrade()` removes the column and index cleanly

Run the migration with:
```bash
cd backend && alembic upgrade head
```

## 🔗 Related Issues

Fixes #2220

## 🧩 Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Verification & Testing

### Local Verification
- [x] Built successfully locally
- [x] Console has zero errors or warnings

### Devices/Browsers Tested
- [ ] Chrome (Desktop)
- [ ] Safari (Mobile)
- [ ] Firefox

## ✅ Checklist
- [x] Code follows project styling guidelines
- [x] Changes are fully responsive and accessible
- [x] No extraneous logs or debug code left
- [x] Documentation updated accordingly