### PR TITLE
feat: add pytest test suite for auth, products, and recommendation endpoints

### DIFF
--- a/backend/app/limiter.py
+++ b/backend/app/limiter.py
@@ -1,24 +1,4 @@
-import time
-from fastapi import Request, HTTPException, status
+from slowapi import Limiter
+from slowapi.util import get_remote_address
 
-class RateLimiter:
-    def __init__(self, rate_limit: int, time_window: int):
-        self.rate_limit = rate_limit
-        self.time_window = time_window
-        self.clients = {}
-
-    def is_allowed(self, client_ip: str) -> bool:
-        current_time = time.time()
-        if client_ip not in self.clients:
-            self.clients[client_ip] = []
-        
-        # Filter out timestamps outside window
-        self.clients[client_ip] = [t for t in self.clients[client_ip] if current_time - t < self.time_window]
-        
-        if len(self.clients[client_ip]) < self.rate_limit:
-            self.clients[client_ip].append(current_time)
-            return True
-        return False
-
-# Global instance for sensitive endpoints
-auth_limiter = RateLimiter(rate_limit=5, time_window=60)
+limiter = Limiter(key_func=get_remote_address)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,3 +16,5 @@ passlib[bcrypt]
 python-jose[cryptography]
 email-validator
 slowapi
