### PR TITLE
fix: remove duplicate nested get_products endpoint definition

### DIFF
--- a/backend/app/api/products.py
+++ b/backend/app/api/products.py
@@ -7,14 +7,12 @@ from ..database import get_db
 router = APIRouter()
 
 @router.get("/", response_model=List[schemas.Product])
-def get_products(db: Session = Depends(get_db)):
-    def get_products(
+def get_products(
     skip: int = 0,
     limit: int = 50,
     db: Session = Depends(get_db)
 ):
     return db.query(models.Product).offset(skip).limit(limit).all()
-    return products
 
 @router.get("/{product_id}", response_model=schemas.Product)
 def get_product(product_id: int, db: Session = Depends(get_db)):


### PR DESCRIPTION
# Related Issue
Closes #2437

# Summary
Removes the redundant inner `get_products` definition from `backend/app/api/products.py`.

# Changes Made
- Refactored the GET `/` route handler for products to be a single, flat function.

# Testing
- Verified through backend unit tests for products retrieval.
