### PR TITLE
Fix issue 1624

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,7 @@ name: Close Stale Issues & PRs
 on:
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
 permissions:
   issues: write


### PR DESCRIPTION
# PR Description

## Summary of Changes
Provide a brief summary of the changes made and the problem being solved.

## Related Issue
Fixes # (issue number)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Verification & Testing
### Local Verification
- [ ] Built successfully locally
- [ ] Console has zero errors or warnings

### Devices/Browsers Tested
- [ ] Chrome (Desktop)
- [ ] Safari (Mobile)
- [ ] Firefox

## Checklist
- [ ] Code follows project styling guidelines
- [ ] Changes are fully responsive and accessible
- [ ] No extraneous logs or debug code left
- [ ] Documentation updated accordingly


### Description
This PR addresses the issue with the stale issue management workflow. The `.github/workflows/stale.yml` action was present but failed to execute properly due to missing permissions under GitHub's default token security model. 

### Changes Made
- Added the `permissions:` block with `issues: write` and `pull-requests: write` to grant the GitHub token the necessary access to label and close stale issues/PRs.
- Added the `workflow_dispatch` trigger so the stale action can be triggered and tested manually from the GitHub Actions UI without having to wait for the midnight schedule.

**Fixes #1624**

### Testing
- Verified that the YAML syntax is valid and conforms to GitHub Actions standards.
- Ensuring there are no merge conflicts with the `main` branch.