### PR TITLE
fix: safe check products array in refreshWishlistPrices (#2377)

### DIFF
--- a/app.js
+++ b/app.js
@@ -241,7 +241,7 @@ function refreshWishlistPrices(items) {
     if (!Array.isArray(items) || typeof products === "undefined") return items;
 
     let changed = false;
-    const catalog = products;
+    const catalog = typeof products !== "undefined" ? products : [];
 
     const updated = items.map((item) => {
         const normalized = normalizeWishlistItem(item);
@@ -1770,3 +1770,4 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 })();
 /* --- END: PRODUCT QUICK-VIEW MODAL FUNCTIONALITY --- */
+


### PR DESCRIPTION
Fixes #2377.

This PR ensures the script does not crash if the `products.js` catalog file fails to load or load out of order.

**Changes Included:**
- Modified `refreshWishlistPrices` to safely evaluate `typeof products` instead of unsafely grabbing a potentially undefined global variable.
