### PR TITLE
Add local linting troubleshooting instructions to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,8 @@ Made with ❤️ by [Janavi Pandole](https://github.com/janavipandole)
 </div>
 
 
-<!-- TODO: Add local linting troubleshooting instructions -->
+### Linting Troubleshooting
+If you encounter issues when running `npm run lint` or `eslint` locally, ensure you have run `npm install` to install all necessary dependencies. Common errors might stem from mismatched Node versions; this project recommends Node.js v16 or above. You can automatically fix simple formatting issues by running `npm run lint -- --fix` or `npx eslint . --fix`.
 
 
 <!-- Setup guidelines including package-lock node_modules cleanup directives. -->


### PR DESCRIPTION
This PR updates the README.md to include a new "Linting Troubleshooting" section. It guides developers on how to properly install dependencies, run eslint, and use the --fix flag, addressing the TODO found in the documentation.

Fixes #2318
