### PR TITLE
Fix: Add inventory stock checking and deduction to orders (Issue #2395)

### DIFF
--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -25,6 +25,14 @@ def create_order(
                 status_code=400,
                 detail=f"Product not found: {item.product_name}"
             )
+            
+        if db_product.stock < item.quantity:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Insufficient stock for product: {item.product_name}"
+            )
+
+        db_product.stock -= item.quantity
 
         real_price = db_product.price
         subtotal += real_price * item.quantity


### PR DESCRIPTION
Fixes #2395

### Description
This pull request resolves a critical business logic flaw where the checkout process failed to verify product inventory or deduct purchased quantities.

**Changes Include:**
- Added a validation step during `create_order` to verify that `db_product.stock` is sufficient for the requested `item.quantity`.
- Automatically deducts the purchased quantity from the `Product.stock` upon successful order creation to prevent negative inventory balances.
- Throws a `400 Bad Request` if a user attempts to purchase more units than are currently available in stock.

### Testing Instructions
1. Check the stock of a product (e.g., defaults to 10 units).
2. Attempt to purchase 15 units of that product. Verify it fails with an "Insufficient stock" error.
3. Purchase 2 units. Verify the order succeeds and the product stock is permanently reduced by 2.
