### PR TITLE
Fix : Navbar logo visibility in light mode (#2232)

### DIFF
--- a/app.js
+++ b/app.js
@@ -643,7 +643,7 @@ window.buyNow = function (productName, productPrice, productImage, quantity, siz
         if (themeIconMobile) themeIconMobile.className = iconClass;
 
         const siteLogo = document.getElementById("siteLogo");
-        if (siteLogo) siteLogo.src = theme === "dark" ? "images/Dlogo.png" : "images/logo.png";
+        if (siteLogo) siteLogo.src = theme === "dark" ? "images/Dlogo.png" : "images/oldlogo.png";
     }
 
     function toggleTheme() {


### PR DESCRIPTION
## Summary of Changes

Fixed the navbar logo visibility issue in light mode.

The light mode theme was referencing a logo asset that was not available, causing the logo to be invisible. Updated the reference to use an existing logo asset.

## Related Issue

Fixes #2232

## Type of Change

- [x] Bug fix

## Verification & Testing

### Local Verification

- [x] Built successfully locally
- [x] Logo visible in light mode
- [x] Logo remains visible in dark mode

### Devices/Browsers Tested

- [x] Chrome (Desktop)

## Checklist

- [x] Code follows project style guidelines
- [x] Changes are fully responsive and accessible