### PR TITLE
fix: correct indentation in recommend_outfit route

### DIFF
--- a/backend/app/api/recommendation.py
+++ b/backend/app/api/recommendation.py
@@ -38,8 +38,8 @@ def recommend_outfit(request: Request, req: schemas.RecommendationRequest, db: S
     # personalization_tracker.rerank(req.user_id, filtered_candidates)
     
     # Limit results
-  limit = max(1, min(req.limit, 20))
-return filtered_candidates[:limit]
+    limit = max(1, min(req.limit, 20))
+    return filtered_candidates[:limit]
 
 @router.post("/feedback")
 @limiter.limit("30/minute")


### PR DESCRIPTION
# Related Issue
Closes #2439 
# Summary
Aligns the indentation of the return statement in the `recommend_outfit` endpoint.
# Changes Made
- Indented lines 41 and 42 with 4 spaces in `backend/app/api/recommendation.py`.
# Testing
- Verified recommendations unit tests run successfully.