### PR TITLE
fix: prevent Google Maps iframe from causing horizontal page overflow (#2283)

### DIFF
--- a/shop.html
+++ b/shop.html
@@ -254,9 +254,9 @@
 <div class="map-container" style="margin-top:15px;">
   <iframe
     src="https://www.google.com/maps?q=San+Francisco+California+USA&output=embed"
-    width="500%"
+    width="100%"
     height="350"
-    style="border:0; border-radius:10px;"
+    style="border:0; border-radius:10px; max-width:100%;"
     allowfullscreen=""
     loading="lazy">
   </iframe>


### PR DESCRIPTION
Closes #2283