### PR TITLE
Fix: Mitigate cache padding bypass in authentication rate limiting (I…

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -181,13 +181,15 @@ def login(request: Request, response: Response, payload: UserLogin, db: Session 
     user = db.query(models.User).filter(models.User.email == payload.email).first()
 
     if not user or not pwd.verify(payload.password, user.hashed_password):
-        # Update attempts and move to end (Most Recently Used)
-        failed_login_attempts[payload.email] = attempts + 1
-        failed_login_attempts.move_to_end(payload.email)
-        
-        # Enforce LRU bounds to prevent memory leaks from massive bot networks
-        if len(failed_login_attempts) > MAX_TRACKED_EMAILS:
-            failed_login_attempts.popitem(last=False)
+        # Only track failed attempts for valid emails to prevent botnets from 
+        # flushing the LRU cache with random dummy emails (cache padding attack).
+        if user:
+            failed_login_attempts[payload.email] = attempts + 1
+            failed_login_attempts.move_to_end(payload.email)
+            
+            # Enforce LRU bounds to prevent memory leaks from massive bot networks
+            if len(failed_login_attempts) > MAX_TRACKED_EMAILS:
+                failed_login_attempts.popitem(last=False)
             
         raise HTTPException(401, "Invalid email or password.")
 


### PR DESCRIPTION
Fixes #2396

### Description
This pull request resolves a security vulnerability where the in-memory brute-force protection (Captcha) could be entirely bypassed. Previously, an attacker could perform a "cache padding" attack by sending 1,000 dummy login attempts for non-existent emails. This would forcefully evict the targeted victim's email from the `failed_login_attempts` LRU dictionary, effectively resetting their failed attempt counter and allowing infinite password guesses.

**Changes Include:**
- Modified the `/login` endpoint to only track failed attempts in the LRU cache if the provided email actually exists in the database.
- This prevents botnets from flushing the cache with generated/dummy emails, forcing them to cycle through 1,000 *valid* registered accounts to trigger a single eviction—making the attack mathematically impractical.

### Testing Instructions
1. Attempt to login with a valid email but incorrect password twice. Verify the second attempt demands a Captcha.
2. Send 1,005 dummy login attempts with randomly generated non-existent emails.
3. Attempt to login with the valid email and incorrect password again. Verify it *still* demands a Captcha (the cache was not flushed).
