### PR TITLE
fix(a11y): add aria-labels to login form elements

### DIFF
--- a/login.html
+++ b/login.html
@@ -21,7 +21,7 @@
 <body>
   <section id="header">
     <!-- Logo -->
-    <a href="index.html">
+    <a href="index.html" aria-label="Home">
       <img id="siteLogo" src="images/logo.png" alt="Cara Logo" />
     </a>
 
@@ -50,7 +50,7 @@
       <h2>Welcome Back!</h2>
       <p class="subtitle">Please enter your details to sign in</p>
 
-      <form id="loginForm" class="login-form" novalidate>
+      <form id="loginForm" class="login-form" aria-label="Login form" novalidate>
         <div class="input-group">
           <label for="loginEmail">Email Address</label>
           <input type="email" id="loginEmail" name="email" class="input-field" placeholder="Enter your email address"
@@ -89,7 +89,7 @@
           <label>Login As</label>
           <div class="role-selector">
             <label class="role-option">
-              <input type="radio" name="loginRole" value="USER" checked />
+              <input type="radio" name="loginRole" value="USER" aria-label="Login as User" checked />
               <span class="role-card">
                 <i class="ri-user-3-line"></i>
                 <strong>User</strong>
@@ -97,7 +97,7 @@
               </span>
             </label>
             <label class="role-option">
-              <input type="radio" name="loginRole" value="ADMIN" />
+              <input type="radio" name="loginRole" value="ADMIN" aria-label="Login as Admin" />
               <span class="role-card">
                 <i class="ri-shield-user-line"></i>
                 <strong>Admin</strong>
@@ -107,7 +107,7 @@
           </div>
         </div>
 
-        <button type="submit" class="login-btn"><span>Sign In</span></button>
+        <button type="submit" class="login-btn" aria-label="Sign In"><span>Sign In</span></button>
       </form>
 
       <div class="signup-link">
@@ -144,5 +144,3 @@
 </body>
 
 </html>
-
-<!-- TODO: Integrate aria labels for screen readers -->


### PR DESCRIPTION
## Description
This PR resolves the **Missing Accessibility (ARIA) Labels** technical debt in the login view.
Closes #2248 
The `login.html` file was missing essential accessibility tags, leaving interactive elements obscure to screen readers. This PR implements the necessary `aria-label` attributes to ensure better compliance with web accessibility standards and resolves the related `TODO`.

## Changes Made
- Added `aria-label="Home"` to the site logo link.
- Added `aria-label="Login form"` to the main login `<form>`.
- Added `aria-label="Login as User"` and `aria-label="Login as Admin"` to the respective radio button roles.
- Added `aria-label="Sign In"` to the form submit button.
- Removed the obsolete `<!-- TODO: Integrate aria labels for screen readers -->` comment from the bottom of the file.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Accessibility improvement
