### PR TITLE
Replace empty href="#" anchors with javascript:void(0)

### DIFF
--- a/404page.html
+++ b/404page.html
@@ -185,7 +185,7 @@
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode" style="margin-left: 10px; border: none; background: transparent; cursor: pointer;">
         <i class="ri-moon-line" id="themeIconMobile" style="font-size: 20px;"></i>
       </button>
-      <a href="#" id="bar" aria-label="Open menu" aria-expanded="false" style="margin-left: 10px;">
+      <a href="javascript:void(0)" id="bar" aria-label="Open menu" aria-expanded="false" style="margin-left: 10px;">
         <i class="fa-solid fa-bars"></i>
       </a>
     </div>

--- a/about.html
+++ b/about.html
@@ -438,7 +438,7 @@
       </li>
 
       <!-- Close Button -->
-      <a href="#" id="close" aria-label="Close menu" aria-hidden="false">
+      <a href="javascript:void(0)" id="close" aria-label="Close menu" aria-hidden="false">
         <i class="fa-solid fa-xmark"></i>
       </a>
     </ul>
@@ -555,7 +555,7 @@
     }
   </script>
   <section id="about-app">
-    <h1>Download Our <a href="#">App</a></h1>
+    <h1>Download Our <a href="javascript:void(0)">App</a></h1>
     <div class="video">
       <video autoplay muted loop src="images/about/1.mp4"></video>
     </div>

--- a/blog-aw20-menswear.html
+++ b/blog-aw20-menswear.html
@@ -185,7 +185,7 @@
                         <i class="ri-moon-line" id="themeIcon"></i>
                     </button>
                 </li>
-                <a href="#" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="javascript:void(0)" id="close"><i class="fa-solid fa-xmark"></i></a>
             </ul>
         </div>
         <div class="mobile">
@@ -331,7 +331,7 @@
       <div class="col">
         <h4>About</h4>
         <a href="about.html">About Us</a>
-        <a href="#">Delivery Information</a>
+        <a href="javascript:void(0)">Delivery Information</a>
         <a href="privacy.html">Privacy Policy</a>
         <a href="terms.html">Terms and Conditions</a>
         <a href="contact.html">Contact Us</a>
@@ -342,7 +342,7 @@
         <h4>My Account</h4>
         <a href="login.html">Sign In</a>
         <a href="cart.html">View Cart</a>
-        <a href="#">My Wishlist</a>
+        <a href="javascript:void(0)">My Wishlist</a>
         <a href="cart.html">Track My Order</a>
         <a href="contact.html">Help</a>
       </div>

--- a/blog-cotton-jersey-hoodie.html
+++ b/blog-cotton-jersey-hoodie.html
@@ -200,7 +200,7 @@
                         <i class="ri-moon-line" id="themeIcon"></i>
                     </button>
                 </li>
-                <a href="#" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="javascript:void(0)" id="close"><i class="fa-solid fa-xmark"></i></a>
             </ul>
         </div>
         <div class="mobile">
@@ -339,7 +339,7 @@
       <div class="col">
         <h4>About</h4>
         <a href="about.html">About Us</a>
-        <a href="#">Delivery Information</a>
+        <a href="javascript:void(0)">Delivery Information</a>
         <a href="privacy.html">Privacy Policy</a>
         <a href="terms.html">Terms and Conditions</a>
         <a href="contact.html">Contact Us</a>
@@ -350,7 +350,7 @@
         <h4>My Account</h4>
         <a href="login.html">Sign In</a>
         <a href="cart.html">View Cart</a>
-        <a href="#">My Wishlist</a>
+        <a href="javascript:void(0)">My Wishlist</a>
         <a href="cart.html">Track My Order</a>
         <a href="contact.html">Help</a>
       </div>

--- a/blog-quiff-styling.html
+++ b/blog-quiff-styling.html
@@ -185,7 +185,7 @@
                         <i class="ri-moon-line" id="themeIcon"></i>
                     </button>
                 </li>
-                <a href="#" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="javascript:void(0)" id="close"><i class="fa-solid fa-xmark"></i></a>
             </ul>
         </div>
         <div class="mobile">
@@ -322,7 +322,7 @@
       <div class="col">
         <h4>About</h4>
         <a href="about.html">About Us</a>
-        <a href="#">Delivery Information</a>
+        <a href="javascript:void(0)">Delivery Information</a>
         <a href="privacy.html">Privacy Policy</a>
         <a href="terms.html">Terms and Conditions</a>
         <a href="contact.html">Contact Us</a>
@@ -333,7 +333,7 @@
         <h4>My Account</h4>
         <a href="login.html">Sign In</a>
         <a href="cart.html">View Cart</a>
