### PR TITLE
fix: rewrite forgotPassword.js validation to fix broken control flow

### DIFF
--- a/forgotPassword.js
+++ b/forgotPassword.js
@@ -1,111 +1,129 @@
 /* ===== FORGOT PASSWORD JS ===== */
 
 document.addEventListener('DOMContentLoaded', function () {
-  if (!document.getElementById('forgotForm')) 
+  if (!document.getElementById('forgotForm')) return;
+
+  const toggleNewPass = document.getElementById('toggleNewPass');
+  if (toggleNewPass) {
+    toggleNewPass.addEventListener('click', function () {
+      const pwd = document.getElementById('forgotNewPass');
+      pwd.type = pwd.type === 'password' ? 'text' : 'password';
+      this.classList.toggle('ri-eye-line');
+      this.classList.toggle('ri-eye-off-line');
+    });
+  }
+
+  const toggleConfirmPass = document.getElementById('toggleConfirmPass');
+  if (toggleConfirmPass) {
+    toggleConfirmPass.addEventListener('click', function () {
+      const pwd = document.getElementById('forgotConfirmPass');
+      pwd.type = pwd.type === 'password' ? 'text' : 'password';
+      this.classList.toggle('ri-eye-line');
+      this.classList.toggle('ri-eye-off-line');
+    });
+  }
+
+  document
+    .getElementById('forgotForm')
+    .addEventListener('submit', function (e) {
+      e.preventDefault();
+
+      const email = document.getElementById('forgotEmail').value.trim();
+      const newPass = document.getElementById('forgotNewPass').value;
+      const confirmPass = document.getElementById('forgotConfirmPass').value;
+
+      /* validations — each check returns early so only one message shows at a time */
+      if (!email || !email.includes('@')) {
+        showToast('Please enter a valid email!', 'warning');
         return;
-
-const toggleNewPass = document.getElementById('toggleNewPass');
-if (toggleNewPass) toggleNewPass.addEventListener('click', function () {
-  const pwd = document.getElementById('forgotNewPass');
-  pwd.type = pwd.type === 'password' ? 'text' : 'password';
-  this.classList.toggle('ri-eye-line');
-  this.classList.toggle('ri-eye-off-line');
-});
-
-/* toggle confirm password visibility */
-document.getElementById('toggleConfirmPass').addEventListener('click', function () {
-  const pwd = document.getElementById('forgotConfirmPass');
-  pwd.type = pwd.type === 'password' ? 'text' : 'password';
-  this.classList.toggle('ri-eye-line');
-  this.classList.toggle('ri-eye-off-line');
-});
-
-/* form submit */
-document.getElementById('forgotForm').addEventListener('submit', function (e) {
-  e.preventDefault();
-
-  const email       = document.getElementById('forgotEmail').value.trim();
-  const newPass     = document.getElementById('forgotNewPass').value;
-  const confirmPass = document.getElementById('forgotConfirmPass').value;
-
-  /* validations */
-  if (!email || !email.includes('@')) {
-    showToast('Please enter a valid email!', 'warning');
-    return;
-  }
-
-  if (!newPass || newPass.length < 6) {
-    showToast('Password must be at least 6 characters!', 'warning');
-  if (/\s/.test(newPass)) {
-    showToast('Password must not contain spaces.', 'warning');
-    return;
-  }
-
-  if (!newPass || newPass.length < 8) {
-    showToast('Password must be at least 8 characters long.', 'warning');
-    return;
-  }
-
-  if (!/[A-Z]/.test(newPass)) {
-    showToast('Password must contain at least one uppercase letter (A-Z).', 'warning');
-    return;
-  }
-
-  if (!/[a-z]/.test(newPass)) {
-    showToast('Password must contain at least one lowercase letter (a-z).', 'warning');
-    return;
-  }
-
-  if (!/[0-9]/.test(newPass)) {
-    showToast('Password must contain at least one number (0-9).', 'warning');
-    return;
-  }
-
-  if (!/[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/.test(newPass)) {
-    showToast('Password must contain at least one special character (e.g. @, #, $).', 'warning');
-    return;
-  }
-
-  if (newPass !== confirmPass) {
-    showToast('Passwords do not match!', 'warning');
-    return;
-  }
-
-  /* ── Loading state: disable button & show spinner ── */
-  const submitBtn = document.querySelector('#forgotForm button[type="submit"], #forgotForm .btn-primary');
-  if (submitBtn) {
-    submitBtn.classList.add('btn-loading');
-    submitBtn.disabled = true;
-  }
-
-  /* Simulate async request */
-  setTimeout(function () {
-    /* check if email exists in localStorage */
-    let users = JSON.parse(localStorage.getItem('users') || '[]');
-    const userIndex = users.findIndex(u => u.email === email);
-
-    if (userIndex === -1) {
-      showToast('No account found with this email!', 'error');
-      /* Re-enable button on failure */
-      if (submitBtn) {
-        submitBtn.classList.remove('btn-loading');
-        submitBtn.disabled = false;
       }
-      return;
-    }
 
-    /* update password */
-    users[userIndex].password = await hashPassword(newPass); 
-    users[userIndex].password = newPass;
-    localStorage.setItem('users', JSON.stringify(users));
+      if (!newPass) {
+        showToast('Password is required.', 'warning');
+        return;
+      }
 
-    showToast('Password reset successful! Redirecting to login...', 'success');
+      if (/\s/.test(newPass)) {
+        showToast('Password must not contain spaces.', 'warning');
+        return;
+      }
 
-    /* redirect to login after success */
-    setTimeout(() => {
-      window.location.href = 'login.html';
-    }, 2000);
-  }, 1500);
+      if (newPass.length < 8) {
+        showToast('Password must be at least 8 characters long.', 'warning');
+        return;
+      }
+
+      if (!/[A-Z]/.test(newPass)) {
+        showToast(
+          'Password must contain at least one uppercase letter (A-Z).',
+          'warning'
+        );
+        return;
+      }
+
+      if (!/[a-z]/.test(newPass)) {
+        showToast(
+          'Password must contain at least one lowercase letter (a-z).',
+          'warning'
+        );
+        return;
+      }
+
+      if (!/[0-9]/.test(newPass)) {
+        showToast(
+          'Password must contain at least one number (0-9).',
+          'warning'
+        );
+        return;
+      }
+
+      if (!/[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]/.test(newPass)) {
+        showToast(
+          'Password must contain at least one special character (e.g. @, #, $).',
+          'warning'
+        );
+        return;
+      }
+
+      if (newPass !== confirmPass) {
+        showToast('Passwords do not match!', 'warning');
+        return;
+      }
+
+      /* ── Loading state: disable button & show spinner ── */
+      const submitBtn = document.querySelector(
+        '#forgotForm button[type="submit"], #forgotForm .btn-primary'
+      );
+      if (submitBtn) {
+        submitBtn.classList.add('btn-loading');
+        submitBtn.disabled = true;
+      }
+
+      /* Simulate async request */
+      setTimeout(function () {
+        const users = JSON.parse(localStorage.getItem('users') || '[]');
+        const userIndex = users.findIndex((u) => u.email === email);
+
+        if (userIndex === -1) {
+          showToast('No account found with this email!', 'error');
+          if (submitBtn) {
+            submitBtn.classList.remove('btn-loading');
+            submitBtn.disabled = false;
+          }
+          return;
+        }
+
+        users[userIndex].password = newPass;
+        localStorage.setItem('users', JSON.stringify(users));
+
+        showToast(
+          'Password reset successful! Redirecting to login...',
+          'success'
+        );
+
+        setTimeout(() => {
+          window.location.href = 'login.html';
+        }, 2000);
+      }, 1500);
+    });
 });
-});
-

--- a/tests/unit/forgot-password-validation.test.js
+++ b/tests/unit/forgot-password-validation.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+
+// Validation rules mirroring forgotPassword.js — kept in sync manually
+function validateForgotPassword(newPass, confirmPass) {
+  if (!newPass) return 'Password is required.';
+  if (/\s/.test(newPass)) return 'Password must not contain spaces.';
+  if (newPass.length < 8) return 'Password must be at least 8 characters long.';
+  if (!/[A-Z]/.test(newPass))
+    return 'Password must contain at least one uppercase letter (A-Z).';
+  if (!/[a-z]/.test(newPass))
+    return 'Password must contain at least one lowercase letter (a-z).';
+  if (!/[0-9]/.test(newPass))
+    return 'Password must contain at least one number (0-9).';
+  if (!/[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]/.test(newPass))
+    return 'Password must contain at least one special character (e.g. @, #, $).';
+  if (newPass !== confirmPass) return 'Passwords do not match!';
+  return null;
+}
+
+describe('forgotPassword.js validation logic', () => {
+  it('returns null for a valid password', () => {
+    expect(validateForgotPassword('MyPass1@', 'MyPass1@')).toBeNull();
+  });
+
+  it('rejects an empty password', () => {
+    expect(validateForgotPassword('', '')).toBe('Password is required.');
+  });
+
+  it('rejects a password with spaces', () => {
+    expect(validateForgotPassword('My Pass1@', 'My Pass1@')).toBe(
+      'Password must not contain spaces.'
+    );
+  });
+
+  it('rejects a password shorter than 8 characters', () => {
+    expect(validateForgotPassword('Mp1@', 'Mp1@')).toBe(
+      'Password must be at least 8 characters long.'
+    );
+  });
+
+  it('rejects a password with no uppercase letter', () => {
+    expect(validateForgotPassword('mypass1@', 'mypass1@')).toBe(
+      'Password must contain at least one uppercase letter (A-Z).'
+    );
+  });
+
+  it('rejects a password with no lowercase letter', () => {
+    expect(validateForgotPassword('MYPASS1@', 'MYPASS1@')).toBe(
+      'Password must contain at least one lowercase letter (a-z).'
+    );
+  });
+
+  it('rejects a password with no digit', () => {
+    expect(validateForgotPassword('MyPass@@', 'MyPass@@')).toBe(
+      'Password must contain at least one number (0-9).'
+    );
+  });
+
+  it('rejects a password with no special character', () => {
+    expect(validateForgotPassword('MyPass12', 'MyPass12')).toBe(
+      'Password must contain at least one special character (e.g. @, #, $).'
+    );
+  });
+
+  it('rejects mismatched confirm password', () => {
+    expect(validateForgotPassword('MyPass1@', 'MyPass1!')).toBe(
+      'Passwords do not match!'
+    );
+  });
+
+  it('space check runs before length check', () => {
+    // "ab cd" is 5 chars AND has a space — should report spaces, not length
+    expect(validateForgotPassword('ab cd', 'ab cd')).toBe(
+      'Password must not contain spaces.'
+    );
+  });
+});


### PR DESCRIPTION
## 📄 Description

The password validation block in `forgotPassword.js` had a structural defect — the opening `if (!newPass || newPass.length < 6)` check called `showToast` but had no closing `}` and no `return`. Every subsequent guard (space check, second length check, uppercase, etc.) was a sibling statement, not nested, despite the indentation suggesting otherwise.

**Result:** Submitting a short password fired a toast but execution fell through, triggering multiple toasts in the wrong order. Some edge cases allowed form submission to continue past failed checks.

**Additional issues fixed in the same block:**
- Dual conflicting minimum-length checks (`< 6` and `< 8`) — unified to 8 characters to match the registration form
- Dead code removed: `await hashPassword(newPass)` inside a non-`async` `setTimeout` callback whose result was immediately overwritten by a plaintext assignment on the next line
- Added null guard on `toggleConfirmPass` listener to prevent an uncaught throw if the element is absent

**Validation order is now deterministic:** empty → spaces → length → uppercase → lowercase → digit → special char → confirm match. Each check has exactly one early `return`.

## 🔗 Related Issues

Fixes #2305

## 🧩 Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## ✅ Checklist

- [x] I have searched existing issues and this is not a duplicate
- [x] Code follows project styling guidelines
- [x] Linter passes on changed files
- [x] Tests pass: `Test Files 2 passed (2) | Tests 14 passed (14)`
- [x] No extraneous logs or debug code left
- [x] Changes are tested in Chrome (Desktop)