### PR TITLE
fix: handleAddToCart missing MainImg on listing pages (#2374)

### DIFF
--- a/app.js
+++ b/app.js
@@ -582,7 +582,7 @@ window.handleAddToCart = function () {
     const priceElement    = document.getElementById("product-price");
     const sizeSelect      = document.getElementById("product-size");
     const quantityInput   = document.getElementById("product-quantity");
-    const imageElement    = document.getElementById("MainImg");
+    const imageElement = document.getElementById("MainImg") || document.querySelector(".pro-img-wrap img");
 
     if (!nameElement || !priceElement || !sizeSelect || !quantityInput || !imageElement) {
         console.error("Missing product elements on page.");
@@ -1770,3 +1770,4 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 })();
 /* --- END: PRODUCT QUICK-VIEW MODAL FUNCTIONALITY --- */
+


### PR DESCRIPTION
Fixes #2374.

This PR fixes an issue where attempting to add a product to the cart from a standard listing page (like `shop.html`) would crash the script due to the missing `#MainImg` container.

**Changes Included:**
- Added a fallback in `handleAddToCart` to look for the image inside `.pro-img-wrap img` when `#MainImg` is not found in the DOM.
