### PR TITLE
fix(auth): enforce strict password complexity

### DIFF
--- a/register.js
+++ b/register.js
@@ -30,6 +30,14 @@ document.addEventListener("DOMContentLoaded", () => {
             messageBox.style.color = "red";
             return;
         }
+
+        // Password complexity: at least one uppercase, one lowercase, one number, and one special character
+        const complexityRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$/;
+        if (!complexityRegex.test(password)) {
+            messageBox.innerText = "Password must contain at least one uppercase letter, one lowercase letter, one number, and one special character!";
+            messageBox.style.color = "red";
+            return;
+        }
         if (password !== confirmPassword) {
             messageBox.innerText = "Passwords do not match!";
             messageBox.style.color = "red";
@@ -74,4 +82,3 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     });
 });
-// TODO: Prevent signup triggers if password complexity score is poor


### PR DESCRIPTION
## Description
This PR resolves **Issue 3: Unenforced Password Complexity**.
Closes #2249 
The previous registration validation only enforced a minimum length of 8 characters, meaning users could enter extremely weak passwords (like "12345678"). This PR implements a robust regular expression check to enforce modern password security standards before hitting the backend API.

## Changes Made
- Added `complexityRegex` to `register.js` to ensure passwords contain at least:
  - One uppercase letter
  - One lowercase letter
  - One number
  - One special character
- Added clear error messaging to the UI `messageBox` to alert the user if they do not meet the complexity requirements.
- Removed the obsolete `// TODO: Prevent signup triggers if password complexity score is poor` comment.

## Type of Change
- [x] Security patch
- [x] Bug fix
