### PR TITLE
Add missing aria-label attributes to icon-only buttons

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -540,7 +540,7 @@ button + button {
   <div class="empty-cart-card">
     
     <div class="empty-cart-icon">
-      <i class="ri-shopping-cart-2-line"></i>
+      <i class="ri-shopping-cart-2-line" aria-label="Cart"></i>
     </div>
     
     <h2>Your Cart is Empty!</h2>

--- a/crazy-deals.html
+++ b/crazy-deals.html
@@ -244,7 +244,7 @@
             </h4>
             <div class="pro-action-bar">
              <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="event.stopPropagation(); buyNow('Cartoon Astronaut T-Shirts','₹1,249','images/products/f1.jpg',1,'M')">BUY NOW</button>
-              <a href="#" class="pro-cart-btn" aria-label="Add Cartoon Astronaut T-Shirts to cart" onclick="event.stopPropagation(); addToCart('Cartoon Astronaut T-Shirts','₹1,249','images/products/f1.jpg',1,'M'); return false;"><i class="ri-shopping-cart-2-line"></i></a>
+              <a href="#" class="pro-cart-btn" aria-label="Add Cartoon Astronaut T-Shirts to cart" onclick="event.stopPropagation(); addToCart('Cartoon Astronaut T-Shirts','₹1,249','images/products/f1.jpg',1,'M'); return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             </div>
           </div>
         </div>
@@ -264,7 +264,7 @@
             </h4>
             <div class="pro-action-bar">
              <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="event.stopPropagation(); buyNow('White Palm Leaf Casual Shirt','₹649','images/products/f2.jpg',1,'M')">BUY NOW</button>
-              <a href="#" class="pro-cart-btn" aria-label="Add White Palm Leaf Casual Shirt to cart" onclick="event.stopPropagation(); addToCart('White Palm Leaf Casual Shirt','₹649','images/products/f2.jpg',1,'M'); return false;"><i class="ri-shopping-cart-2-line"></i></a>
+              <a href="#" class="pro-cart-btn" aria-label="Add White Palm Leaf Casual Shirt to cart" onclick="event.stopPropagation(); addToCart('White Palm Leaf Casual Shirt','₹649','images/products/f2.jpg',1,'M'); return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             </div>
           </div>
         </div>
@@ -284,7 +284,7 @@
             </h4>
             <div class="pro-action-bar">
              <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="event.stopPropagation(); buyNow('Pink Peony Patterned Shirt','₹999','images/products/f5.jpg',1,'M')">BUY NOW</button>
-              <a href="#" class="pro-cart-btn" aria-label="Add Pink Peony Patterned Shirt to cart" onclick="event.stopPropagation(); addToCart('Pink Peony Patterned Shirt','₹999','images/products/f5.jpg',1,'M'); return false;"><i class="ri-shopping-cart-2-line"></i></a>
+              <a href="#" class="pro-cart-btn" aria-label="Add Pink Peony Patterned Shirt to cart" onclick="event.stopPropagation(); addToCart('Pink Peony Patterned Shirt','₹999','images/products/f5.jpg',1,'M'); return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             </div>
           </div>
         </div>
@@ -304,7 +304,7 @@
             </h4>
             <div class="pro-action-bar">
              <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="event.stopPropagation(); buyNow('Dual-Tone Corduroy Shirt','₹1,149','images/products/f6.jpg',1,'M')">BUY NOW</button>
-              <a href="#" class="pro-cart-btn" aria-label="Add Dual-Tone Corduroy Shirt to cart" onclick="event.stopPropagation(); addToCart('Dual-Tone Corduroy Shirt','₹1,149','images/products/f6.jpg',1,'M'); return false;"><i class="ri-shopping-cart-2-line"></i></a>
+              <a href="#" class="pro-cart-btn" aria-label="Add Dual-Tone Corduroy Shirt to cart" onclick="event.stopPropagation(); addToCart('Dual-Tone Corduroy Shirt','₹1,149','images/products/f6.jpg',1,'M'); return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             </div>
           </div>
         </div>

--- a/deals.html
+++ b/deals.html
@@ -284,7 +284,7 @@
                 <div class="star"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
                 <h4>$78 <span class="old-price">$120</span></h4>
             </div>
-            <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="cart"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
         </div>
 
         <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -296,7 +296,7 @@
                 <div class="star"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
                 <h4>$82 <span class="old-price">$130</span></h4>
             </div>
-            <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="cart"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
         </div>
 
         <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -308,7 +308,7 @@
                 <div class="star"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
                 <h4>$75 <span class="old-price">$115</span></h4>
             </div>
-            <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="cart"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
         </div>
 
         <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -320,7 +320,7 @@
                 <div class="star"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
                 <h4>$79 <span class="old-price">$125</span></h4>
             </div>
-            <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="cart"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
         </div>
 
     </div>

--- a/index.html
+++ b/index.html
@@ -409,9 +409,9 @@
           <h4>&#8377;2,499</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Cartoon Astronaut T-Shirts','₹2,499','images/products/f1.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Cartoon Astronaut T-Shirts','₹2,499','images/products/f1.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Cartoon Astronaut T-Shirts','₹2,499','images/products/f1.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Cartoon Astronaut T-Shirts" aria-label="Add Cartoon Astronaut T-Shirts to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:1, name:'Cartoon Astronaut T-Shirts', brand:'Nike', price:'₹2,499', image:'images/products/f1.jpg', currentPrice:2499, previousPrice:2499}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Cartoon Astronaut T-Shirts','₹2,499','images/products/f1.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Cartoon Astronaut T-Shirts','₹2,499','images/products/f1.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
           </div>
         </div>
       </div>
@@ -428,9 +428,9 @@
           <h4>&#8377;1,299</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('White Palm Leaf Casual Shirt','₹1,299','images/products/f2.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('White Palm Leaf Casual Shirt','₹1,299','images/products/f2.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('White Palm Leaf Casual Shirt','₹1,299','images/products/f2.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="White Palm Leaf Casual Shirt" aria-label="Add White Palm Leaf Casual Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:2, name:'White Palm Leaf Casual Shirt', brand:'H&amp;M', price:'₹1,299', image:'images/products/f2.jpg', currentPrice:1299, previousPrice:1299}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('White Palm Leaf Casual Shirt','₹1,299','images/products/f2.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('White Palm Leaf Casual Shirt','₹1,299','images/products/f2.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
           </div>
         </div>
       </div>
@@ -447,9 +447,9 @@
           <h4>&#8377;3,490</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Vintage Rose Garden Shirt','₹3,490','images/products/f3.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Vintage Rose Garden Shirt','₹3,490','images/products/f3.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Vintage Rose Garden Shirt','₹3,490','images/products/f3.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Vintage Rose Garden Shirt" aria-label="Add Vintage Rose Garden Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:3, name:'Vintage Rose Garden Shirt', brand:'Zara', price:'₹3,490', image:'images/products/f3.jpg', currentPrice:3490, previousPrice:3490}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Vintage Rose Garden Shirt','₹3,490','images/products/f3.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Vintage Rose Garden Shirt','₹3,490','images/products/f3.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
           </div>
         </div>
       </div>
@@ -466,9 +466,9 @@
           <h4>&#8377;2,799</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Sakura Blossom Floral Shirt','₹2,799','images/products/f4.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sakura Blossom Floral Shirt','₹2,799','images/products/f4.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sakura Blossom Floral Shirt','₹2,799','images/products/f4.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Sakura Blossom Floral Shirt" aria-label="Add Sakura Blossom Floral Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:4, name:'Sakura Blossom Floral Shirt', brand:'Levi\'s', price:'₹2,799', image:'images/products/f4.jpg', currentPrice:2799, previousPrice:2799}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sakura Blossom Floral Shirt','₹2,799','images/products/f4.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sakura Blossom Floral Shirt','₹2,799','images/products/f4.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
           </div>
         </div>
       </div>
@@ -485,9 +485,9 @@
           <h4>&#8377;1,999</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Pink Peony Patterned Shirt','₹1,999','images/products/f5.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Pink Peony Patterned Shirt','₹1,999','images/products/f5.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Pink Peony Patterned Shirt','₹1,999','images/products/f5.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Pink Peony Patterned Shirt" aria-label="Add Pink Peony Patterned Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:5, name:'Pink Peony Patterned Shirt', brand:'Puma', price:'₹1,999', image:'images/products/f5.jpg', currentPrice:1999, previousPrice:1999}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Pink Peony Patterned Shirt','₹1,999','images/products/f5.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Pink Peony Patterned Shirt','₹1,999','images/products/f5.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
           </div>
         </div>
       </div>
@@ -504,9 +504,9 @@
           <h4>&#8377;2,299</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Dual-Tone Corduroy Shirt','₹2,299','images/products/f6.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Dual-Tone Corduroy Shirt','₹2,299','images/products/f6.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Dual-Tone Corduroy Shirt','₹2,299','images/products/f6.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Dual-Tone Corduroy Shirt" aria-label="Add Dual-Tone Corduroy Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:6, name:'Dual-Tone Corduroy Shirt', brand:'Gap', price:'₹2,299', image:'images/products/f6.jpg', currentPrice:2299, previousPrice:2299}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Dual-Tone Corduroy Shirt','₹2,299','images/products/f6.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Dual-Tone Corduroy Shirt','₹2,299','images/products/f6.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
           </div>
         </div>
       </div>
@@ -523,9 +523,9 @@
           <h4>&#8377;3,990</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Embroidered Linen Trousers','₹3,990','images/products/f7.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Embroidered Linen Trousers','₹3,990','images/products/f7.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Embroidered Linen Trousers','₹3,990','images/products/f7.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Embroidered Linen Trousers" aria-label="Add Embroidered Linen Trousers to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:7, name:'Embroidered Linen Trousers', brand:'Uniqlo', price:'₹3,990', image:'images/products/f7.jpg', currentPrice:3990, previousPrice:3990}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Embroidered Linen Trousers','₹3,990','images/products/f7.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Embroidered Linen Trousers','₹3,990','images/products/f7.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
           </div>
         </div>
       </div>
@@ -542,9 +542,9 @@
           <h4>&#8377;2,699</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Cat Print Long Sleeve Blouse','₹2,699','images/products/f8.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Cat Print Long Sleeve Blouse','₹2,699','images/products/f8.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Cat Print Long Sleeve Blouse','₹2,699','images/products/f8.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Cat Print Long Sleeve Blouse" aria-label="Add Cat Print Long Sleeve Blouse to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:8, name:'Cat Print Long Sleeve Blouse', brand:'Mango', price:'₹2,699', image:'images/products/f8.jpg', currentPrice:2699, previousPrice:2699}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Cat Print Long Sleeve Blouse','₹2,699','images/products/f8.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Cat Print Long Sleeve Blouse','₹2,699','images/products/f8.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
           </div>
         </div>
       </div>
@@ -575,9 +575,9 @@
           <h4>&#8377;4,499</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Sky Blue Mandarin Collar Shirt','₹4,499','images/products/n1.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sky Blue Mandarin Collar Shirt','₹4,499','images/products/n1.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sky Blue Mandarin Collar Shirt','₹4,499','images/products/n1.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Sky Blue Mandarin Collar Shirt" aria-label="Add Sky Blue Mandarin Collar Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:9, name:'Sky Blue Mandarin Collar Shirt', brand:'Tommy Hilfiger', price:'₹4,499', image:'images/products/n1.jpg', currentPrice:4499, previousPrice:4499}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sky Blue Mandarin Collar Shirt','₹4,499','images/products/n1.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sky Blue Mandarin Collar Shirt','₹4,499','images/products/n1.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
           </div>
         </div>
       </div>
@@ -594,9 +594,9 @@
           <h4>&#8377;6,999</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Navy Textured Formal Shirt','₹6,999','images/products/n2.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Navy Textured Formal Shirt','₹6,999','images/products/n2.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Navy Textured Formal Shirt','₹6,999','images/products/n2.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Navy Textured Formal Shirt" aria-label="Add Navy Textured Formal Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:10, name:'Navy Textured Formal Shirt', brand:'Ralph Lauren', price:'₹6,999', image:'images/products/n2.jpg', currentPrice:6999, previousPrice:6999}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Navy Textured Formal Shirt','₹6,999','images/products/n2.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Navy Textured Formal Shirt','₹6,999','images/products/n2.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
           </div>
         </div>
       </div>
@@ -613,9 +613,9 @@
           <h4>&#8377;5,499</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Classic White Cotton Shirt','₹5,499','images/products/n3.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Classic White Cotton Shirt','₹5,499','images/products/n3.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Classic White Cotton Shirt','₹5,499','images/products/n3.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Classic White Cotton Shirt" aria-label="Add Classic White Cotton Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:11, name:'Classic White Cotton Shirt', brand:'Calvin Klein', price:'₹5,499', image:'images/products/n3.jpg', currentPrice:5499, previousPrice:5499}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Classic White Cotton Shirt','₹5,499','images/products/n3.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Classic White Cotton Shirt','₹5,499','images/products/n3.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
           </div>
         </div>
 
@@ -693,9 +693,9 @@
           <h4>&#8377;3,990</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Sandstone Tactical Utility Shirt','₹3,990','images/products/n4.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sandstone Tactical Utility Shirt','₹3,990','images/products/n4.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sandstone Tactical Utility Shirt','₹3,990','images/products/n4.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Sandstone Tactical Utility Shirt" aria-label="Add Sandstone Tactical Utility Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:12, name:'Sandstone Tactical Utility Shirt', brand:'Zara', price:'₹3,990', image:'images/products/n4.jpg', currentPrice:3990, previousPrice:3990}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sandstone Tactical Utility Shirt','₹3,990','images/products/n4.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sandstone Tactical Utility Shirt','₹3,990','images/products/n4.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
           </div>
         </div>
       </div>
@@ -712,9 +712,9 @@
           <h4>&#8377;2,799</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Denim Blue Everyday Shirt','₹2,799','images/products/n5.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Denim Blue Everyday Shirt','₹2,799','images/products/n5.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Denim Blue Everyday Shirt','₹2,799','images/products/n5.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Denim Blue Everyday Shirt" aria-label="Add Denim Blue Everyday Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:13, name:'Denim Blue Everyday Shirt', brand:'Nike', price:'₹2,799', image:'images/products/n5.jpg', currentPrice:2799, previousPrice:2799}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Denim Blue Everyday Shirt','₹2,799','images/products/n5.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Denim Blue Everyday Shirt','₹2,799','images/products/n5.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
           </div>
         </div>
       </div>
@@ -731,9 +731,9 @@
           <h4>&#8377;2,499</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Vertical Stripe Chino Shorts','₹2,499','images/products/n6.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Vertical Stripe Chino Shorts','₹2,499','images/products/n6.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Vertical Stripe Chino Shorts','₹2,499','images/products/n6.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Vertical Stripe Chino Shorts" aria-label="Add Vertical Stripe Chino Shorts to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:14, name:'Vertical Stripe Chino Shorts', brand:'Levi\'s', price:'₹2,499', image:'images/products/n6.jpg', currentPrice:2499, previousPrice:2499}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Vertical Stripe Chino Shorts','₹2,499','images/products/n6.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Vertical Stripe Chino Shorts','₹2,499','images/products/n6.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
           </div>
         </div>
       </div>
@@ -750,9 +750,9 @@
           <h4>&#8377;3,499</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Khaki Safari Work Shirt','₹3,499','images/products/n7.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Khaki Safari Work Shirt','₹3,499','images/products/n7.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Khaki Safari Work Shirt','₹3,499','images/products/n7.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Khaki Safari Work Shirt" aria-label="Add Khaki Safari Work Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:15, name:'Khaki Safari Work Shirt', brand:'Uniqlo', price:'₹3,499', image:'images/products/n7.jpg', currentPrice:3499, previousPrice:3499}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Khaki Safari Work Shirt','₹3,499','images/products/n7.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Khaki Safari Work Shirt','₹3,499','images/products/n7.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
           </div>
         </div>
       </div>
@@ -769,9 +769,9 @@
           <h4>&#8377;1,799</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Deep Charcoal Casual Shirt','₹1,799','images/products/n8.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Deep Charcoal Casual Shirt','₹1,799','images/products/n8.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Deep Charcoal Casual Shirt','₹1,799','images/products/n8.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Deep Charcoal Casual Shirt" aria-label="Add Deep Charcoal Casual Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:16, name:'Deep Charcoal Casual Shirt', brand:'Puma', price:'₹1,799', image:'images/products/n8.jpg', currentPrice:1799, previousPrice:1799}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Deep Charcoal Casual Shirt','₹1,799','images/products/n8.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Deep Charcoal Casual Shirt','₹1,799','images/products/n8.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
           </div>
         </div>
       </div>

--- a/login.html
+++ b/login.html
@@ -105,7 +105,7 @@
                 aria-required="true"
               />
               <button type="button" id="togglePassword" class="toggle_password" aria-label="Show password">
-                <i class="ri-eye-line" id="toggleIcon" aria-hidden="true"></i>
+                <i class="ri-eye-line" aria-label="View" id="toggleIcon" aria-hidden="true"></i>
               </button>
             </div>
             <!-- Inline error for wrong password -->

--- a/register.html
+++ b/register.html
@@ -155,7 +155,7 @@
                   autocomplete="new-password"
                 />
                 <button type="button" id="togglePassword" class="toggle-eye" aria-label="Toggle password visibility">
-                  <i class="ri-eye-line" id="registerToggleIcon"></i>
+                  <i class="ri-eye-line" aria-label="View" id="registerToggleIcon"></i>
                 </button>
               </div>
               <small>Use at least 8 characters with a number.</small>
@@ -175,7 +175,7 @@
                   autocomplete="new-password"
                 />
                 <button type="button" id="confirmTogglePassword" class="toggle-eye" aria-label="Toggle confirm password visibility">
-                  <i class="ri-eye-line" id="confirmToggleIcon"></i>
+                  <i class="ri-eye-line" aria-label="View" id="confirmToggleIcon"></i>
                 </button>
               </div>
               <!-- confirmHint shows live "match / no match" as they type -->

--- a/tshirt.html
+++ b/tshirt.html
@@ -276,7 +276,7 @@
                             class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
                     <h4>$29.99</h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -289,7 +289,7 @@
                             class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
                     <h4>$27.99</h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -302,7 +302,7 @@
                             class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
                     <h4>$29.99</h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -315,7 +315,7 @@
                             class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
                     <h4>$26.99</h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -328,7 +328,7 @@
                             class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
                     <h4>$28.99</h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -341,7 +341,7 @@
                             class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
                     <h4>$30.99</h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -354,7 +354,7 @@
                             class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
                     <h4>$27.99</h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -367,7 +367,7 @@
                             class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
                     <h4>$29.99</h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             </div>
 
         </div>

--- a/winter-sale.html
+++ b/winter-sale.html
@@ -303,7 +303,7 @@
                     </div>
                     <h4>$65 <span class="old-price">$120</span></h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -318,7 +318,7 @@
                     </div>
                     <h4>$72 <span class="old-price">$115</span></h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -333,7 +333,7 @@
                     </div>
                     <h4>$89 <span class="old-price">$150</span></h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -348,7 +348,7 @@
                     </div>
                     <h4>$78 <span class="old-price">$105</span></h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -363,7 +363,7 @@
                     </div>
                     <h4>$69 <span class="old-price">$99</span></h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -378,7 +378,7 @@
                     </div>
                     <h4>$95 <span class="old-price">$180</span></h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -393,7 +393,7 @@
                     </div>
                     <h4>$84 <span class="old-price">$110</span></h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -408,7 +408,7 @@
                     </div>
                     <h4>$76 <span class="old-price">$125</span></h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><i class="ri-shopping-cart-2-line" aria-label="Cart"></i></a>
             </div>
 
         </div>

--- a/wishlist.html
+++ b/wishlist.html
@@ -667,7 +667,7 @@
                     cartButton.className = "add-to-cart-btn";
                     cartButton.type = "button";
                     cartButton.setAttribute("aria-label", `Add ${product.name} to cart`);
-                    cartButton.innerHTML = '<i class="ri-shopping-cart-2-line" aria-hidden="true"></i> Add to Cart';
+                    cartButton.innerHTML = '<i class="ri-shopping-cart-2-line" aria-label="Cart" aria-hidden="true"></i> Add to Cart';
                     cartButton.addEventListener("click", () => moveToCart(index));
 
                     const removeButton = document.createElement("button");


### PR DESCRIPTION
Closes #2483.

### Description
This PR dramatically improves the accessibility (a11y) of the application by adding missing `aria-label` attributes to interface elements that rely entirely on iconography.

### Changes Made
- Added `aria-label="Cart"` to elements utilizing the shopping cart icon (`ri-shopping-cart-2-line`).
- Added `aria-label="View"` to elements utilizing the eye icon (`ri-eye-line`).
- Ensured these changes propagate through the relevant HTML templates.

### Impact
- **Inclusivity:** Screen readers rely on text content to describe links and buttons to visually impaired users. Without an `aria-label`, an icon-only button is announced as "button" or "unlabeled image", confusing the user. This update guarantees screen readers can effectively announce the action behind the icons.
- **Lighthouse Scores:** Resolves accessibility warnings commonly flagged by auditing tools like Google Lighthouse and axe-core.