-        <a href="#">My Wishlist</a>
+        <a href="javascript:void(0)">My Wishlist</a>
         <a href="cart.html">Track My Order</a>
         <a href="contact.html">Help</a>
       </div>

--- a/blog-runway-trends.html
+++ b/blog-runway-trends.html
@@ -184,7 +184,7 @@
                         <i class="ri-moon-line" id="themeIcon"></i>
                     </button>
                 </li>
-                <a href="#" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="javascript:void(0)" id="close"><i class="fa-solid fa-xmark"></i></a>
             </ul>
         </div>
         <div class="mobile">
@@ -319,7 +319,7 @@
       <div class="col">
         <h4>About</h4>
         <a href="about.html">About Us</a>
-        <a href="#">Delivery Information</a>
+        <a href="javascript:void(0)">Delivery Information</a>
         <a href="privacy.html">Privacy Policy</a>
         <a href="terms.html">Terms and Conditions</a>
         <a href="contact.html">Contact Us</a>
@@ -330,7 +330,7 @@
         <h4>My Account</h4>
         <a href="login.html">Sign In</a>
         <a href="cart.html">View Cart</a>
-        <a href="#">My Wishlist</a>
+        <a href="javascript:void(0)">My Wishlist</a>
         <a href="cart.html">Track My Order</a>
         <a href="contact.html">Help</a>
       </div>

--- a/blog-skater-girls.html
+++ b/blog-skater-girls.html
@@ -184,7 +184,7 @@
                         <i class="ri-moon-line" id="themeIcon"></i>
                     </button>
                 </li>
-                <a href="#" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="javascript:void(0)" id="close"><i class="fa-solid fa-xmark"></i></a>
             </ul>
         </div>
         <div class="mobile">
@@ -326,7 +326,7 @@
       <div class="col">
         <h4>About</h4>
         <a href="about.html">About Us</a>
-        <a href="#">Delivery Information</a>
+        <a href="javascript:void(0)">Delivery Information</a>
         <a href="privacy.html">Privacy Policy</a>
         <a href="terms.html">Terms and Conditions</a>
         <a href="contact.html">Contact Us</a>
@@ -337,7 +337,7 @@
         <h4>My Account</h4>
         <a href="login.html">Sign In</a>
         <a href="cart.html">View Cart</a>
-        <a href="#">My Wishlist</a>
+        <a href="javascript:void(0)">My Wishlist</a>
         <a href="cart.html">Track My Order</a>
         <a href="contact.html">Help</a>
       </div>

--- a/blog.html
+++ b/blog.html
@@ -165,7 +165,7 @@
 
       <!-- Close Button -->
       <a
-        href="#"
+        href="javascript:void(0)"
         id="close"
         aria-label="Close menu"
         aria-hidden="false"

--- a/checkout.html
+++ b/checkout.html
@@ -28,7 +28,7 @@
     <div class="checkout-header">
       <div class="back-to-cart">
         <a href="cart.html" class="back-link" aria-label="Back to cart"><i class="ri-arrow-left-line"></i> Back to Cart</a>
-        <a href="#" id="logout-btn" style="display:none">Logout</a>
+        <a href="javascript:void(0)" id="logout-btn" style="display:none">Logout</a>
       </div>
       <div class="logo" style="display: flex; align-items: center; gap: 15px;">
         <span>Cara</span>

--- a/community.html
+++ b/community.html
@@ -287,7 +287,7 @@
 
       <!-- Close Button -->
       <a
-        href="#"
+        href="javascript:void(0)"
         id="close"
         aria-label="Close menu"
         aria-hidden="false"

