### PR TITLE
Fix: Enforce strict server-side password validation (Issue #2394)

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -70,8 +70,10 @@ class UserRegister(BaseModel):
             raise ValueError("Password must contain at least one uppercase letter.")
         if not re.search(r"\d", v):
             raise ValueError("Password must contain at least one digit.")
-        if not re.search(r"[!@#$%^&*(),.?\":{}|<>]", v):
-            raise ValueError("Password must contain at least one special character.")
+        if not re.search(r"[@$!%*?&]", v):
+            raise ValueError("Password must contain at least one special character (@$!%*?&).")
+        if not re.match(r"^[A-Za-z\d@$!%*?&]{8,}$", v):
+            raise ValueError("Password contains invalid characters. Only letters, numbers, and @$!%*?& are allowed.")
         return v
 
 


### PR DESCRIPTION
Fixes #2394

### Description
This pull request strengthens the server-side password validation logic in the `UserRegister` Pydantic schema to strictly align with the frontend validation requirements.

**Changes Include:**
- Updated the Pydantic `@field_validator` to enforce the exact same character whitelist and complexity rules (`@$!%*?&`) as the frontend registration form.
- Added strict regex matching to prevent the injection of unsupported characters that could previously bypass the backend despite failing client-side checks.

### Testing Instructions
1. Attempt to register via the API (using curl or Postman) with a password lacking a special character, uppercase letter, or number. Verify it returns a `422 Unprocessable Entity` error.
2. Attempt to register with valid credentials and verify success.
