### PR TITLE
Fix hardcoded javascript:history.back() attributes

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -307,7 +307,7 @@
 
     <!-- Policy Content -->
     <main id="policy-page">
-      <button onclick="javascript:history.back()" class="back-btn" aria-label="Go back to previous page" style="border: none; font-family: inherit; font-size: inherit;">
+      <button onclick="history.back()" class="back-btn" aria-label="Go back to previous page" style="border: none; font-family: inherit; font-size: inherit;">
         <i class="ri-arrow-left-line"></i> Back
       </button>
 

--- a/terms.html
+++ b/terms.html
@@ -264,7 +264,7 @@
 
       <!-- Main Terms Texts -->
       <div class="terms-content-wrap">
-        <button onclick="javascript:history.back()" class="back-btn" aria-label="Go back to previous page" style="border: none; font-family: inherit; font-size: inherit; display: inline-flex; align-items: center; gap: 8px; margin-bottom: 25px; background: #088178; color: #fff; padding: 8px 18px; border-radius: 4px; font-weight: 600; cursor: pointer;">
+        <button onclick="history.back()" class="back-btn" aria-label="Go back to previous page" style="border: none; font-family: inherit; font-size: inherit; display: inline-flex; align-items: center; gap: 8px; margin-bottom: 25px; background: #088178; color: #fff; padding: 8px 18px; border-radius: 4px; font-weight: 600; cursor: pointer;">
           <i class="ri-arrow-left-line"></i> Back
         </button>
 


### PR DESCRIPTION
Closes #2486.

### Description
This PR cleans up outdated and unnecessary code syntax within inline event handlers, specifically targeting the "Go Back" buttons.

### Changes Made
- Scanned HTML templates (like `terms.html`) for the `onclick="javascript:history.back()"` pattern.
- Refactored the attribute to the simpler and more standards-compliant `onclick="history.back()"`.

### Impact
- **Code Quality:** The `javascript:` pseudo-protocol prefix is a relic of the very early web and is completely redundant inside an intrinsic event handler (like `onclick` or `onmouseover`), as the browser already inherently expects and executes JavaScript in this context. Removing it reduces noise and aligns the code with modern web standards.