--- a/contact.html
+++ b/contact.html
@@ -483,7 +483,7 @@ footer .copyright {
 
       <!-- Close Button -->
       <a
-        href="#"
+        href="javascript:void(0)"
         id="close"
         aria-label="Close menu"
         aria-hidden="false"

--- a/crazy-deals.html
+++ b/crazy-deals.html
@@ -244,7 +244,7 @@
             </h4>
             <div class="pro-action-bar">
              <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="event.stopPropagation(); buyNow('Cartoon Astronaut T-Shirts','₹1,249','images/products/f1.jpg',1,'M')">BUY NOW</button>
-              <a href="#" class="pro-cart-btn" aria-label="Add Cartoon Astronaut T-Shirts to cart" onclick="event.stopPropagation(); addToCart('Cartoon Astronaut T-Shirts','₹1,249','images/products/f1.jpg',1,'M'); return false;"><i class="ri-shopping-cart-2-line"></i></a>
+              <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add Cartoon Astronaut T-Shirts to cart" onclick="event.stopPropagation(); addToCart('Cartoon Astronaut T-Shirts','₹1,249','images/products/f1.jpg',1,'M'); return false;"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
           </div>
         </div>
@@ -264,7 +264,7 @@
             </h4>
             <div class="pro-action-bar">
              <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="event.stopPropagation(); buyNow('White Palm Leaf Casual Shirt','₹649','images/products/f2.jpg',1,'M')">BUY NOW</button>
-              <a href="#" class="pro-cart-btn" aria-label="Add White Palm Leaf Casual Shirt to cart" onclick="event.stopPropagation(); addToCart('White Palm Leaf Casual Shirt','₹649','images/products/f2.jpg',1,'M'); return false;"><i class="ri-shopping-cart-2-line"></i></a>
+              <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add White Palm Leaf Casual Shirt to cart" onclick="event.stopPropagation(); addToCart('White Palm Leaf Casual Shirt','₹649','images/products/f2.jpg',1,'M'); return false;"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
           </div>
         </div>
@@ -284,7 +284,7 @@
             </h4>
             <div class="pro-action-bar">
              <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="event.stopPropagation(); buyNow('Pink Peony Patterned Shirt','₹999','images/products/f5.jpg',1,'M')">BUY NOW</button>
-              <a href="#" class="pro-cart-btn" aria-label="Add Pink Peony Patterned Shirt to cart" onclick="event.stopPropagation(); addToCart('Pink Peony Patterned Shirt','₹999','images/products/f5.jpg',1,'M'); return false;"><i class="ri-shopping-cart-2-line"></i></a>
+              <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add Pink Peony Patterned Shirt to cart" onclick="event.stopPropagation(); addToCart('Pink Peony Patterned Shirt','₹999','images/products/f5.jpg',1,'M'); return false;"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
           </div>
         </div>
@@ -304,7 +304,7 @@
             </h4>
             <div class="pro-action-bar">
              <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="event.stopPropagation(); buyNow('Dual-Tone Corduroy Shirt','₹1,149','images/products/f6.jpg',1,'M')">BUY NOW</button>
-              <a href="#" class="pro-cart-btn" aria-label="Add Dual-Tone Corduroy Shirt to cart" onclick="event.stopPropagation(); addToCart('Dual-Tone Corduroy Shirt','₹1,149','images/products/f6.jpg',1,'M'); return false;"><i class="ri-shopping-cart-2-line"></i></a>
+              <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add Dual-Tone Corduroy Shirt to cart" onclick="event.stopPropagation(); addToCart('Dual-Tone Corduroy Shirt','₹1,149','images/products/f6.jpg',1,'M'); return false;"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
           </div>
         </div>

--- a/deals.html
+++ b/deals.html
@@ -212,7 +212,7 @@
                     <i class="ri-moon-line" id="themeIcon"></i>
                 </button>
             </li>
-            <a href="#" id="close"><i class="fa-solid fa-xmark"></i></a>
+            <a href="javascript:void(0)" id="close"><i class="fa-solid fa-xmark"></i></a>
         </ul>
     </div>
     <div class="mobile">
@@ -284,7 +284,7 @@
                 <div class="star"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
                 <h4>$78 <span class="old-price">$120</span></h4>
             </div>
-            <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
         </div>
 
         <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -296,7 +296,7 @@
                 <div class="star"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
                 <h4>$82 <span class="old-price">$130</span></h4>
             </div>
-            <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
         </div>
 
         <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -308,7 +308,7 @@
                 <div class="star"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
                 <h4>$75 <span class="old-price">$115</span></h4>
             </div>
-            <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
         </div>
 
         <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -320,7 +320,7 @@
                 <div class="star"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
                 <h4>$79 <span class="old-price">$125</span></h4>
             </div>
-            <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
         </div>
 
     </div>
@@ -353,9 +353,9 @@
     <div class="col">
         <h4>About</h4>
         <a href="about.html">About us</a>
-        <a href="#">Delivery Information</a>
-        <a href="#">Privacy Policy</a>
-        <a href="#">Terms & Conditions</a>
+        <a href="javascript:void(0)">Delivery Information</a>
+        <a href="javascript:void(0)">Privacy Policy</a>
+        <a href="javascript:void(0)">Terms & Conditions</a>
         <a href="contact.html">Contact Us</a>
     </div>
 

--- a/footware-collection.html
+++ b/footware-collection.html
@@ -226,7 +226,7 @@
                     </button>
                 </li>
 
-                <a href="#" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="javascript:void(0)" id="close"><i class="fa-solid fa-xmark"></i></a>
             </ul>
         </div>
 
@@ -335,7 +335,7 @@
                     <h4>$89</h4>
                 </div>
 
-                <a href="#"><i class="ri-shopping-cart-2-line cart"></i></a>
+                <a href="javascript:void(0)"><i class="ri-shopping-cart-2-line cart"></i></a>
             </div>
 
 
@@ -360,7 +360,7 @@
                     <h4>$95</h4>
                 </div>
 
-                <a href="#"><i class="ri-shopping-cart-2-line cart"></i></a>
+                <a href="javascript:void(0)"><i class="ri-shopping-cart-2-line cart"></i></a>
             </div>
 
 
@@ -385,7 +385,7 @@
                     <h4>$99</h4>
                 </div>
 
-                <a href="#"><i class="ri-shopping-cart-2-line cart"></i></a>
+                <a href="javascript:void(0)"><i class="ri-shopping-cart-2-line cart"></i></a>
             </div>
 
 
@@ -410,7 +410,7 @@
                     <h4>$110</h4>
                 </div>
 
-                <a href="#"><i class="ri-shopping-cart-2-line cart"></i></a>
+                <a href="javascript:void(0)"><i class="ri-shopping-cart-2-line cart"></i></a>
             </div>
 
 
@@ -435,7 +435,7 @@
                     <h4>$120</h4>
                 </div>
 
-                <a href="#"><i class="ri-shopping-cart-2-line cart"></i></a>
+                <a href="javascript:void(0)"><i class="ri-shopping-cart-2-line cart"></i></a>
             </div>
 
 
@@ -460,7 +460,7 @@
                     <h4>$130</h4>
                 </div>
 
-                <a href="#"><i class="ri-shopping-cart-2-line cart"></i></a>
+                <a href="javascript:void(0)"><i class="ri-shopping-cart-2-line cart"></i></a>
             </div>
 
 
@@ -485,7 +485,7 @@
                     <h4>$149</h4>
                 </div>
 
-                <a href="#"><i class="ri-shopping-cart-2-line cart"></i></a>
+                <a href="javascript:void(0)"><i class="ri-shopping-cart-2-line cart"></i></a>
             </div>
 
 
@@ -510,7 +510,7 @@
                     <h4>$105</h4>
                 </div>
 
-                <a href="#"><i class="ri-shopping-cart-2-line cart"></i></a>
+                <a href="javascript:void(0)"><i class="ri-shopping-cart-2-line cart"></i></a>
             </div>
 
 
@@ -559,9 +559,9 @@
             <h4>About</h4>
 
             <a href="about.html">About us</a>
-            <a href="#">Delivery Information</a>
-            <a href="#">Privacy Policy</a>
-            <a href="#">Terms & Conditions</a>
+            <a href="javascript:void(0)">Delivery Information</a>
+            <a href="javascript:void(0)">Privacy Policy</a>
+            <a href="javascript:void(0)">Terms & Conditions</a>
             <a href="contact.html">Contact Us</a>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -409,7 +409,7 @@
           <h4>&#8377;2,499</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Cartoon Astronaut T-Shirts','₹2,499','images/products/f1.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Cartoon Astronaut T-Shirts','₹2,499','images/products/f1.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Cartoon Astronaut T-Shirts','₹2,499','images/products/f1.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Cartoon Astronaut T-Shirts" aria-label="Add Cartoon Astronaut T-Shirts to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:1, name:'Cartoon Astronaut T-Shirts', brand:'Nike', price:'₹2,499', image:'images/products/f1.jpg', currentPrice:2499, previousPrice:2499}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
             <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Cartoon Astronaut T-Shirts','₹2,499','images/products/f1.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
           </div>
@@ -428,7 +428,7 @@
           <h4>&#8377;1,299</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('White Palm Leaf Casual Shirt','₹1,299','images/products/f2.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('White Palm Leaf Casual Shirt','₹1,299','images/products/f2.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('White Palm Leaf Casual Shirt','₹1,299','images/products/f2.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="White Palm Leaf Casual Shirt" aria-label="Add White Palm Leaf Casual Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:2, name:'White Palm Leaf Casual Shirt', brand:'H&amp;M', price:'₹1,299', image:'images/products/f2.jpg', currentPrice:1299, previousPrice:1299}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
             <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('White Palm Leaf Casual Shirt','₹1,299','images/products/f2.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
           </div>
@@ -447,7 +447,7 @@
           <h4>&#8377;3,490</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Vintage Rose Garden Shirt','₹3,490','images/products/f3.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Vintage Rose Garden Shirt','₹3,490','images/products/f3.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Vintage Rose Garden Shirt','₹3,490','images/products/f3.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Vintage Rose Garden Shirt" aria-label="Add Vintage Rose Garden Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:3, name:'Vintage Rose Garden Shirt', brand:'Zara', price:'₹3,490', image:'images/products/f3.jpg', currentPrice:3490, previousPrice:3490}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
             <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Vintage Rose Garden Shirt','₹3,490','images/products/f3.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
           </div>
@@ -466,7 +466,7 @@
           <h4>&#8377;2,799</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Sakura Blossom Floral Shirt','₹2,799','images/products/f4.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sakura Blossom Floral Shirt','₹2,799','images/products/f4.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sakura Blossom Floral Shirt','₹2,799','images/products/f4.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Sakura Blossom Floral Shirt" aria-label="Add Sakura Blossom Floral Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:4, name:'Sakura Blossom Floral Shirt', brand:'Levi\'s', price:'₹2,799', image:'images/products/f4.jpg', currentPrice:2799, previousPrice:2799}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
             <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sakura Blossom Floral Shirt','₹2,799','images/products/f4.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
           </div>
@@ -485,7 +485,7 @@
           <h4>&#8377;1,999</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Pink Peony Patterned Shirt','₹1,999','images/products/f5.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Pink Peony Patterned Shirt','₹1,999','images/products/f5.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Pink Peony Patterned Shirt','₹1,999','images/products/f5.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Pink Peony Patterned Shirt" aria-label="Add Pink Peony Patterned Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:5, name:'Pink Peony Patterned Shirt', brand:'Puma', price:'₹1,999', image:'images/products/f5.jpg', currentPrice:1999, previousPrice:1999}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
             <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Pink Peony Patterned Shirt','₹1,999','images/products/f5.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
           </div>
@@ -504,7 +504,7 @@
           <h4>&#8377;2,299</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Dual-Tone Corduroy Shirt','₹2,299','images/products/f6.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Dual-Tone Corduroy Shirt','₹2,299','images/products/f6.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Dual-Tone Corduroy Shirt','₹2,299','images/products/f6.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Dual-Tone Corduroy Shirt" aria-label="Add Dual-Tone Corduroy Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:6, name:'Dual-Tone Corduroy Shirt', brand:'Gap', price:'₹2,299', image:'images/products/f6.jpg', currentPrice:2299, previousPrice:2299}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
             <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Dual-Tone Corduroy Shirt','₹2,299','images/products/f6.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
           </div>
@@ -523,7 +523,7 @@
           <h4>&#8377;3,990</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Embroidered Linen Trousers','₹3,990','images/products/f7.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Embroidered Linen Trousers','₹3,990','images/products/f7.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Embroidered Linen Trousers','₹3,990','images/products/f7.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Embroidered Linen Trousers" aria-label="Add Embroidered Linen Trousers to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:7, name:'Embroidered Linen Trousers', brand:'Uniqlo', price:'₹3,990', image:'images/products/f7.jpg', currentPrice:3990, previousPrice:3990}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
             <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Embroidered Linen Trousers','₹3,990','images/products/f7.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
           </div>
@@ -542,7 +542,7 @@
           <h4>&#8377;2,699</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Cat Print Long Sleeve Blouse','₹2,699','images/products/f8.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Cat Print Long Sleeve Blouse','₹2,699','images/products/f8.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Cat Print Long Sleeve Blouse','₹2,699','images/products/f8.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Cat Print Long Sleeve Blouse" aria-label="Add Cat Print Long Sleeve Blouse to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:8, name:'Cat Print Long Sleeve Blouse', brand:'Mango', price:'₹2,699', image:'images/products/f8.jpg', currentPrice:2699, previousPrice:2699}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
             <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Cat Print Long Sleeve Blouse','₹2,699','images/products/f8.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
           </div>
@@ -575,7 +575,7 @@
           <h4>&#8377;4,499</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Sky Blue Mandarin Collar Shirt','₹4,499','images/products/n1.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sky Blue Mandarin Collar Shirt','₹4,499','images/products/n1.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sky Blue Mandarin Collar Shirt','₹4,499','images/products/n1.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Sky Blue Mandarin Collar Shirt" aria-label="Add Sky Blue Mandarin Collar Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:9, name:'Sky Blue Mandarin Collar Shirt', brand:'Tommy Hilfiger', price:'₹4,499', image:'images/products/n1.jpg', currentPrice:4499, previousPrice:4499}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
             <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sky Blue Mandarin Collar Shirt','₹4,499','images/products/n1.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
           </div>
@@ -594,7 +594,7 @@
           <h4>&#8377;6,999</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Navy Textured Formal Shirt','₹6,999','images/products/n2.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Navy Textured Formal Shirt','₹6,999','images/products/n2.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Navy Textured Formal Shirt','₹6,999','images/products/n2.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Navy Textured Formal Shirt" aria-label="Add Navy Textured Formal Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:10, name:'Navy Textured Formal Shirt', brand:'Ralph Lauren', price:'₹6,999', image:'images/products/n2.jpg', currentPrice:6999, previousPrice:6999}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
             <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Navy Textured Formal Shirt','₹6,999','images/products/n2.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
           </div>
@@ -613,7 +613,7 @@
           <h4>&#8377;5,499</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Classic White Cotton Shirt','₹5,499','images/products/n3.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Classic White Cotton Shirt','₹5,499','images/products/n3.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Classic White Cotton Shirt','₹5,499','images/products/n3.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Classic White Cotton Shirt" aria-label="Add Classic White Cotton Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:11, name:'Classic White Cotton Shirt', brand:'Calvin Klein', price:'₹5,499', image:'images/products/n3.jpg', currentPrice:5499, previousPrice:5499}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
             <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Classic White Cotton Shirt','₹5,499','images/products/n3.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
           </div>
@@ -693,7 +693,7 @@
           <h4>&#8377;3,990</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Sandstone Tactical Utility Shirt','₹3,990','images/products/n4.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sandstone Tactical Utility Shirt','₹3,990','images/products/n4.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sandstone Tactical Utility Shirt','₹3,990','images/products/n4.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Sandstone Tactical Utility Shirt" aria-label="Add Sandstone Tactical Utility Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:12, name:'Sandstone Tactical Utility Shirt', brand:'Zara', price:'₹3,990', image:'images/products/n4.jpg', currentPrice:3990, previousPrice:3990}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
             <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sandstone Tactical Utility Shirt','₹3,990','images/products/n4.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
           </div>
@@ -712,7 +712,7 @@
           <h4>&#8377;2,799</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Denim Blue Everyday Shirt','₹2,799','images/products/n5.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Denim Blue Everyday Shirt','₹2,799','images/products/n5.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Denim Blue Everyday Shirt','₹2,799','images/products/n5.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Denim Blue Everyday Shirt" aria-label="Add Denim Blue Everyday Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:13, name:'Denim Blue Everyday Shirt', brand:'Nike', price:'₹2,799', image:'images/products/n5.jpg', currentPrice:2799, previousPrice:2799}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
             <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Denim Blue Everyday Shirt','₹2,799','images/products/n5.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
           </div>
@@ -731,7 +731,7 @@
           <h4>&#8377;2,499</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Vertical Stripe Chino Shorts','₹2,499','images/products/n6.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Vertical Stripe Chino Shorts','₹2,499','images/products/n6.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Vertical Stripe Chino Shorts','₹2,499','images/products/n6.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Vertical Stripe Chino Shorts" aria-label="Add Vertical Stripe Chino Shorts to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:14, name:'Vertical Stripe Chino Shorts', brand:'Levi\'s', price:'₹2,499', image:'images/products/n6.jpg', currentPrice:2499, previousPrice:2499}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
             <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Vertical Stripe Chino Shorts','₹2,499','images/products/n6.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
           </div>
@@ -750,7 +750,7 @@
           <h4>&#8377;3,499</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Khaki Safari Work Shirt','₹3,499','images/products/n7.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Khaki Safari Work Shirt','₹3,499','images/products/n7.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Khaki Safari Work Shirt','₹3,499','images/products/n7.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Khaki Safari Work Shirt" aria-label="Add Khaki Safari Work Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:15, name:'Khaki Safari Work Shirt', brand:'Uniqlo', price:'₹3,499', image:'images/products/n7.jpg', currentPrice:3499, previousPrice:3499}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
             <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Khaki Safari Work Shirt','₹3,499','images/products/n7.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
           </div>
@@ -769,7 +769,7 @@
           <h4>&#8377;1,799</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Deep Charcoal Casual Shirt','₹1,799','images/products/n8.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Deep Charcoal Casual Shirt','₹1,799','images/products/n8.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Deep Charcoal Casual Shirt','₹1,799','images/products/n8.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
             <button type="button" class="wishlist-btn" data-product-name="Deep Charcoal Casual Shirt" aria-label="Add Deep Charcoal Casual Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:16, name:'Deep Charcoal Casual Shirt', brand:'Puma', price:'₹1,799', image:'images/products/n8.jpg', currentPrice:1799, previousPrice:1799}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
             <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Deep Charcoal Casual Shirt','₹1,799','images/products/n8.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
           </div>

--- a/license.html
+++ b/license.html
@@ -140,7 +140,7 @@
                     </button>
                 </li>
                 <li><a href="login.html" id="login-btn">Login</a></li>
-                <a href="#" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="javascript:void(0)" id="close"><i class="fa-solid fa-xmark"></i></a>
             </ul>
         </div>
       <div class="mobile">
@@ -218,8 +218,8 @@
             <h4>About</h4>
             <a href="about.html">About us</a>
          <a href="delivery.html">Delivery Information</a>
-            <a href="#">Privacy Policy</a>
-            <a href="#">Terms & Conditions</a>
+            <a href="javascript:void(0)">Privacy Policy</a>
+            <a href="javascript:void(0)">Terms & Conditions</a>
             <a href="contact.html">Contact Us</a>
         </div>
         <!-- My Account Section -->
@@ -227,7 +227,7 @@
             <h4>My Account</h4>
             <a href="login.html">Sign In</a>
             <a href="cart.html">View Cart</a>
-            <a href="#">My Wishlist</a>
+            <a href="javascript:void(0)">My Wishlist</a>
             <a href="track-order.html">Track My Order</a>
             <a href="contact.html">Help</a>
         </div>

--- a/privacy.html
+++ b/privacy.html
@@ -281,7 +281,7 @@
               <i class="ri-moon-line" id="themeIcon"></i>
             </button>
           </li>
-          <a href="#" id="close"><i class="fa-solid fa-xmark"></i></a>
+          <a href="javascript:void(0)" id="close"><i class="fa-solid fa-xmark"></i></a>
         </ul>
       </div>
       <div class="mobile">
@@ -476,7 +476,7 @@
       <div class="col">
         <h4>About</h4>
         <a href="about.html">About Us</a>
-        <a href="#">Delivery Information</a>
+        <a href="javascript:void(0)">Delivery Information</a>
         <a href="privacy.html">Privacy Policy</a>
         <a href="terms.html">Terms and Conditions</a>
         <a href="contact.html">Contact Us</a>

--- a/promotions.html
+++ b/promotions.html
@@ -292,7 +292,7 @@
         <h4>My Account</h4>
         <a href="login.html">Sign In</a>
         <a href="cart.html">View Cart</a>
-        <a href="#">My Wishlist</a>
+        <a href="javascript:void(0)">My Wishlist</a>
         <a href="cart.html">Track My Order</a>
         <a href="contact.html">Help</a>
       </div>

--- a/register.html
+++ b/register.html
@@ -78,7 +78,7 @@
               <i class="ri-moon-line" id="themeIcon"></i>
             </button>
           </li>
-          <a href="#" id="close" aria-label="Close menu"><i class="fa-solid fa-xmark"></i></a>
+          <a href="javascript:void(0)" id="close" aria-label="Close menu"><i class="fa-solid fa-xmark"></i></a>
         </ul>
       </div>
       <div class="mobile">
@@ -244,7 +244,7 @@
         <div class="footer-col">
           <h4>QUICK LINKS</h4>
           <a href="about.html">About Us</a>
-          <a href="#">Delivery Information</a>
+          <a href="javascript:void(0)">Delivery Information</a>
           <a href="privacy.html">Privacy Policy</a>
           <a href="terms.html">Terms and Conditions</a>
           <a href="contact.html">Contact Us</a>

--- a/singleProduct.html
+++ b/singleProduct.html
@@ -79,7 +79,7 @@
           </button>
         </li>
 
-        <a href="#" id="close" aria-label="Close menu"><i class="fa-solid fa-xmark"></i></a>
+        <a href="javascript:void(0)" id="close" aria-label="Close menu"><i class="fa-solid fa-xmark"></i></a>
       </ul>
     </div>
     <div class="mobile">
@@ -492,7 +492,7 @@
     <div class="col">
       <h4>About</h4>
       <a href="about.html">About Us</a>
-      <a href="#">Delivery Information</a>
+      <a href="javascript:void(0)">Delivery Information</a>
       <a href="privacy.html">Privacy Policy</a>
       <a href="terms.html">Terms and Conditions</a>
       <a href="contact.html">Contact Us</a>

--- a/terms.html
+++ b/terms.html
@@ -194,7 +194,7 @@
 
       <!-- Close Button -->
       <a
-        href="#"
+        href="javascript:void(0)"
         id="close"
         aria-label="Close menu"
         aria-hidden="false"
@@ -437,7 +437,7 @@
       <div class="col">
         <h4>About</h4>
         <a href="about.html">About Us</a>
-        <a href="#">Delivery Information</a>
+        <a href="javascript:void(0)">Delivery Information</a>
         <a href="privacy.html">Privacy Policy</a>
         <a href="terms.html">Terms and Conditions</a>
         <a href="contact.html">Contact Us</a>

--- a/track-order.html
+++ b/track-order.html
@@ -118,7 +118,7 @@
 
       <!-- Close Button -->
       <a
-        href="#"
+        href="javascript:void(0)"
         id="close"
         aria-label="Close menu"
         aria-hidden="false"

--- a/try-on.html
+++ b/try-on.html
@@ -581,7 +581,7 @@
 
       <!-- Close Button -->
       <a
-        href="#"
+        href="javascript:void(0)"
         id="close"
         aria-label="Close menu"
         aria-hidden="false"
@@ -793,7 +793,7 @@
       <h4>My Account</h4>
       <a href="login.html">Sign In</a>
       <a href="cart.html">View Cart</a>
-      <a href="#">My Wishlist</a>
+      <a href="javascript:void(0)">My Wishlist</a>
       <a href="cart.html">Track My Order</a>
       <a href="contact.html">Help</a>
     </div>

--- a/tshirt.html
+++ b/tshirt.html
@@ -205,7 +205,7 @@
                         <i class="ri-moon-line" id="themeIcon"></i>
                     </button>
                 </li>
-                <a href="#" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="javascript:void(0)" id="close"><i class="fa-solid fa-xmark"></i></a>
             </ul>
         </div>
         <div class="mobile">
@@ -276,7 +276,7 @@
                             class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
                     <h4>$29.99</h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="javascript:void(0)" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -289,7 +289,7 @@
                             class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
                     <h4>$27.99</h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="javascript:void(0)" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -302,7 +302,7 @@
                             class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
                     <h4>$29.99</h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="javascript:void(0)" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -315,7 +315,7 @@
                             class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
                     <h4>$26.99</h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="javascript:void(0)" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -328,7 +328,7 @@
                             class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
                     <h4>$28.99</h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="javascript:void(0)" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -341,7 +341,7 @@
                             class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
                     <h4>$30.99</h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="javascript:void(0)" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -354,7 +354,7 @@
                             class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
                     <h4>$27.99</h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="javascript:void(0)" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -367,7 +367,7 @@
                             class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
                     <h4>$29.99</h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="javascript:void(0)" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
 
         </div>
@@ -401,9 +401,9 @@
         <div class="col">
             <h4>About</h4>
             <a href="about.html">About us</a>
-            <a href="#">Delivery Information</a>
-            <a href="#">Privacy Policy</a>
-            <a href="#">Terms & Conditions</a>
+            <a href="javascript:void(0)">Delivery Information</a>
+            <a href="javascript:void(0)">Privacy Policy</a>
+            <a href="javascript:void(0)">Terms & Conditions</a>
             <a href="contact.html">Contact Us</a>
         </div>
 

--- a/winter-sale.html
+++ b/winter-sale.html
@@ -235,7 +235,7 @@
                         <i class="ri-moon-line" id="themeIcon"></i>
                     </button>
                 </li>
-                <a href="#" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="javascript:void(0)" id="close"><i class="fa-solid fa-xmark"></i></a>
             </ul>
         </div>
 
@@ -303,7 +303,7 @@
                     </div>
                     <h4>$65 <span class="old-price">$120</span></h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="javascript:void(0)" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -318,7 +318,7 @@
                     </div>
                     <h4>$72 <span class="old-price">$115</span></h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="javascript:void(0)" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -333,7 +333,7 @@
                     </div>
                     <h4>$89 <span class="old-price">$150</span></h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="javascript:void(0)" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -348,7 +348,7 @@
                     </div>
                     <h4>$78 <span class="old-price">$105</span></h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="javascript:void(0)" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -363,7 +363,7 @@
                     </div>
                     <h4>$69 <span class="old-price">$99</span></h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="javascript:void(0)" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -378,7 +378,7 @@
                     </div>
                     <h4>$95 <span class="old-price">$180</span></h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="javascript:void(0)" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -393,7 +393,7 @@
                     </div>
                     <h4>$84 <span class="old-price">$110</span></h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="javascript:void(0)" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -408,7 +408,7 @@
                     </div>
                     <h4>$76 <span class="old-price">$125</span></h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="javascript:void(0)" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
             </div>
 
         </div>
@@ -454,9 +454,9 @@
         <div class="col">
             <h4>About</h4>
             <a href="about.html">About us</a>
-            <a href="#">Delivery Information</a>
-            <a href="#">Privacy Policy</a>
-            <a href="#">Terms & Conditions</a>
+            <a href="javascript:void(0)">Delivery Information</a>
+            <a href="javascript:void(0)">Privacy Policy</a>
+            <a href="javascript:void(0)">Terms & Conditions</a>
             <a href="contact.html">Contact Us</a>
         </div>
 
@@ -465,7 +465,7 @@
             <h4>My Account</h4>
             <a href="login.html">Sign In</a>
             <a href="cart.html">View Cart</a>
-            <a href="#">My Wishlist</a>
+            <a href="javascript:void(0)">My Wishlist</a>
             <a href="cart.html">Track My Order</a>
             <a href="contact.html">Help</a>
         </div>


### PR DESCRIPTION
Closes #2479.

### Description
This PR fixes a pervasive UI annoyance where clicking on interactive icon links or dropdown toggles caused the browser window to abruptly jump to the top of the page.

### Changes Made
- Scanned all HTML files for `href="#"` inside `<a>` tags.
- Replaced these placeholder links with `href="javascript:void(0)"`.

### Impact
- **Improved User Experience:** The `href="#"` attribute is an old anti-pattern for creating click handlers on links. Clicking it tells the browser to navigate to an empty hash anchor at the top of the page, forcing the user to lose their scroll position. Switching to `javascript:void(0)` ensures the link evaluates safely without triggering a page jump, keeping the UI smooth and predictable.
