### PR TITLE
Fix: Remove insecure hardcoded fallback secret key (Issue #2393)

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -20,7 +20,7 @@ from collections import OrderedDict
 failed_login_attempts = OrderedDict()
 MAX_TRACKED_EMAILS = 1000
 
-SECRET_KEY = os.environ.get("SECRET_KEY", "fallback_secret_key_for_dev")
+SECRET_KEY = os.environ.get("SECRET_KEY")
 if not SECRET_KEY:
     raise RuntimeError(
         "SECRET_KEY environment variable is not set. "


### PR DESCRIPTION
Fixes #2393

### Description
This pull request resolves a critical security vulnerability where the JWT `SECRET_KEY` would silently fall back to an insecure, hardcoded string (`fallback_secret_key_for_dev`) instead of throwing an error if the environment variable was missing.

**Changes Include:**
- Removed the hardcoded fallback from `os.environ.get("SECRET_KEY")`.
- Ensured the server will properly crash on startup with a clear `RuntimeError` if deployed to production without the `SECRET_KEY` securely configured in the environment.

### Testing Instructions
1. Run the backend server without `SECRET_KEY` set in the `.env` file. It should immediately crash with a `RuntimeError`.
2. Add `SECRET_KEY=my_secure_random_string` to the `.env` file or export it in the terminal.
3. Start the backend server and verify it runs successfully.
