### PR TITLE
fix: prevent setInterval leak from accumulating on repeated order lookups (track-order.js)

### DIFF
--- a/tests/unit/track-order-timer.test.js
+++ b/tests/unit/track-order-timer.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Isolate the timer management logic from the DOM-heavy module.
+// We test the invariant: at most one interval is active at any time.
+describe('track-order progress timer management', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('clears an existing interval before creating a new one', () => {
+    const clearSpy = vi.spyOn(globalThis, 'clearInterval');
+    const setSpy = vi.spyOn(globalThis, 'setInterval');
+
+    // Simulate what renderResult() does with the module-level progressTimer
+    let progressTimer = null;
+
+    function startProgressTimer() {
+      if (progressTimer !== null) {
+        clearInterval(progressTimer);
+        progressTimer = null;
+      }
+      progressTimer = setInterval(() => {}, 3000);
+      return progressTimer;
+    }
+
+    function stopProgressTimer() {
+      if (progressTimer !== null) {
+        clearInterval(progressTimer);
+        progressTimer = null;
+      }
+    }
+
+    // First lookup
+    startProgressTimer();
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    expect(clearSpy).not.toHaveBeenCalled();
+
+    // Second lookup without reset — must clear the first before creating a new one
+    startProgressTimer();
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+    expect(setSpy).toHaveBeenCalledTimes(2);
+
+    // Third lookup — again clears the previous
+    startProgressTimer();
+    expect(clearSpy).toHaveBeenCalledTimes(2);
+    expect(setSpy).toHaveBeenCalledTimes(3);
+
+    // After N lookups only one interval is active (the most recent)
+    stopProgressTimer();
+    expect(progressTimer).toBeNull();
+  });
+
+  it('resets progressTimer to null after clearing', () => {
+    let progressTimer = null;
+
+    progressTimer = setInterval(() => {}, 3000);
+    expect(progressTimer).not.toBeNull();
+
+    clearInterval(progressTimer);
+    progressTimer = null;
+
+    expect(progressTimer).toBeNull();
+  });
+
+  it('sets progressTimer to null when progress reaches 99', () => {
+    let progressTimer = null;
+    let currentPct = 98.9;
+
+    progressTimer = setInterval(() => {
+      if (currentPct < 99) {
+        currentPct += 0.5;
+      } else {
+        clearInterval(progressTimer);
+        progressTimer = null;
+      }
+    }, 3000);
+
+    // First tick: 98.9 + 0.5 = 99.4 (still incrementing, not yet in else branch)
+    // Second tick: 99.4 >= 99 → else branch fires clearInterval and sets null
+    vi.advanceTimersByTime(6000);
+    expect(progressTimer).toBeNull();
+    expect(currentPct).toBeGreaterThanOrEqual(99);
+  });
+});

--- a/track-order.js
+++ b/track-order.js
@@ -5,7 +5,7 @@
  */
 
 // ── Dynamic copyright year ────────────────────────────────
-const copyrightYearEl = document.getElementById("copyrightYear");
+const copyrightYearEl = document.getElementById('copyrightYear');
 if (copyrightYearEl) {
   copyrightYearEl.textContent = new Date().getFullYear();
 }
