### PR TITLE
feat: add PR title conventional commit validator workflow

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,29 @@
+name: PR Title Quality Lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  lint:
+    name: Lint PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate Conventional Commits Title
+        uses: amannn/action-semantic-pull-request@v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false


### PR DESCRIPTION
# Related Issue
Closes #2443

# Summary
Adds a GitHub Actions workflow to lint incoming PR titles.

# Changes Made
- Created `.github/workflows/pr-lint.yml`.

# Testing
- Checked workflow syntax validity.
