### PR TITLE
Restrict recommendation limit to a maximum of 20

### DIFF
--- a/backend/app/api/recommendation.py
+++ b/backend/app/api/recommendation.py
@@ -33,7 +33,8 @@ def recommend_outfit(request: Request, req: schemas.RecommendationRequest, db: S
     # personalization_tracker.rerank(req.user_id, filtered_candidates)
     
     # Limit results
-    return filtered_candidates[:req.limit]
+  limit = max(1, min(req.limit, 20))
+return filtered_candidates[:limit]
 
 @router.post("/feedback")
 @limiter.limit("30/minute")


### PR DESCRIPTION
Added validation for recommendation result limits to prevent negative values and excessively large requests from producing unexpected responses.

