### PR TITLE
feat: add fallback UI for product fetch failures (#2378)

### DIFF
--- a/app.js
+++ b/app.js
@@ -87,7 +87,7 @@ document.addEventListener("DOMContentLoaded", async () => {
                     smallImgs[0].src = finalImage;
                 }
             } catch (error) {
-                console.error("Error fetching product details:", error);
+                console.error("Error fetching product details:", error); if(document.getElementById("product-name")) document.getElementById("product-name").textContent = "Unable to load product";
             }
         }
 
@@ -1770,3 +1770,4 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 })();
 /* --- END: PRODUCT QUICK-VIEW MODAL FUNCTIONALITY --- */
+


### PR DESCRIPTION
Fixes #2378.

This PR introduces a graceful error state on the single product page if the backend `/api/products` is unavailable.

**Changes Included:**
- Injected DOM updates to show an "Unable to load product" message so the user isn't left staring at a broken UI.
