### PR TITLE
fix: scope updateQty to specific elements (#2373)

### DIFF
--- a/app.js
+++ b/app.js
@@ -557,8 +557,8 @@ function dismissToast(toast) {
     toast.addEventListener("animationend", function () { toast.remove(); });
 }
 
-window.updateQty = function (change) {
-    let quantityElement = document.querySelector(".qty"); // check class
+window.updateQty = function (element, change) {
+    let quantityElement = element ? element.parentElement.querySelector(".qty") : document.querySelector(".qty");
     let quantity = parseInt(quantityElement.textContent);
 
     quantity += change;
@@ -1770,3 +1770,4 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 })();
 /* --- END: PRODUCT QUICK-VIEW MODAL FUNCTIONALITY --- */
+


### PR DESCRIPTION
Fixes #2373.

This PR resolves an issue where the quantity update button would only ever target the first item on the screen due to an overly broad DOM query.

**Changes Included:**
- Scoped the `document.querySelector(".qty")` lookup relative to the specific element being clicked so multiple items on a page work independently.
