### PR TITLE
fix: remove duplicate ui-fix.css link in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,6 @@
     integrity="sha512-Kc323vGBEqzTmouAECnVceyQqyqdsSiqLQISBL29aUW4U/M7pSPA/gEUZQqv1cwx4OnYxTxve5UMg5GT6L4JJg=="
     crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="global.css">
-  <link rel="stylesheet" href="ui-fix.css" />
 
   <!-- Inline Critical CSS -->
   <style>


### PR DESCRIPTION
## 📄 Description

`ui-fix.css` was included twice in `index.html` (lines 78 and 85), causing the browser to download and parse the same stylesheet twice on every page load — wasted bandwidth and extra render-blocking time.

Removed the second redundant `<link>` tag.

## 🔗 Related Issues

Fixes #2237

## 🧩 Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## ✅ Checklist

- [x] Code follows project styling guidelines
- [x] Changes are fully responsive and accessible
- [x] No extraneous logs or debug code left
- [x] Documentation updated accordingly
- [x] Built successfully locally
- [x] Console has zero errors or warnings