### PR TITLE
fix: add request timeout to all fetch calls

### DIFF
--- a/contributors.html
+++ b/contributors.html
@@ -250,6 +250,7 @@
 </footer>
 
   <script src="navbar.js"></script>
+  <script src="js/fetch-timeout.js"></script>
   <script src="contributors.js"></script>
 
   <script>

--- a/contributors.js
+++ b/contributors.js
@@ -4,7 +4,7 @@ async function fetchContributors() {
 
   try {
 
-    const response = await fetch(
+    const response = await fetchWithTimeout(
       "https://api.github.com/repos/janavipandole/Cara/contributors"
     );
 

--- a/login.html
+++ b/login.html
@@ -124,6 +124,7 @@
       loadNavbar();
     </script>
     <script src="app.js"></script>
+    <script src="js/fetch-timeout.js"></script>
     <script src="login.js"></script>
     <script>
       document.addEventListener('DOMContentLoaded', () => {

--- a/login.js
+++ b/login.js
@@ -219,7 +219,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
         try {
 
-            const response = await fetch(
+            const response = await fetchWithTimeout(
                 '/api/auth/login',
                 {
                     method: 'POST',

--- a/register.html
+++ b/register.html
@@ -283,6 +283,7 @@
 <div id="toast-container"></div>
 
 <script src="app.js"></script>
+<script src="js/fetch-timeout.js"></script>
 <script src="register.js"></script>
 
 <script src="js/register-interests.js" defer></script>

--- a/register.js
+++ b/register.js
@@ -44,7 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     try {
-      const res = await fetch('/api/auth/register', {
+      const res = await fetchWithTimeout('/api/auth/register', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## 📄 Description

All `fetch()` calls in `contributors.js`, `login.js`, and `register.js` had no timeout, so a slow or unresponsive server would leave users with a permanently spinning UI.

- Added `js/fetch-timeout.js` — a shared `fetchWithTimeout(url, options, ms=10000)` helper that wraps `fetch()` with an `AbortController` and a configurable timeout (default 10 s).
- Replaced every bare `fetch()` call in the three affected files with `fetchWithTimeout()`.
- Loaded `js/fetch-timeout.js` before the consumer scripts in `contributors.html`, `login.html`, and `register.html`.

## 🔗 Related Issues

Fixes #2238

## 🧩 Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## ✅ Checklist

- [x] Code follows project styling guidelines
- [x] Changes are fully responsive and accessible
- [x] No extraneous logs or debug code left
- [x] Documentation updated accordingly
- [x] Built successfully locally
- [x] Console has zero errors or warnings