### PR TITLE
fix: add null guard to register.js to prevent TypeError (closes #818)

### DIFF
--- a/Cara-main/register.js
+++ b/Cara-main/register.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', function () {
     const form = document.getElementById('registerForm');
+        if (!form) return;
     form.addEventListener('submit', function (e) {
         e.preventDefault();
         const name = document.getElementById('registerUsername').value.trim();


### PR DESCRIPTION
Fixes #818

## Summary

`register.js` was calling `form.addEventListener()` immediately after `getElementById` with no null check. This crashes with `TypeError` when loaded on any page without `#registerForm`.

## Changes
- Added `if (!form) return;` guard after form selection, matching the pattern already used in `login.js`