### PR TITLE
fix(security): require authentication to place orders and enforce tok…

### DIFF
--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -2,11 +2,16 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from .. import models, schemas
 from ..database import get_db
+from .auth import get_current_user
 
 router = APIRouter()
 
 @router.post("/", status_code=201)
-def create_order(order_data: schemas.OrderCreate, db: Session = Depends(get_db)):
+def create_order(
+    order_data: schemas.OrderCreate, 
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user)
+):
     subtotal = 0.0
     db_items = []
     
@@ -36,7 +41,7 @@ def create_order(order_data: schemas.OrderCreate, db: Session = Depends(get_db))
     
     new_order = models.Order(
         full_name=order_data.fullName,
-        email=order_data.email,
+        email=current_user.email,  # Force email to match authenticated user
         address=order_data.address,
         city=order_data.city,
         zip_code=order_data.zip,


### PR DESCRIPTION
## Description
Resolves **Issue #2356** (Unauthenticated Order Placement).

The `/api/orders` endpoint previously lacked authorization controls, allowing anonymous unauthenticated users to create arbitrary database records. Furthermore, the endpoint trusted the email provided in the JSON payload, exposing the system to identity spoofing.

This PR implements strict access control and enforces zero-trust identity mapping.

## Changes Made
- **Access Control Layer**: Injected the `get_current_user` JWT authorization dependency into the `create_order` route, immediately blocking anonymous requests with a `401 Unauthorized`.
- **Identity Enforcement**: The `Order` model instantiation now ignores `order_data.email` and directly maps `current_user.email` to the order, preventing malicious users from spoofing orders under other accounts.

## Type of Change
- [x] Security Fix
- [x] Data Integrity
