### PR TITLE
fix: correct broken \d regex in password complexity check (register.js)

### DIFF
--- a/register.js
+++ b/register.js
@@ -1,78 +1,79 @@
-document.addEventListener("DOMContentLoaded", () => {
-    const btn = document.getElementById("registerSubmitBtn");
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('registerSubmitBtn');
 
-    if (!btn) {
-        return;
+  if (!btn) {
+    return;
+  }
+
+  btn.addEventListener('click', async (e) => {
+    e.preventDefault();
+
+    const username = document.getElementById('registerUsername')?.value.trim();
+    const email = document.getElementById('registerEmail')?.value.trim();
+    const password = document.getElementById('registerPassword')?.value;
+    const confirmPassword = document.getElementById('confirmPassword')?.value;
+
+    const messageBox = document.getElementById('formMessage');
+
+    // basic validation
+    if (!username || !email || !password) {
+      messageBox.innerText = 'All fields are required!';
+      messageBox.style.color = 'red';
+      return;
     }
 
-    btn.addEventListener("click", async (e) => {
-        e.preventDefault();
+    if (password.length < 8) {
+      messageBox.innerText = 'Password must be at least 8 characters long!';
+      messageBox.style.color = 'red';
+      return;
+    }
 
-        const username = document.getElementById("registerUsername")?.value.trim();
-        const email = document.getElementById("registerEmail")?.value.trim();
-        const password = document.getElementById("registerPassword")?.value.trim();
-        const confirmPassword = document.getElementById("confirmPassword")?.value.trim();
+    // Password complexity: at least one uppercase, one lowercase, one number, and one special character
+    const complexityRegex =
+      /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/;
+    if (!complexityRegex.test(password)) {
+      messageBox.innerText =
+        'Password must contain at least one uppercase letter, one lowercase letter, one number, and one special character!';
+      messageBox.style.color = 'red';
+      return;
+    }
+    if (password !== confirmPassword) {
+      messageBox.innerText = 'Passwords do not match!';
+      messageBox.style.color = 'red';
+      return;
+    }
 
-        const messageBox = document.getElementById("formMessage");
+    try {
+      const res = await fetch('/api/auth/register', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          username,
+          email,
+          password,
+        }),
+      });
 
-        // basic validation
-        if (!username || !email || !password) {
-            messageBox.innerText = "All fields are required!";
-            messageBox.style.color = "red";
-            return;
-        }
+      const data = await res.json();
 
-        if (password.length < 8) {
-            messageBox.innerText = "Password must be at least 8 characters long!";
-            messageBox.style.color = "red";
-            return;
-        }
+      if (!res.ok) {
+        throw new Error(data.detail || 'Registration failed');
+      }
 
-        // Password complexity: at least one uppercase, one lowercase, one number, and one special character
-        const complexityRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$/;
-        if (!complexityRegex.test(password)) {
-            messageBox.innerText = "Password must contain at least one uppercase letter, one lowercase letter, one number, and one special character!";
-            messageBox.style.color = "red";
-            return;
-        }
-        if (password !== confirmPassword) {
-            messageBox.innerText = "Passwords do not match!";
-            messageBox.style.color = "red";
-            return;
-        }
+      localStorage.setItem('token', data.access_token);
+      localStorage.setItem('user', JSON.stringify(data.user));
 
-        try {
-            const res = await fetch("/api/auth/register", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json"
-                },
-                body: JSON.stringify({
-                    username,
-                    email,
-                    password
-                })
-            });
+      messageBox.style.color = 'green';
+      messageBox.innerText = 'Account created successfully! Redirecting...';
 
-            const data = await res.json();
-
-            if (!res.ok) {
-                throw new Error(data.detail || "Registration failed");
-            }
-
-            localStorage.setItem("token", data.access_token);
-            localStorage.setItem("user", JSON.stringify(data.user));
-
-            messageBox.style.color = "green";
-            messageBox.innerText = "Account created successfully! Redirecting...";
-
-            setTimeout(() => {
-                window.location.href = "index.html";
-            }, 1200);
-
-        } catch (err) {
-            messageBox.style.color = "red";
-            messageBox.innerText = err.message;
-        }
-    });
+      setTimeout(() => {
+        window.location.href = 'index.html';
+      }, 1200);
+    } catch (err) {
+      messageBox.style.color = 'red';
+      messageBox.innerText = err.message;
+    }
+  });
 });

--- a/tests/unit/register-password-complexity.test.js
+++ b/tests/unit/register-password-complexity.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+
+// Mirrors the regex in register.js — keep in sync if the rule changes
+const complexityRegex =
+  /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/;
+
+describe('register.js password complexity regex', () => {
+  it('accepts a valid strong password', () => {
+    expect(complexityRegex.test('MyPass1@')).toBe(true);
+  });
+
+  it('accepts a longer valid password', () => {
+    expect(complexityRegex.test('StrongP4$$word')).toBe(true);
+  });
+
+  it('rejects a password with no uppercase letter', () => {
+    expect(complexityRegex.test('mypass1@')).toBe(false);
+  });
+
+  it('rejects a password with no lowercase letter', () => {
+    expect(complexityRegex.test('MYPASS1@')).toBe(false);
+  });
+
+  it('rejects a password with no digit', () => {
+    expect(complexityRegex.test('MyPass@@')).toBe(false);
+  });
+
+  it('rejects a password with no special character', () => {
+    expect(complexityRegex.test('MyPass12')).toBe(false);
+  });
+
+  it('rejects a password shorter than 8 characters', () => {
+    expect(complexityRegex.test('Mp1@')).toBe(false);
+  });
+
+  it('rejects an empty string', () => {
+    expect(complexityRegex.test('')).toBe(false);
+  });
+});


### PR DESCRIPTION
## 📄 Description

The password complexity regex in `register.js` used `\\d` inside a regex literal. In a JavaScript regex literal, `\\d` is a literal backslash followed by the letter `d` — not the digit metacharacter `\d`. This caused `complexityRegex.test()` to return `false` for every humanly-typeable password, permanently blocking client-side registration for all users.

Additionally, the password value was `.trim()`-ed before submission, silently stripping leading/trailing whitespace from passwords — a direct violation of NIST SP 800-63B which states passwords must not be modified prior to hashing.

**Changes:**
- `register.js`: `\\d` → `\d` in both the lookahead and character class inside the complexity regex
- `register.js`: Removed `.trim()` from `password` and `confirmPassword` field reads
- Added `tests/unit/register-password-complexity.test.js` with 8 test cases covering all complexity branches

**Verified in console:**
```js
// Broken (was in file):
/^(?=.*\\d).../.test('MyPass1@')  // false — always

// Fixed:
/^(?=.*\d).../.test('MyPass1@')   // true ✓
/^(?=.*\d).../.test('mypass1@')   // false ✓ (no uppercase)
/^(?=.*\d).../.test('MyPass@@')   // false ✓ (no digit)
```

## 🔗 Related Issues

Fixes #2304

## 🧩 Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## ✅ Checklist

- [x] I have searched existing issues and this is not a duplicate
- [x] Code follows project styling guidelines
- [x] Linter passes on changed files (`eslint register.js`)
- [x] Tests pass: `Test Files 2 passed (2) | Tests 12 passed (12)`
- [x] No extraneous logs or debug code left
- [x] Changes are tested in Chrome (Desktop)