### PR TITLE
fix: correct indentation error in OrderItem model

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -56,11 +56,11 @@ class Order(Base):
 class OrderItem(Base):
     __tablename__ = "order_items"
     id = Column(Integer, primary_key=True, index=True)
-   order_id = Column(
-    Integer,
-    ForeignKey("orders.id"),
-    nullable=False
-)
+    order_id = Column(
+        Integer,
+        ForeignKey("orders.id"),
+        nullable=False
+    )
     product_name = Column(String, nullable=False)
     quantity = Column(Integer, nullable=False)
     price = Column(Float, nullable=False)


### PR DESCRIPTION
# Related Issue
Closes #2435

# Summary
Fixes the IndentationError in the OrderItem model class.

# Changes Made
- Indented `order_id` with 4 spaces in `backend/app/models.py`.

# Testing
- Ran `python -m pytest` to confirm tests run successfully.