@@ -14,71 +14,96 @@ if (copyrightYearEl) {
 // In a real app this would be a backend API call.
 // We use a demo entry so reviewers can test the UI immediately.
 const MOCK_ORDERS = {
-  "CARA-20261234": {
-    id: "CARA-20261234",
-    date: "May 14, 2026",
-    carrier: "FedEx Express",
-    trackingNo: "7489 2091 3847",
-    estDelivery: "May 20, 2026",
-    status: "In Transit",          // "Processing" | "Packed" | "Shipped" | "In Transit" | "Delivered"
-    currentStep: "transit",        // ordered | packed | shipped | transit | delivered
-    location: "Chicago, IL",
+  'CARA-20261234': {
+    id: 'CARA-20261234',
+    date: 'May 14, 2026',
+    carrier: 'FedEx Express',
+    trackingNo: '7489 2091 3847',
+    estDelivery: 'May 20, 2026',
+    status: 'In Transit', // "Processing" | "Packed" | "Shipped" | "In Transit" | "Delivered"
+    currentStep: 'transit', // ordered | packed | shipped | transit | delivered
+    location: 'Chicago, IL',
     items: [
       {
-        name: "Cartoon Astronaut T-Shirt",
-        img: "images/products/f1.jpg",
-        size: "M",
+        name: 'Cartoon Astronaut T-Shirt',
+        img: 'images/products/f1.jpg',
+        size: 'M',
         qty: 1,
-        price: "$78.00",
+        price: '$78.00',
       },
       {
-        name: "Classic Hoodie",
-        img: "images/products/n2.jpg",
-        size: "L",
+        name: 'Classic Hoodie',
+        img: 'images/products/n2.jpg',
+        size: 'L',
         qty: 2,
-        price: "$156.00",
+        price: '$156.00',
       },
     ],
-    total: "$234.00",
+    total: '$234.00',
     timeline: {
-      ordered: { done: true,  date: "May 14, 2026 — 10:32 AM", note: "Your order has been confirmed and is being processed." },
-      packed:  { done: true,  date: "May 15, 2026 — 2:14 PM",  note: "Your items have been packed and are ready for pickup." },
-      shipped: { done: true,  date: "May 16, 2026 — 9:05 AM",  note: "Your package has been handed off to FedEx Express." },
-      transit: { done: false, date: "May 18, 2026 — 6:45 AM",  note: "Your package is on its way — currently in Chicago, IL.", active: true },
-      delivered:{ done: false,date: "Expected: May 20, 2026",   note: "Your package will be delivered to your door." },
+      ordered: {
+        done: true,
+        date: 'May 14, 2026 — 10:32 AM',
+        note: 'Your order has been confirmed and is being processed.',
+      },
+      packed: {
+        done: true,
+        date: 'May 15, 2026 — 2:14 PM',
+        note: 'Your items have been packed and are ready for pickup.',
+      },
+      shipped: {
+        done: true,
+        date: 'May 16, 2026 — 9:05 AM',
+        note: 'Your package has been handed off to FedEx Express.',
+      },
+      transit: {
+        done: false,
+        date: 'May 18, 2026 — 6:45 AM',
+        note: 'Your package is on its way — currently in Chicago, IL.',
+        active: true,
+      },
+      delivered: {
+        done: false,
+        date: 'Expected: May 20, 2026',
+        note: 'Your package will be delivered to your door.',
+      },
     },
   },
 };
 
 // ── DOM references ────────────────────────────────────────
-const form        = document.getElementById("trackOrderForm");
-const trackBtn    = document.getElementById("trackBtn");
-const btnLoader   = document.getElementById("btnLoader");
-const formCard    = document.querySelector(".track-form-card");
-const resultCard  = document.getElementById("trackResult");
-const errorCard   = document.getElementById("trackError");
+const form = document.getElementById('trackOrderForm');
+const trackBtn = document.getElementById('trackBtn');
+const btnLoader = document.getElementById('btnLoader');
+const formCard = document.querySelector('.track-form-card');
+const resultCard = document.getElementById('trackResult');
+const errorCard = document.getElementById('trackError');
+
+// ── Module-level timer reference so it can be cleared from any function ──
+let progressTimer = null;
 
 // ── Form submit handler ───────────────────────────────────
 if (form) {
-  form.addEventListener("submit", function (e) {
+  form.addEventListener('submit', function (e) {
     e.preventDefault();
 
-    const orderIdInput = document.getElementById("orderId");
-    const emailInput   = document.getElementById("orderEmail");
-    const orderIdRaw   = orderIdInput.value.trim().toUpperCase();
-    const emailRaw     = emailInput.value.trim().toLowerCase();
+    const orderIdInput = document.getElementById('orderId');
+    const emailInput = document.getElementById('orderEmail');
+    const orderIdRaw = orderIdInput.value.trim().toUpperCase();
+    const emailRaw = emailInput.value.trim().toLowerCase();
 
     // Reset previous validation visual states and message tags
-    document.querySelectorAll(".track-error-msg").forEach(el => el.remove());
-    orderIdInput.classList.remove("input-error");
-    emailInput.classList.remove("input-error");
+    document.querySelectorAll('.track-error-msg').forEach((el) => el.remove());
+    orderIdInput.classList.remove('input-error');
+    emailInput.classList.remove('input-error');
 
     function showTrackError(inputElement, msgText) {
-      const errorMsg = document.createElement("small");
-      errorMsg.className = "track-error-msg";
-      errorMsg.style.cssText = "color: #ef4444; display: block; margin-top: 4px; font-weight: 600;";
+      const errorMsg = document.createElement('small');
+      errorMsg.className = 'track-error-msg';
+      errorMsg.style.cssText =
+        'color: #ef4444; display: block; margin-top: 4px; font-weight: 600;';
       errorMsg.textContent = msgText;
-      inputElement.classList.add("input-error");
+      inputElement.classList.add('input-error');
       inputElement.parentNode.insertBefore(errorMsg, inputElement.nextSibling);
     }
 
@@ -86,18 +111,21 @@ if (form) {
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
     if (!orderIdRaw) {
-      showTrackError(orderIdInput, "Order ID is required");
+      showTrackError(orderIdInput, 'Order ID is required');
       isTrackValid = false;
     } else if (!/^CARA-\d+$/.test(orderIdRaw)) {
-      showTrackError(orderIdInput, "Invalid Format. Pattern should be CARA-XXXXXXXX (e.g. CARA-20261234)");
+      showTrackError(
+        orderIdInput,
+        'Invalid Format. Pattern should be CARA-XXXXXXXX (e.g. CARA-20261234)'
+      );
       isTrackValid = false;
     }
 
     if (!emailRaw) {
-      showTrackError(emailInput, "Email is required");
+      showTrackError(emailInput, 'Email is required');
       isTrackValid = false;
     } else if (!emailRegex.test(emailRaw)) {
-      showTrackError(emailInput, "Please enter a valid email address");
+      showTrackError(emailInput, 'Please enter a valid email address');
       isTrackValid = false;
     }
 
@@ -123,10 +151,10 @@ if (form) {
 // ── Set loading state on button ───────────────────────────
 function setLoading(isLoading) {
   if (isLoading) {
-    trackBtn.classList.add("loading");
+    trackBtn.classList.add('loading');
     trackBtn.disabled = true;
   } else {
-    trackBtn.classList.remove("loading");
+    trackBtn.classList.remove('loading');
     trackBtn.disabled = false;
   }
 }
@@ -134,32 +162,33 @@ function setLoading(isLoading) {
 // ── Render the result card ────────────────────────────────
 function renderResult(order) {
   // Save order tracking parameters to localStorage for history retention
-  localStorage.setItem("cara_last_tracked_id", order.id);
-  const emailInput = document.getElementById("orderEmail");
+  localStorage.setItem('cara_last_tracked_id', order.id);
+  const emailInput = document.getElementById('orderEmail');
   if (emailInput) {
-    localStorage.setItem("cara_last_tracked_email", emailInput.value.trim());
+    localStorage.setItem('cara_last_tracked_email', emailInput.value.trim());
   }
 
   // Populate header
-  document.getElementById("resultOrderId").textContent = order.id;
-  document.getElementById("statusText").textContent    = order.status;
-  document.getElementById("orderDate").textContent     = order.date;
-  document.getElementById("orderCarrier").textContent  = order.carrier;
-  document.getElementById("trackingNo").textContent    = order.trackingNo;
-  document.getElementById("estDelivery").textContent   = order.estDelivery;
+  document.getElementById('resultOrderId').textContent = order.id;
+  document.getElementById('statusText').textContent = order.status;
+  document.getElementById('orderDate').textContent = order.date;
+  document.getElementById('orderCarrier').textContent = order.carrier;
+  document.getElementById('trackingNo').textContent = order.trackingNo;
+  document.getElementById('estDelivery').textContent = order.estDelivery;
 
   // Status badge colour
-  const badge = document.getElementById("statusBadge");
-  badge.className = "order-status-badge";
-  if (order.status === "Delivered") badge.classList.add("delivered");
-  if (order.status === "In Transit") badge.classList.add("in-transit");
+  const badge = document.getElementById('statusBadge');
+  badge.className = 'order-status-badge';
+  if (order.status === 'Delivered') badge.classList.add('delivered');
+  if (order.status === 'In Transit') badge.classList.add('in-transit');
 
   // Dynamic live progress bar tracker (Simulated Distance Cover)
-  let liveContainer = document.getElementById("liveProgressBarWrap");
+  let liveContainer = document.getElementById('liveProgressBarWrap');
   if (!liveContainer) {
-    liveContainer = document.createElement("div");
-    liveContainer.id = "liveProgressBarWrap";
-    liveContainer.style.cssText = "background: rgba(8, 129, 120, 0.08); padding: 15px; border-radius: 8px; margin-bottom: 25px; border: 1px solid rgba(8, 129, 120, 0.15);";
+    liveContainer = document.createElement('div');
+    liveContainer.id = 'liveProgressBarWrap';
+    liveContainer.style.cssText =
+      'background: rgba(8, 129, 120, 0.08); padding: 15px; border-radius: 8px; margin-bottom: 25px; border: 1px solid rgba(8, 129, 120, 0.15);';
     liveContainer.innerHTML = `
       <div style="display: flex; justify-content: space-between; font-size: 12px; margin-bottom: 6px; font-weight: 600; color: #088178;">
         <span>Simulated Delivery Progress</span>
@@ -170,51 +199,59 @@ function renderResult(order) {
       </div>
       <span style="display: block; font-size: 11px; color: #666; margin-top: 6px; font-style: italic;">Live simulated parcel dispatch tracing active...</span>
     `;
-    const detailsWrap = document.querySelector(".result-grid");
-    if (detailsWrap) detailsWrap.parentNode.insertBefore(liveContainer, detailsWrap);
+    const detailsWrap = document.querySelector('.result-grid');
+    if (detailsWrap)
+      detailsWrap.parentNode.insertBefore(liveContainer, detailsWrap);
   }
 
-  // Animate simulated progress bar dynamically
+  // Animate simulated progress bar dynamically.
+  // Clear any existing timer first so repeated lookups don't stack intervals.
+  if (progressTimer !== null) {
+    clearInterval(progressTimer);
+    progressTimer = null;
+  }
   let currentPct = 62;
-  const progressTimer = setInterval(() => {
+  progressTimer = setInterval(() => {
     if (currentPct < 99) {
-      currentPct += (Math.random() * 0.5 + 0.1);
-      const bar = document.getElementById("liveProgressBar");
-      const label = document.getElementById("liveProgressPercent");
-      if (bar) bar.style.width = currentPct.toFixed(1) + "%";
-      if (label) label.textContent = currentPct.toFixed(1) + "%";
+      currentPct += Math.random() * 0.5 + 0.1;
+      const bar = document.getElementById('liveProgressBar');
+      const label = document.getElementById('liveProgressPercent');
+      if (bar) bar.style.width = currentPct.toFixed(1) + '%';
+      if (label) label.textContent = currentPct.toFixed(1) + '%';
     } else {
       clearInterval(progressTimer);
+      progressTimer = null;
     }
   }, 3000);
 
   // Populate timeline
-  const steps = ["ordered", "packed", "shipped", "transit", "delivered"];
+  const steps = ['ordered', 'packed', 'shipped', 'transit', 'delivered'];
   steps.forEach(function (key) {
-    const stepEl = document.getElementById("step-" + key);
+    const stepEl = document.getElementById('step-' + key);
     if (!stepEl) return;
 
     const stepData = order.timeline[key];
-    stepEl.classList.remove("completed", "active");
+    stepEl.classList.remove('completed', 'active');
 
     if (stepData.active) {
-      stepEl.classList.add("active");
+      stepEl.classList.add('active');
     } else if (stepData.done) {
-      stepEl.classList.add("completed");
+      stepEl.classList.add('completed');
     }
 
     // Update text
-    const pEl   = stepEl.querySelector(".step-content p");
-    const timeEl = stepEl.querySelector(".step-content time");
-    if (pEl)    pEl.textContent   = stepData.note;
+    const pEl = stepEl.querySelector('.step-content p');
+    const timeEl = stepEl.querySelector('.step-content time');
+    if (pEl) pEl.textContent = stepData.note;
     if (timeEl) timeEl.textContent = stepData.date;
   });
 
   // Populate order items
-  const itemsList = document.getElementById("orderItemsList");
+  const itemsList = document.getElementById('orderItemsList');
   if (itemsList && order.items) {
-    itemsList.innerHTML = order.items.map(function (item) {
-      return `
+    itemsList.innerHTML = order.items
+      .map(function (item) {
+        return `
         <div class="order-item">
           <img src="${item.img}" alt="${item.name}" loading="lazy" />
           <div class="item-info">
@@ -224,77 +261,92 @@ function renderResult(order) {
           <span class="item-price">${item.price}</span>
         </div>
       `;
-    }).join("");
+      })
+      .join('');
 
     // Update total
-    const totalEl = document.querySelector(".order-total-row strong");
+    const totalEl = document.querySelector('.order-total-row strong');
     if (totalEl) totalEl.textContent = order.total;
   }
 
   // Hide form, show result
   hideAll();
-  resultCard.style.display = "block";
-  resultCard.scrollIntoView({ behavior: "smooth", block: "start" });
+  resultCard.style.display = 'block';
+  resultCard.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
 
 // Auto-fill tracked order from localStorage if available
-document.addEventListener("DOMContentLoaded", () => {
-  const cachedId = localStorage.getItem("cara_last_tracked_id");
-  const cachedEmail = localStorage.getItem("cara_last_tracked_email");
-  if (cachedId && document.getElementById("orderId")) {
-    document.getElementById("orderId").value = cachedId;
+document.addEventListener('DOMContentLoaded', () => {
+  const cachedId = localStorage.getItem('cara_last_tracked_id');
+  const cachedEmail = localStorage.getItem('cara_last_tracked_email');
+  if (cachedId && document.getElementById('orderId')) {
+    document.getElementById('orderId').value = cachedId;
   }
-  if (cachedEmail && document.getElementById("orderEmail")) {
-    document.getElementById("orderEmail").value = cachedEmail;
+  if (cachedEmail && document.getElementById('orderEmail')) {
+    document.getElementById('orderEmail').value = cachedEmail;
   }
 });
 
 // ── Show error card ───────────────────────────────────────
 function showError() {
   hideAll();
-  errorCard.style.display = "block";
-  errorCard.scrollIntoView({ behavior: "smooth", block: "start" });
+  errorCard.style.display = 'block';
+  errorCard.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
 
 // ── Hide all panels ───────────────────────────────────────
 function hideAll() {
-  formCard.style.display   = "none";
-  resultCard.style.display = "none";
-  errorCard.style.display  = "none";
+  formCard.style.display = 'none';
+  resultCard.style.display = 'none';
+  errorCard.style.display = 'none';
 }
 
 // ── Reset back to the search form ─────────────────────────
 function resetTracker() {
-  formCard.style.display   = "block";
-  resultCard.style.display = "none";
-  errorCard.style.display  = "none";
+  // Stop the progress bar animation before leaving the result view
+  if (progressTimer !== null) {
+    clearInterval(progressTimer);
+    progressTimer = null;
+  }
+
+  formCard.style.display = 'block';
+  resultCard.style.display = 'none';
+  errorCard.style.display = 'none';
 
   // Clear fields
-  const orderIdInput = document.getElementById("orderId");
-  const emailInput   = document.getElementById("orderEmail");
-  if (orderIdInput) orderIdInput.value = "";
-  if (emailInput)   emailInput.value   = "";
+  const orderIdInput = document.getElementById('orderId');
+  const emailInput = document.getElementById('orderEmail');
+  if (orderIdInput) orderIdInput.value = '';
+  if (emailInput) emailInput.value = '';
 
-  formCard.scrollIntoView({ behavior: "smooth", block: "start" });
+  formCard.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
 
 // ── FAQ accordion ─────────────────────────────────────────
 function toggleFaq(questionEl) {
   const answerEl = questionEl.nextElementSibling;
-  const isOpen   = questionEl.classList.contains("open");
+  const isOpen = questionEl.classList.contains('open');
 
   // Close all first
-  document.querySelectorAll(".faq-question").forEach(function (q) {
-    q.classList.remove("open");
+  document.querySelectorAll('.faq-question').forEach(function (q) {
+    q.classList.remove('open');
     const a = q.nextElementSibling;
-    if (a) a.classList.remove("open");
+    if (a) a.classList.remove('open');
   });
 
   // If it was closed, open it
   if (!isOpen) {
-    questionEl.classList.add("open");
-    if (answerEl) answerEl.classList.add("open");
+    questionEl.classList.add('open');
+    if (answerEl) answerEl.classList.add('open');
   }
 }
+
+// ── Cleanup on page unload ────────────────────────────────
+window.addEventListener('beforeunload', function () {
+  if (progressTimer !== null) {
+    clearInterval(progressTimer);
+    progressTimer = null;
+  }
+});
 
 // Timeline animator simulating transitions through shipping progress milestones.


### PR DESCRIPTION
## 📄 Description

`renderResult()` in `track-order.js` created a `setInterval` for the progress bar animation using `const progressTimer` scoped inside the function. Because `progressTimer` was locally scoped, `resetTracker()` had no reference to it and could never cancel it.

Every time the user clicked "Track Another Order" and submitted again, a new interval was spawned while the previous one kept running. After N lookups: N independent intervals all writing to `#liveProgressBar` every 3 seconds simultaneously, causing jittery/competing updates and wasting resources indefinitely.

**Changes in `track-order.js`:**
- Hoisted `progressTimer` to module scope as `let progressTimer = null`
- Added clear-before-create guard at the top of the animation block in `renderResult()` — at most one interval is ever active
- Added `clearInterval(progressTimer)` at the top of `resetTracker()` so animation stops when the user navigates back to the form
- Added `beforeunload` listener to clean up on page navigation
- Set `progressTimer = null` after every `clearInterval` call to keep the null check reliable

## 🔗 Related Issues

Fixes #2306

## 🧩 Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## ✅ Checklist

- [x] I have searched existing issues and this is not a duplicate
- [x] Code follows project styling guidelines
- [x] Linter passes on changed files
- [x] Tests pass: `Test Files 2 passed (2) | Tests 7 passed (7)`
- [x] No extraneous logs or debug code left
- [x] Changes are tested in Chrome (Desktop) — verified single interval active after multiple lookups