### PR TITLE
fix(security): restrict CORS allow_methods to GET, POST, OPTIONS

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,7 +20,7 @@ app.add_middleware(
     "http://localhost:5500",
     "https://cara-janavipandoles-projects.vercel.app",],  # update as needed
     allow_credentials=True,
-    allow_methods=["*"],
+    allow_methods=["GET", "POST", "OPTIONS"],
     allow_headers=["*"],
 )
 


### PR DESCRIPTION
## 📄 Description

`allow_methods=["*"]` in the CORS middleware exposed `DELETE`, `PUT`, `PATCH`, `TRACE`, and other HTTP methods to cross-origin requests.

Replaced the wildcard with an explicit allowlist `["GET", "POST", "OPTIONS"]` — the only three methods used by the API. `OPTIONS` is required for preflight requests.

## 🔗 Related Issues

Fixes #2236

## 🧩 Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## ✅ Checklist

- [x] Code follows project styling guidelines
- [x] Changes are fully responsive and accessible
- [x] No extraneous logs or debug code left
- [x] Documentation updated accordingly
- [x] Built successfully locally
- [x] Console has zero errors or warnings