### PR TITLE
fix: stop camera stream on page navigation and tab hide

### DIFF
--- a/try-on.js
+++ b/try-on.js
@@ -205,6 +205,20 @@ window.stopCamera=function() {
     document.getElementById('stop-camera-btn').style.display = 'none';
 }
 
+// Stop camera when the user navigates away or hides the tab
+window.addEventListener('beforeunload', () => {
+    if (cameraStream) {
+        cameraStream.getTracks().forEach(t => t.stop());
+        cameraStream = null;
+    }
+});
+
+document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden' && cameraStream) {
+        window.stopCamera();
+    }
+});
+
 // ============================================
 // IMAGE UPLOAD HANDLING
 // ============================================


### PR DESCRIPTION
## 📄 Description

The camera MediaStream was not stopped when the user navigated away from or hid the try-on page, leaving the browser camera indicator active in the background.

Added two event listeners in `try-on.js`:
- `beforeunload` — releases all MediaStream tracks immediately when the user navigates away.
- `visibilitychange` — calls the existing `stopCamera()` when the tab becomes hidden.

## 🔗 Related Issues

Fixes #2235

## 🧩 Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## ✅ Checklist

- [x] Code follows project styling guidelines
- [x] Changes are fully responsive and accessible
- [x] No extraneous logs or debug code left
- [x] Documentation updated accordingly
- [x] Built successfully locally
- [x] Console has zero errors or warnings