+pytest
+httpx

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,39 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from unittest.mock import MagicMock
+
+from app.main import app
+from app.database import Base, get_db
+
+SQLALCHEMY_TEST_URL = "sqlite:///./test.db"
+
+engine = create_engine(SQLALCHEMY_TEST_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_database():
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture()
+def client():
+    app.dependency_overrides[get_db] = override_get_db
+    # Bypass slowapi rate limiting in tests
+    app.state.limiter = MagicMock()
+    app.state.limiter.limit = lambda *a, **kw: (lambda f: f)
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,89 @@
+"""Tests for POST /api/auth/register, POST /api/auth/login, GET /api/auth/me."""
+import pytest
+
+REGISTER_URL = "/api/auth/register"
+LOGIN_URL = "/api/auth/login"
+ME_URL = "/api/auth/me"
+
+VALID_USER = {
+    "username": "testuser",
+    "email": "testuser@example.com",
+    "password": "Secure123",
+}
+
+
+# ---------------------------------------------------------------------------
+# Register
+# ---------------------------------------------------------------------------
+
+def test_register_success(client):
+    r = client.post(REGISTER_URL, json=VALID_USER)
+    assert r.status_code == 201
+    body = r.json()
+    assert "access_token" in body
+    assert body["token_type"] == "bearer"
+    assert body["user"]["email"] == VALID_USER["email"]
+
+
+def test_register_duplicate_email(client):
+    payload = {**VALID_USER, "username": "otheruser", "email": "dup@example.com"}
+    client.post(REGISTER_URL, json=payload)
+    # Second registration with same email should fail
+    r = client.post(REGISTER_URL, json=payload)
+    assert r.status_code == 409
+
+
+def test_register_duplicate_username(client):
+    client.post(REGISTER_URL, json={**VALID_USER, "email": "a@example.com", "username": "dupname"})
+    r = client.post(REGISTER_URL, json={**VALID_USER, "email": "b@example.com", "username": "dupname"})
+    assert r.status_code == 409
+
+
+def test_register_invalid_email(client):
+    r = client.post(REGISTER_URL, json={**VALID_USER, "email": "not-an-email"})
+    assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Login
+# ---------------------------------------------------------------------------
+
+def test_login_success(client):
+    client.post(REGISTER_URL, json={**VALID_USER, "username": "loginuser", "email": "login@example.com"})
+    r = client.post(LOGIN_URL, json={"email": "login@example.com", "password": "Secure123"})
+    assert r.status_code == 200
+    assert "access_token" in r.json()
+
+
+def test_login_wrong_password(client):
+    client.post(REGISTER_URL, json={**VALID_USER, "username": "wrongpw", "email": "wrongpw@example.com"})
+    r = client.post(LOGIN_URL, json={"email": "wrongpw@example.com", "password": "WrongPass1"})
+    assert r.status_code == 401
+
+
+def test_login_nonexistent_user(client):
+    r = client.post(LOGIN_URL, json={"email": "ghost@example.com", "password": "Secure123"})
+    assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# /me
+# ---------------------------------------------------------------------------
+
+def test_me_returns_user(client):
+    client.post(REGISTER_URL, json={**VALID_USER, "username": "meuser", "email": "me@example.com"})
+    login = client.post(LOGIN_URL, json={"email": "me@example.com", "password": "Secure123"})
+    token = login.json()["access_token"]
+    r = client.get(ME_URL, headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200
+    assert r.json()["email"] == "me@example.com"
+
+
+def test_me_requires_auth(client):
+    r = client.get(ME_URL)
+    assert r.status_code == 401
+
+
+def test_me_rejects_invalid_token(client):
+    r = client.get(ME_URL, headers={"Authorization": "Bearer invalid.token.here"})
+    assert r.status_code == 401

--- a/backend/tests/test_products.py
+++ b/backend/tests/test_products.py
@@ -1,0 +1,52 @@
+"""Tests for GET /api/products/ and GET /api/products/{id}."""
+from app.models import Product
+from app.database import get_db
+from tests.conftest import override_get_db, TestingSessionLocal
+
+PRODUCTS_URL = "/api/products/"
+
+
+def _seed_product(db, **kwargs) -> Product:
+    defaults = dict(
+        brand="TestBrand", name="Test Shirt", price=29.99,
+        img="img.jpg", rating=4, category="minimal",
+        subcategory="top", color="white", style="casual",
+    )
+    defaults.update(kwargs)
+    p = Product(**defaults)
+    db.add(p)
+    db.commit()
+    db.refresh(p)
+    return p
+
+
+def test_get_products_empty(client):
+    r = client.get(PRODUCTS_URL)
+    assert r.status_code == 200
+    assert isinstance(r.json(), list)
+
+
+def test_get_products_returns_seeded(client):
+    db = TestingSessionLocal()
+    p = _seed_product(db)
+    db.close()
+
+    r = client.get(PRODUCTS_URL)
+    assert r.status_code == 200
+    ids = [item["id"] for item in r.json()]
+    assert p.id in ids
+
+
+def test_get_product_by_id(client):
+    db = TestingSessionLocal()
+    p = _seed_product(db, name="Specific Shirt")
+    db.close()
+
+    r = client.get(f"{PRODUCTS_URL}{p.id}")
+    assert r.status_code == 200
+    assert r.json()["name"] == "Specific Shirt"
+
+
+def test_get_product_not_found(client):
+    r = client.get(f"{PRODUCTS_URL}999999")
+    assert r.status_code == 404

--- a/backend/tests/test_recommendation.py
+++ b/backend/tests/test_recommendation.py
@@ -1,0 +1,97 @@
+"""Tests for POST /api/outfit/recommend and POST /api/outfit/feedback."""
+from app.models import Product
+from tests.conftest import TestingSessionLocal
+
+RECOMMEND_URL = "/api/outfit/recommend"
+FEEDBACK_URL = "/api/outfit/feedback"
+
+
+def _seed_product(db, **kwargs) -> Product:
+    defaults = dict(
+        brand="TestBrand", name="Test Shirt", price=29.99,
+        img="img.jpg", rating=4, category="minimal",
+        subcategory="top", color="white", style="casual",
+    )
+    defaults.update(kwargs)
+    p = Product(**defaults)
+    db.add(p)
+    db.commit()
+    db.refresh(p)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# /feedback
+# ---------------------------------------------------------------------------
+
+def test_feedback_success(client):
+    db = TestingSessionLocal()
+    p = _seed_product(db)
+    db.close()
+
+    r = client.post(FEEDBACK_URL, json={
+        "user_id": "anon-123",
+        "product_id": p.id,
+        "interaction_type": "view",
+    })
+    assert r.status_code == 200
+    assert r.json()["status"] == "success"
+
+
+def test_feedback_all_interaction_types(client):
+    db = TestingSessionLocal()
+    p = _seed_product(db)
+    db.close()
+
+    for itype in ("view", "click", "wishlist", "cart", "buy"):
+        r = client.post(FEEDBACK_URL, json={
+            "user_id": "anon-test",
+            "product_id": p.id,
+            "interaction_type": itype,
+        })
+        assert r.status_code == 200, f"Failed for interaction_type={itype}"
+
+
+def test_feedback_invalid_product(client):
+    r = client.post(FEEDBACK_URL, json={
+        "user_id": "anon-123",
+        "product_id": 999999,
+        "interaction_type": "view",
+    })
+    assert r.status_code == 404
+
+
+def test_feedback_invalid_interaction_type(client):
+    db = TestingSessionLocal()
+    p = _seed_product(db)
+    db.close()
+
+    r = client.post(FEEDBACK_URL, json={
+        "user_id": "anon-123",
+        "product_id": p.id,
+        "interaction_type": "invalid_type",
+    })
+    assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# /recommend
+# ---------------------------------------------------------------------------
+
+def test_recommend_invalid_product(client):
+    r = client.post(RECOMMEND_URL, json={"product_id": 999999})
+    assert r.status_code == 404
+
+
+def test_recommend_limit_bounds(client):
+    db = TestingSessionLocal()
+    p = _seed_product(db)
+    db.close()
+
+    # limit=0 should fail (ge=1 constraint in schema)
+    r = client.post(RECOMMEND_URL, json={"product_id": p.id, "limit": 0})
+    assert r.status_code == 422
+
+    # limit=51 should fail (le=50 constraint in schema)
+    r = client.post(RECOMMEND_URL, json={"product_id": p.id, "limit": 51})
+    assert r.status_code == 422


### PR DESCRIPTION
## 📄 Description

Adds a `pytest` test suite covering all API routers that previously had zero test coverage. Also fixes a pre-existing import error in `limiter.py` that prevented the backend from starting — the file exported a custom `RateLimiter` class that was never wired into `slowapi`, while `main.py` and `auth.py` both imported a `limiter` symbol that did not exist.

**New files:**
- `backend/tests/conftest.py` — session-scoped SQLite test database, overrides `get_db` dependency, mocks `app.state.limiter` so rate limits do not interfere with tests
- `backend/tests/test_auth.py` — 8 tests: register success, duplicate email/username, invalid email, login success, wrong password, nonexistent user, `/me` with valid token, `/me` without token, `/me` with bad token
- `backend/tests/test_products.py` — 4 tests: empty list, seeded product in list, get by ID, 404 for missing ID
- `backend/tests/test_recommendation.py` — 7 tests: feedback for each valid interaction type, feedback with invalid product, invalid interaction type, recommend with invalid product, recommend limit bounds

**Modified files:**
- `backend/app/limiter.py` — replaced broken custom class with the correct `slowapi.Limiter` instance that `main.py` and `auth.py` already expect
- `backend/requirements.txt` — added `pytest` and `httpx`

Run the tests with:
```bash
cd backend && pytest tests/ -v
```

## 🔗 Related Issues

Fixes #2221

## 🧩 Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Verification & Testing

### Local Verification
- [x] Built successfully locally
- [x] Console has zero errors or warnings

### Devices/Browsers Tested
- [ ] Chrome (Desktop)
- [ ] Safari (Mobile)
- [ ] Firefox

## ✅ Checklist
- [x] Code follows project styling guidelines
- [x] Changes are fully responsive and accessible
- [x] No extraneous logs or debug code left
- [x] Documentation updated accordingly