### PR TITLE
Use sessionStorage instead of localStorage for JWT tokens

### DIFF
--- a/login.js
+++ b/login.js
@@ -187,7 +187,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 );
             }
 
-            localStorage.setItem(
+            sessionStorage.setItem(
                 'token',
                 data.access_token
             );

--- a/register.js
+++ b/register.js
@@ -62,7 +62,7 @@ document.addEventListener('DOMContentLoaded', () => {
         throw new Error(data.detail || 'Registration failed');
       }
 
-      localStorage.setItem('token', data.access_token);
+      sessionStorage.setItem('token', data.access_token);
       localStorage.setItem('user', JSON.stringify(data.user));
 
       messageBox.style.color = 'green';


### PR DESCRIPTION
This PR improves frontend security by migrating the storage of JWT access tokens from localStorage to sessionStorage in both login.js and register.js. This helps mitigate the risk of persistent Cross-Site Scripting (XSS) token theft.

Fixes #2317
