### PR TITLE
fix: replace deprecated .dict() with .model_dump() for Pydantic v2 compatibility

### DIFF
--- a/backend/app/api/recommendation.py
+++ b/backend/app/api/recommendation.py
@@ -38,7 +38,7 @@ def track_feedback(interaction: schemas.InteractionCreate, db: Session = Depends
     product = db.query(models.Product).filter(models.Product.id == interaction.product_id).first()
     if not product:
         raise HTTPException(status_code=404, detail="Product not found")
-    new_interaction = models.Interaction(**interaction.dict())
+    new_interaction = models.Interaction(**interaction.model_dump())
     db.add(new_interaction)
     db.commit()
     return {"status": "success"}


### PR DESCRIPTION
The `.dict()` method was deprecated in Pydantic v2 and raises warnings (or `AttributeError` in strict mode). Replacing it with `.model_dump()` ensures compatibility with fresh installs that pull Pydantic v2.

Closes #2219