### PR TITLE
Replace obsolete <i> tags used for icons with semantic <span aria-hid…

### DIFF
--- a/404page.html
+++ b/404page.html
@@ -181,12 +181,12 @@
     </a>
     <div id="navbar-container"></div>
     <div id="mobile">
-      <a href="cart.html" aria-label="Cart"><i class="ri-shopping-bag-4-line"></i></a>
+      <a href="cart.html" aria-label="Cart"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a>
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode" style="margin-left: 10px; border: none; background: transparent; cursor: pointer;">
-        <i class="ri-moon-line" id="themeIconMobile" style="font-size: 20px;"></i>
+        <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile" style="font-size: 20px;"></span>
       </button>
       <a href="#" id="bar" aria-label="Open menu" aria-expanded="false" style="margin-left: 10px;">
-        <i class="fa-solid fa-bars"></i>
+        <span aria-hidden="true" class="fa-solid fa-bars"></span>
       </a>
     </div>
   </section>
@@ -195,7 +195,7 @@
   <main id="main-content">
   <section id="not-found">
 
-    <i class="ri-map-pin-line not-found-icon"></i>
+    <span aria-hidden="true" class="ri-map-pin-line not-found-icon"></span>
 
     <h1 class="not-found-code">404</h1>
 
@@ -208,10 +208,10 @@
 
     <div class="not-found-actions">
       <a href="index.html" class="btn-primary-404">
-        <i class="ri-home-4-line"></i> Go Back Home
+        <span aria-hidden="true" class="ri-home-4-line"></span> Go Back Home
       </a>
       <a href="shop.html" class="btn-outline-404">
-        <i class="ri-store-2-line"></i> Browse Shop
+        <span aria-hidden="true" class="ri-store-2-line"></span> Browse Shop
       </a>
     </div>
 
@@ -233,7 +233,7 @@
         <img class="footer-logo" src="images/logo.png" alt="Cara Logo" width="110" height="34" loading="lazy" />
       </div>
       <div class="footer-socials">
-        <a href="https://x.com/JanaviPandole" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-x-twitter"></i></a>
+        <a href="https://x.com/JanaviPandole" target="_blank" rel="noopener noreferrer"><span aria-hidden="true" class="fa-brands fa-x-twitter"></span></a>
         <a href="https://github.com/janavipandole" target="_blank" rel="noopener noreferrer"><i class="fab fa-github"></i></a>
         <a href="https://www.linkedin.com/in/janavi-pandole-80a7b2290" target="_blank" rel="noopener noreferrer"><i class="fab fa-linkedin"></i></a>
         <a href="https://www.youtube.com/@JanaviPandole" target="_blank" rel="noopener noreferrer"><i class="fab fa-youtube"></i></a>

--- a/about.html
+++ b/about.html
@@ -408,21 +408,21 @@
       <!-- Contact Icon -->
       <li class="nav-icon">
         <a href="contact.html" aria-label="Contact">
-          <i class="ri-customer-service-2-line"></i>
+          <span aria-hidden="true" class="ri-customer-service-2-line"></span>
         </a>
       </li>
 
       <!-- Login Icon -->
       <li class="nav-icon">
         <a href="login.html" aria-label="Login">
-          <i class="ri-user-3-line"></i>
+          <span aria-hidden="true" class="ri-user-3-line"></span>
         </a>
       </li>
 
       <!-- Cart Icon -->
       <li class="nav-icon">
         <a href="cart.html" id="lg-bag" aria-label="Cart">
-          <i class="ri-shopping-bag-4-line"></i>
+          <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
         </a>
       </li>
 
@@ -433,13 +433,13 @@
           id="themeToggle"
           aria-label="Toggle dark mode"
         >
-          <i class="ri-moon-line" id="themeIcon"></i>
+          <span aria-hidden="true" class="ri-moon-line" id="themeIcon"></span>
         </button>
       </li>
 
       <!-- Close Button -->
       <a href="#" id="close" aria-label="Close menu" aria-hidden="false">
-        <i class="fa-solid fa-xmark"></i>
+        <span aria-hidden="true" class="fa-solid fa-xmark"></span>
       </a>
     </ul>
   </div>
@@ -448,12 +448,12 @@
   <div class="mobile">
     <!-- Login Icon -->
     <a href="login.html" aria-label="Login">
-      <i class="ri-user-3-line"></i>
+      <span aria-hidden="true" class="ri-user-3-line"></span>
     </a>
 
     <!-- Cart Icon -->
     <a href="cart.html" aria-label="Cart">
-      <i class="ri-shopping-bag-4-line"></i>
+      <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
     </a>
 
     <!-- Hamburger Menu -->
@@ -467,7 +467,7 @@
     ></i>
       <!-- Theme Toggle -->
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-        <i class="ri-moon-line" id="themeIconMobile"></i>
+        <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
       </button>
   </div>
 </section>
@@ -524,7 +524,7 @@
     <div class="faq-item" style="padding: 15px 0;">
       <button onclick="toggleFaq(this)" class="faq-accordion-btn" style="width: 100%; text-align: left; background: none; border: none; font-size: 18px; font-weight: 600; cursor: pointer; display: flex; justify-content: space-between; align-items: center;">
         <span>What is the return policy?</span>
-        <i class="ri-add-line"></i>
+        <span aria-hidden="true" class="ri-add-line"></span>
       </button>
       <div class="faq-answer" style="display: none; padding-top: 10px;">
         We offer a 30-day return policy for all unworn apparel items with tags intact.
@@ -533,7 +533,7 @@
     <div class="faq-item" style="padding: 15px 0;">
       <button onclick="toggleFaq(this)" class="faq-accordion-btn" style="width: 100%; text-align: left; background: none; border: none; font-size: 18px; font-weight: 600; cursor: pointer; display: flex; justify-content: space-between; align-items: center;">
         <span>Do you ship internationally?</span>
-        <i class="ri-add-line"></i>
+        <span aria-hidden="true" class="ri-add-line"></span>
       </button>
       <div class="faq-answer" style="display: none; padding-top: 10px;">
         Yes! We ship to over 50 countries worldwide. Shipping fees are calculated at checkout.
@@ -642,7 +642,7 @@
           <p style="margin: 0; font-size: 14px; color: #666;">Cara was launched with a core vision of fast, beautiful e-commerce.</p>
         </div>
         <div class="milestone-dot" style="position: absolute; left: 50%; width: 40px; height: 40px; border-radius: 50%; background: #088178; color: white; display: flex; align-items: center; justify-content: center; z-index: 2; box-shadow: 0 4px 6px rgba(0,0,0,0.1);">
-          <i class="ri-rocket-2-line"></i>
+          <span aria-hidden="true" class="ri-rocket-2-line"></span>
         </div>
         <div style="width: 45%;"></div>
       </div>
@@ -651,7 +651,7 @@
       <div class="milestone-item milestone-right" style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 40px; position: relative;">
         <div style="width: 45%;"></div>
         <div class="milestone-dot" style="position: absolute; left: 50%; width: 40px; height: 40px; border-radius: 50%; background: #088178; color: white; display: flex; align-items: center; justify-content: center; z-index: 2; box-shadow: 0 4px 6px rgba(0,0,0,0.1);">
-          <i class="ri-team-line"></i>
+          <span aria-hidden="true" class="ri-team-line"></span>
         </div>
         <div style="width: 45%; padding-left: 30px;">
           <span style="font-weight: 700; color: #088178; font-size: 20px;">2025</span>
@@ -668,7 +668,7 @@
           <p style="margin: 0; font-size: 14px; color: #666;">Pioneered custom AI-powered stylist assistance for virtual selections.</p>
         </div>
         <div class="milestone-dot" style="position: absolute; left: 50%; width: 40px; height: 40px; border-radius: 50%; background: #088178; color: white; display: flex; align-items: center; justify-content: center; z-index: 2; box-shadow: 0 4px 6px rgba(0,0,0,0.1);">
-          <i class="ri-sparkling-line"></i>
+          <span aria-hidden="true" class="ri-sparkling-line"></span>
         </div>
         <div style="width: 45%;"></div>
       </div>
@@ -697,7 +697,7 @@
           rel="noopener noreferrer"
           aria-label="Twitter / X"
         >
-          <i class="fa-brands fa-x-twitter"></i>
+          <span aria-hidden="true" class="fa-brands fa-x-twitter"></span>
         </a>
         <a
           href="https://github.com/janavipandole"
@@ -831,7 +831,7 @@
 </footer>
 
 <button id="scrollTopBtn" title="Go to top" aria-label="Go to top">
-  <i class="ri-arrow-up-line"></i>
+  <span aria-hidden="true" class="ri-arrow-up-line"></span>
 </button>
 
 <!-- Scripts -->

--- a/blog-aw20-menswear.html
+++ b/blog-aw20-menswear.html
@@ -179,19 +179,19 @@
                 <li><a href="about.html">About</a></li>
                 <li><a href="contact.html">Contact</a></li>
                 <li><a href="login.html" id="login-btn">Login</a></li>
-                <li><a href="cart.html" id="lg-bag"><i class="ri-shopping-bag-4-line"></i></a></li>
+                <li><a href="cart.html" id="lg-bag"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a></li>
                 <li>
                     <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
-                        <i class="ri-moon-line" id="themeIcon"></i>
+                        <span aria-hidden="true" class="ri-moon-line" id="themeIcon"></span>
                     </button>
                 </li>
-                <a href="#" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="#" id="close"><span aria-hidden="true" class="fa-solid fa-xmark"></span></a>
             </ul>
         </div>
         <div class="mobile">
-            <a href="cart.html"><i class="ri-shopping-bag-4-line"></i></a>
+            <a href="cart.html"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a>
             <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-                <i class="ri-moon-line" id="themeIconMobile"></i>
+                <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
             </button>
             <i class="fas fa-outdent" id="bar"></i>
         </div>
@@ -206,7 +206,7 @@
     <div class="article-container">
 
         <a href="blog.html" class="back-link">
-            <i class="ri-arrow-left-line"></i> Back to Blog
+            <span aria-hidden="true" class="ri-arrow-left-line"></span> Back to Blog
         </a>
 
         <div class="article-meta">
@@ -300,7 +300,7 @@
               target="_blank"
               rel="noopener noreferrer"
             >
-              <i class="fa-brands fa-x-twitter"></i>
+              <span aria-hidden="true" class="fa-brands fa-x-twitter"></span>
             </a>
             <a
               href="https://github.com/janavipandole"

--- a/blog-cotton-jersey-hoodie.html
+++ b/blog-cotton-jersey-hoodie.html
@@ -194,19 +194,19 @@
                 <li><a href="about.html">About</a></li>
                 <li><a href="contact.html">Contact</a></li>
                 <li><a href="login.html" id="login-btn">Login</a></li>
-                <li><a href="cart.html" id="lg-bag"><i class="ri-shopping-bag-4-line"></i></a></li>
+                <li><a href="cart.html" id="lg-bag"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a></li>
                 <li>
                     <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
-                        <i class="ri-moon-line" id="themeIcon"></i>
+                        <span aria-hidden="true" class="ri-moon-line" id="themeIcon"></span>
                     </button>
                 </li>
-                <a href="#" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="#" id="close"><span aria-hidden="true" class="fa-solid fa-xmark"></span></a>
             </ul>
         </div>
         <div class="mobile">
-            <a href="cart.html"><i class="ri-shopping-bag-4-line"></i></a>
+            <a href="cart.html"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a>
             <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-                <i class="ri-moon-line" id="themeIconMobile"></i>
+                <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
             </button>
             <i class="fas fa-outdent" id="bar"></i>
         </div>
@@ -222,7 +222,7 @@
 
         <!-- Back to Blog -->
         <a href="blog.html" class="back-link">
-            <i class="ri-arrow-left-line"></i> Back to Blog
+            <span aria-hidden="true" class="ri-arrow-left-line"></span> Back to Blog
         </a>
 
         <!-- Meta -->
@@ -308,7 +308,7 @@
               target="_blank"
               rel="noopener noreferrer"
             >
-              <i class="fa-brands fa-x-twitter"></i>
+              <span aria-hidden="true" class="fa-brands fa-x-twitter"></span>
             </a>
             <a
               href="https://github.com/janavipandole"

--- a/blog-quiff-styling.html
+++ b/blog-quiff-styling.html
@@ -179,19 +179,19 @@
                 <li><a href="about.html">About</a></li>
                 <li><a href="contact.html">Contact</a></li>
                 <li><a href="login.html" id="login-btn">Login</a></li>
-                <li><a href="cart.html" id="lg-bag"><i class="ri-shopping-bag-4-line"></i></a></li>
+                <li><a href="cart.html" id="lg-bag"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a></li>
                 <li>
                     <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
-                        <i class="ri-moon-line" id="themeIcon"></i>
+                        <span aria-hidden="true" class="ri-moon-line" id="themeIcon"></span>
                     </button>
                 </li>
-                <a href="#" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="#" id="close"><span aria-hidden="true" class="fa-solid fa-xmark"></span></a>
             </ul>
         </div>
         <div class="mobile">
-            <a href="cart.html"><i class="ri-shopping-bag-4-line"></i></a>
+            <a href="cart.html"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a>
             <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-                <i class="ri-moon-line" id="themeIconMobile"></i>
+                <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
             </button>
             <i class="fas fa-outdent" id="bar"></i>
         </div>
@@ -206,7 +206,7 @@
     <div class="article-container">
 
         <a href="blog.html" class="back-link">
-            <i class="ri-arrow-left-line"></i> Back to Blog
+            <span aria-hidden="true" class="ri-arrow-left-line"></span> Back to Blog
         </a>
 
         <div class="article-meta">
@@ -291,7 +291,7 @@
               target="_blank"
               rel="noopener noreferrer"
             >
-              <i class="fa-brands fa-x-twitter"></i>
+              <span aria-hidden="true" class="fa-brands fa-x-twitter"></span>
             </a>
             <a
               href="https://github.com/janavipandole"

--- a/blog-runway-trends.html
+++ b/blog-runway-trends.html
@@ -178,19 +178,19 @@
                 <li><a href="about.html">About</a></li>
                 <li><a href="contact.html">Contact</a></li>
                 <li><a href="login.html" id="login-btn">Login</a></li>
-                <li><a href="cart.html" id="lg-bag"><i class="ri-shopping-bag-4-line"></i></a></li>
+                <li><a href="cart.html" id="lg-bag"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a></li>
                 <li>
                     <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
-                        <i class="ri-moon-line" id="themeIcon"></i>
+                        <span aria-hidden="true" class="ri-moon-line" id="themeIcon"></span>
                     </button>
                 </li>
-                <a href="#" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="#" id="close"><span aria-hidden="true" class="fa-solid fa-xmark"></span></a>
             </ul>
         </div>
         <div class="mobile">
-            <a href="cart.html"><i class="ri-shopping-bag-4-line"></i></a>
+            <a href="cart.html"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a>
             <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-                <i class="ri-moon-line" id="themeIconMobile"></i>
+                <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
             </button>
             <i class="fas fa-outdent" id="bar"></i>
         </div>
@@ -205,7 +205,7 @@
     <div class="article-container">
 
         <a href="blog.html" class="back-link">
-            <i class="ri-arrow-left-line"></i> Back to Blog
+            <span aria-hidden="true" class="ri-arrow-left-line"></span> Back to Blog
         </a>
 
         <div class="article-meta">
@@ -288,7 +288,7 @@
               target="_blank"
               rel="noopener noreferrer"
             >
-              <i class="fa-brands fa-x-twitter"></i>
+              <span aria-hidden="true" class="fa-brands fa-x-twitter"></span>
             </a>
             <a
               href="https://github.com/janavipandole"

--- a/blog-skater-girls.html
+++ b/blog-skater-girls.html
@@ -178,19 +178,19 @@
                 <li><a href="about.html">About</a></li>
                 <li><a href="contact.html">Contact</a></li>
                 <li><a href="login.html" id="login-btn">Login</a></li>
-                <li><a href="cart.html" id="lg-bag"><i class="ri-shopping-bag-4-line"></i></a></li>
+                <li><a href="cart.html" id="lg-bag"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a></li>
                 <li>
                     <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
-                        <i class="ri-moon-line" id="themeIcon"></i>
+                        <span aria-hidden="true" class="ri-moon-line" id="themeIcon"></span>
                     </button>
                 </li>
-                <a href="#" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="#" id="close"><span aria-hidden="true" class="fa-solid fa-xmark"></span></a>
             </ul>
         </div>
         <div class="mobile">
-            <a href="cart.html"><i class="ri-shopping-bag-4-line"></i></a>
+            <a href="cart.html"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a>
             <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-                <i class="ri-moon-line" id="themeIconMobile"></i>
+                <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
             </button>
             <i class="fas fa-outdent" id="bar"></i>
         </div>
@@ -205,7 +205,7 @@
     <div class="article-container">
 
         <a href="blog.html" class="back-link">
-            <i class="ri-arrow-left-line"></i> Back to Blog
+            <span aria-hidden="true" class="ri-arrow-left-line"></span> Back to Blog
         </a>
 
         <div class="article-meta">
@@ -295,7 +295,7 @@
               target="_blank"
               rel="noopener noreferrer"
             >
-              <i class="fa-brands fa-x-twitter"></i>
+              <span aria-hidden="true" class="fa-brands fa-x-twitter"></span>
             </a>
             <a
               href="https://github.com/janavipandole"

--- a/blog.html
+++ b/blog.html
@@ -134,21 +134,21 @@
       <!-- Contact Icon -->
       <li class="nav-icon">
         <a href="contact.html" aria-label="Contact">
-          <i class="ri-customer-service-2-line"></i>
+          <span aria-hidden="true" class="ri-customer-service-2-line"></span>
         </a>
       </li>
 
       <!-- Login Icon -->
       <li class="nav-icon">
         <a href="login.html" aria-label="Login">
-          <i class="ri-user-3-line"></i>
+          <span aria-hidden="true" class="ri-user-3-line"></span>
         </a>
       </li>
 
       <!-- Cart Icon -->
       <li class="nav-icon">
         <a href="cart.html" id="lg-bag" aria-label="Cart">
-          <i class="ri-shopping-bag-4-line"></i>
+          <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
         </a>
       </li>
 
@@ -159,7 +159,7 @@
           id="themeToggle"
           aria-label="Toggle dark mode"
         >
-          <i class="ri-moon-line" id="themeIcon"></i>
+          <span aria-hidden="true" class="ri-moon-line" id="themeIcon"></span>
         </button>
       </li>
 
@@ -170,7 +170,7 @@
         aria-label="Close menu"
         aria-hidden="false"
       >
-        <i class="fa-solid fa-xmark"></i>
+        <span aria-hidden="true" class="fa-solid fa-xmark"></span>
       </a>
 
     </ul>
@@ -181,12 +181,12 @@
 
     <!-- Login Icon -->
     <a href="login.html" aria-label="Login">
-      <i class="ri-user-3-line"></i>
+      <span aria-hidden="true" class="ri-user-3-line"></span>
     </a>
 
     <!-- Cart Icon -->
     <a href="cart.html" aria-label="Cart">
-      <i class="ri-shopping-bag-4-line"></i>
+      <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
     </a>
 
     <!-- Hamburger Menu -->
@@ -200,7 +200,7 @@
     ></i>
       <!-- Theme Toggle -->
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-        <i class="ri-moon-line" id="themeIconMobile"></i>
+        <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
       </button>
 
   </div>
@@ -237,7 +237,7 @@
           </a>
           <div class="blog-share" style="margin-top: 15px; display: flex; gap: 10px; align-items: center;">
             <span style="font-size: 13px; font-weight: 700; color: #777;">Share:</span>
-            <a href="https://twitter.com/intent/tweet?text=Check out this blog post: The Cotton-Jersey Zip-Up Hoodie&url=https://cara-seven-ashen.vercel.app/blog-cotton-jersey-hoodie.html" target="_blank" rel="noopener noreferrer" aria-label="Share on X" style="color: #088178; font-size: 14px;"><i class="fa-brands fa-x-twitter"></i></a>
+            <a href="https://twitter.com/intent/tweet?text=Check out this blog post: The Cotton-Jersey Zip-Up Hoodie&url=https://cara-seven-ashen.vercel.app/blog-cotton-jersey-hoodie.html" target="_blank" rel="noopener noreferrer" aria-label="Share on X" style="color: #088178; font-size: 14px;"><span aria-hidden="true" class="fa-brands fa-x-twitter"></span></a>
             <a href="https://www.facebook.com/sharer/sharer.php?u=https://cara-seven-ashen.vercel.app/blog-cotton-jersey-hoodie.html" target="_blank" rel="noopener noreferrer" aria-label="Share on Facebook" style="color: #088178; font-size: 14px;"><i class="fab fa-facebook-f"></i></a>
             <a href="https://pinterest.com/pin/create/button/?url=https://cara-seven-ashen.vercel.app/blog-cotton-jersey-hoodie.html" target="_blank" rel="noopener noreferrer" aria-label="Share on Pinterest" style="color: #088178; font-size: 14px;"><i class="fab fa-pinterest"></i></a>
           </div>
@@ -260,7 +260,7 @@
           >
           <div class="blog-share" style="margin-top: 15px; display: flex; gap: 10px; align-items: center;">
             <span style="font-size: 13px; font-weight: 700; color: #777;">Share:</span>
-            <a href="https://twitter.com/intent/tweet?text=Check out this blog post: How to style a Quiff&url=https://cara-seven-ashen.vercel.app/blog-quiff-styling.html" target="_blank" rel="noopener noreferrer" aria-label="Share on X" style="color: #088178; font-size: 14px;"><i class="fa-brands fa-x-twitter"></i></a>
+            <a href="https://twitter.com/intent/tweet?text=Check out this blog post: How to style a Quiff&url=https://cara-seven-ashen.vercel.app/blog-quiff-styling.html" target="_blank" rel="noopener noreferrer" aria-label="Share on X" style="color: #088178; font-size: 14px;"><span aria-hidden="true" class="fa-brands fa-x-twitter"></span></a>
             <a href="https://www.facebook.com/sharer/sharer.php?u=https://cara-seven-ashen.vercel.app/blog-quiff-styling.html" target="_blank" rel="noopener noreferrer" aria-label="Share on Facebook" style="color: #088178; font-size: 14px;"><i class="fab fa-facebook-f"></i></a>
             <a href="https://pinterest.com/pin/create/button/?url=https://cara-seven-ashen.vercel.app/blog-quiff-styling.html" target="_blank" rel="noopener noreferrer" aria-label="Share on Pinterest" style="color: #088178; font-size: 14px;"><i class="fab fa-pinterest"></i></a>
           </div>
@@ -284,7 +284,7 @@
           >
           <div class="blog-share" style="margin-top: 15px; display: flex; gap: 10px; align-items: center;">
             <span style="font-size: 13px; font-weight: 700; color: #777;">Share:</span>
-            <a href="https://twitter.com/intent/tweet?text=Check out this blog post: Must-Have Skater Girls Items&url=https://cara-seven-ashen.vercel.app/blog-skater-girls.html" target="_blank" rel="noopener noreferrer" aria-label="Share on X" style="color: #088178; font-size: 14px;"><i class="fa-brands fa-x-twitter"></i></a>
+            <a href="https://twitter.com/intent/tweet?text=Check out this blog post: Must-Have Skater Girls Items&url=https://cara-seven-ashen.vercel.app/blog-skater-girls.html" target="_blank" rel="noopener noreferrer" aria-label="Share on X" style="color: #088178; font-size: 14px;"><span aria-hidden="true" class="fa-brands fa-x-twitter"></span></a>
             <a href="https://www.facebook.com/sharer/sharer.php?u=https://cara-seven-ashen.vercel.app/blog-skater-girls.html" target="_blank" rel="noopener noreferrer" aria-label="Share on Facebook" style="color: #088178; font-size: 14px;"><i class="fab fa-facebook-f"></i></a>
             <a href="https://pinterest.com/pin/create/button/?url=https://cara-seven-ashen.vercel.app/blog-skater-girls.html" target="_blank" rel="noopener noreferrer" aria-label="Share on Pinterest" style="color: #088178; font-size: 14px;"><i class="fab fa-pinterest"></i></a>
           </div>
@@ -307,7 +307,7 @@
           >
           <div class="blog-share" style="margin-top: 15px; display: flex; gap: 10px; align-items: center;">
             <span style="font-size: 13px; font-weight: 700; color: #777;">Share:</span>
-            <a href="https://twitter.com/intent/tweet?text=Check out this blog post: Runway-Inspired Trends&url=https://cara-seven-ashen.vercel.app/blog-runway-trends.html" target="_blank" rel="noopener noreferrer" aria-label="Share on X" style="color: #088178; font-size: 14px;"><i class="fa-brands fa-x-twitter"></i></a>
+            <a href="https://twitter.com/intent/tweet?text=Check out this blog post: Runway-Inspired Trends&url=https://cara-seven-ashen.vercel.app/blog-runway-trends.html" target="_blank" rel="noopener noreferrer" aria-label="Share on X" style="color: #088178; font-size: 14px;"><span aria-hidden="true" class="fa-brands fa-x-twitter"></span></a>
             <a href="https://www.facebook.com/sharer/sharer.php?u=https://cara-seven-ashen.vercel.app/blog-runway-trends.html" target="_blank" rel="noopener noreferrer" aria-label="Share on Facebook" style="color: #088178; font-size: 14px;"><i class="fab fa-facebook-f"></i></a>
             <a href="https://pinterest.com/pin/create/button/?url=https://cara-seven-ashen.vercel.app/blog-runway-trends.html" target="_blank" rel="noopener noreferrer" aria-label="Share on Pinterest" style="color: #088178; font-size: 14px;"><i class="fab fa-pinterest"></i></a>
           </div>
@@ -330,7 +330,7 @@
           >
           <div class="blog-share" style="margin-top: 15px; display: flex; gap: 10px; align-items: center;">
             <span style="font-size: 13px; font-weight: 700; color: #777;">Share:</span>
-            <a href="https://twitter.com/intent/tweet?text=Check out this blog post: AW20 Menswear Trends&url=https://cara-seven-ashen.vercel.app/blog-aw20-menswear.html" target="_blank" rel="noopener noreferrer" aria-label="Share on X" style="color: #088178; font-size: 14px;"><i class="fa-brands fa-x-twitter"></i></a>
+            <a href="https://twitter.com/intent/tweet?text=Check out this blog post: AW20 Menswear Trends&url=https://cara-seven-ashen.vercel.app/blog-aw20-menswear.html" target="_blank" rel="noopener noreferrer" aria-label="Share on X" style="color: #088178; font-size: 14px;"><span aria-hidden="true" class="fa-brands fa-x-twitter"></span></a>
             <a href="https://www.facebook.com/sharer/sharer.php?u=https://cara-seven-ashen.vercel.app/blog-aw20-menswear.html" target="_blank" rel="noopener noreferrer" aria-label="Share on Facebook" style="color: #088178; font-size: 14px;"><i class="fab fa-facebook-f"></i></a>
             <a href="https://pinterest.com/pin/create/button/?url=https://cara-seven-ashen.vercel.app/blog-aw20-menswear.html" target="_blank" rel="noopener noreferrer" aria-label="Share on Pinterest" style="color: #088178; font-size: 14px;"><i class="fab fa-pinterest"></i></a>
           </div>
@@ -341,10 +341,10 @@
 
     <!-- Back to Top and Scroll to Bottom Buttons -->
     <button id="backToTop" title="Back to Top" aria-label="Back to top">
-      <i class="ri-arrow-up-line"></i>
+      <span aria-hidden="true" class="ri-arrow-up-line"></span>
     </button>
     <button id="Toptoback" title="Top To Back" aria-label="Scroll to bottom">
-      <i class="ri-arrow-down-line"></i>
+      <span aria-hidden="true" class="ri-arrow-down-line"></span>
     </button>
 
     <!-- Footer -->
@@ -368,7 +368,7 @@
               target="_blank"
               rel="noopener noreferrer"
             >
-              <i class="fa-brands fa-x-twitter"></i>
+              <span aria-hidden="true" class="fa-brands fa-x-twitter"></span>
             </a>
             <a
               href="https://github.com/janavipandole"
@@ -498,7 +498,7 @@
       </div>
     </footer>
     <button id="scrollTopBtn" title="Go to top" aria-label="Go to top">
-      <i class="ri-arrow-up-line"></i>
+      <span aria-hidden="true" class="ri-arrow-up-line"></span>
     </button>
 
 

--- a/cara.html
+++ b/cara.html
@@ -555,7 +555,7 @@
         </svg>
       </button>
       <button class="icon-btn theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
-        <i class="ri-moon-line" id="themeIcon" style="font-size: 18px;"></i>
+        <span aria-hidden="true" class="ri-moon-line" id="themeIcon" style="font-size: 18px;"></span>
       </button>
     </div>
   </header>

--- a/cart.html
+++ b/cart.html
@@ -379,34 +379,34 @@ button + button {
         <!-- Contact Icon -->
         <li class="nav-icon">
           <a href="contact.html" aria-label="Contact">
-            <i class="ri-customer-service-2-line"></i>
+            <span aria-hidden="true" class="ri-customer-service-2-line"></span>
           </a>
         </li>
 
         <!-- Login Icon -->
         <li class="nav-icon">
           <a href="login.html" aria-label="Login">
-            <i class="ri-user-3-line"></i>
+            <span aria-hidden="true" class="ri-user-3-line"></span>
           </a>
         </li>
 
         <!-- Cart Icon -->
         <li class="nav-icon">
           <a class="active" href="cart.html" id="lg-bag" aria-label="Cart">
-            <i class="ri-shopping-bag-4-line"></i>
+            <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
           </a>
         </li>
 
         <!-- Theme Toggle -->
         <li class="nav-icon">
           <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
-            <i class="ri-moon-line" id="themeIcon"></i>
+            <span aria-hidden="true" class="ri-moon-line" id="themeIcon"></span>
           </button>
         </li>
 
         <!-- Close Button -->
         <a href="javascript:void(0)" id="close" aria-label="Close menu" aria-hidden="false">
-          <i class="fa-solid fa-xmark"></i>
+          <span aria-hidden="true" class="fa-solid fa-xmark"></span>
         </a>
 
       </ul>
@@ -417,19 +417,19 @@ button + button {
 
       <!-- Login Icon -->
       <a href="login.html" aria-label="Login">
-        <i class="ri-user-3-line"></i>
+        <span aria-hidden="true" class="ri-user-3-line"></span>
       </a>
 
       <!-- Cart Icon -->
       <a href="cart.html" aria-label="Cart">
-        <i class="ri-shopping-bag-4-line"></i>
+        <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
       </a>
 
       <!-- Hamburger Menu -->
       <i class="fas fa-outdent" id="bar" role="button" aria-label="Open menu" aria-expanded="false" tabindex="0"></i>
       <!-- Theme Toggle -->
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-        <i class="ri-moon-line" id="themeIconMobile"></i>
+        <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
       </button>
 
     </div>
@@ -472,7 +472,7 @@ button + button {
               <div id="cart-items-container"></div>
               <div class="cart-actions-bottom">
                 <a href="shop.html" class="continue-shopping-btn">
-                  <i class="ri-arrow-left-line"></i> Continue Shopping
+                  <span aria-hidden="true" class="ri-arrow-left-line"></span> Continue Shopping
                 </a>
               </div>
             </div>
@@ -493,7 +493,7 @@ button + button {
 
                 <!-- Loyalty Rewards Section inside Summary -->
                 <div id="loyalty-points-container" style="background: rgba(8, 129, 120, 0.05); margin: 20px 0; padding: 15px; border: 1px solid rgba(8, 129, 120, 0.2); border-radius: 6px; font-family: sans-serif; font-size: 14px;">
-                    <h4 style="color: #088178; margin-top: 0; margin-bottom: 8px;"><i class="ri-medal-line"></i> Cara Loyalty Rewards</h4>
+                    <h4 style="color: #088178; margin-top: 0; margin-bottom: 8px;"><span aria-hidden="true" class="ri-medal-line"></span> Cara Loyalty Rewards</h4>
                     <p style="margin: 4px 0;">Balance: <strong id="loyalty-balance" style="color: #088178;">0</strong> pts</p>
                     <p style="margin: 4px 0;">Earn from order: <strong id="points-to-earn">0</strong> pts</p>
                     <div id="loyalty-apply-section" style="margin-top: 8px; display: flex; gap: 6px;">
@@ -529,7 +529,7 @@ button + button {
                 </div>
 
                 <button class="checkout-btn" onclick="window.location.href='checkout.html'">
-                  PROCEED TO CHECKOUT <i class="ri-arrow-right-line"></i>
+                  PROCEED TO CHECKOUT <span aria-hidden="true" class="ri-arrow-right-line"></span>
                 </button>
               </div>
             </div>
@@ -540,7 +540,7 @@ button + button {
   <div class="empty-cart-card">
     
     <div class="empty-cart-icon">
-      <i class="ri-shopping-cart-2-line"></i>
+      <span aria-hidden="true" class="ri-shopping-cart-2-line"></span>
     </div>
     
     <h2>Your Cart is Empty!</h2>
@@ -571,7 +571,7 @@ button + button {
         const val = couponInput.value.trim().toUpperCase();
         
         if (val === "CARA20") {
-          feedback.innerHTML = `<span style="color: #088178;"><i class="ri-checkbox-circle-fill"></i> Coupon CARA20 Applied! 20% Discount active.</span>`;
+          feedback.innerHTML = `<span style="color: #088178;"><span aria-hidden="true" class="ri-checkbox-circle-fill"></span> Coupon CARA20 Applied! 20% Discount active.</span>`;
           
           if (discountRow && discountVal) {
             discountRow.style.display = "flex";
@@ -594,9 +594,9 @@ button + button {
             document.getElementById("summary-total").textContent = "₹" + total.toLocaleString('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
           }
         } else if (val === "") {
-          feedback.innerHTML = `<span style="color: #ef4444;"><i class="ri-error-warning-fill"></i> Please enter a coupon code.</span>`;
+          feedback.innerHTML = `<span style="color: #ef4444;"><span aria-hidden="true" class="ri-error-warning-fill"></span> Please enter a coupon code.</span>`;
         } else {
-          feedback.innerHTML = `<span style="color: #ef4444;"><i class="ri-error-warning-fill"></i> Invalid coupon code. Try CARA20.</span>`;
+          feedback.innerHTML = `<span style="color: #ef4444;"><span aria-hidden="true" class="ri-error-warning-fill"></span> Invalid coupon code. Try CARA20.</span>`;
           if (discountRow) discountRow.style.display = "none";
         }
       });
@@ -621,7 +621,7 @@ button + button {
     
     <h4 style="color: #ffffff !important; font-size: 13px !important; font-weight: 700 !important; margin: 15px 0 8px 0 !important; text-transform: uppercase; letter-spacing: 0.5px;">Follow us</h4>
     <div class="icon" style="display: flex !important; gap: 12px !important; font-size: 15px !important;">
-      <a href="https://x.com/JanaviPandole" target="_blank" rel="noopener noreferrer" style="color: #cbd5e1 !important;"><i class="ri-twitter-x-fill"></i></a>
+      <a href="https://x.com/JanaviPandole" target="_blank" rel="noopener noreferrer" style="color: #cbd5e1 !important;"><span aria-hidden="true" class="ri-twitter-x-fill"></span></a>
       <a href="https://github.com/janavipandole" target="_blank" rel="noopener noreferrer" style="color: #cbd5e1 !important;"><i class="fab fa-github"></i></a>
       <a href="https://www.linkedin.com/in/janavi-pandole-80a7b2290" target="_blank" rel="noopener noreferrer" style="color: #cbd5e1 !important;"><i class="fab fa-linkedin"></i></a>
       <a href="https://www.youtube.com/@JanaviPandole" target="_blank" rel="noopener noreferrer" style="color: #cbd5e1 !important;"><i class="fab fa-youtube"></i></a>

--- a/checkout.html
+++ b/checkout.html
@@ -27,13 +27,13 @@
 
     <div class="checkout-header">
       <div class="back-to-cart">
-        <a href="cart.html" class="back-link" aria-label="Back to cart"><i class="ri-arrow-left-line"></i> Back to Cart</a>
+        <a href="cart.html" class="back-link" aria-label="Back to cart"><span aria-hidden="true" class="ri-arrow-left-line"></span> Back to Cart</a>
         <a href="#" id="logout-btn" style="display:none">Logout</a>
       </div>
       <div class="logo" style="display: flex; align-items: center; gap: 15px;">
         <span>Cara</span>
         <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode" style="background: transparent; border: none; cursor: pointer;">
-          <i class="ri-moon-line" id="themeIcon" style="font-size: 20px;"></i>
+          <span aria-hidden="true" class="ri-moon-line" id="themeIcon" style="font-size: 20px;"></span>
         </button>
       </div>
     </div>
@@ -44,7 +44,7 @@
 
     <!-- Back button -->
     <button class="back-btn" onclick="window.location.href='cart.html'">
-      <i class="ri-arrow-left-line"></i> Back to Cart
+      <span aria-hidden="true" class="ri-arrow-left-line"></span> Back to Cart
     </button>
 
     <!-- Page title -->
@@ -56,7 +56,7 @@
 
     <!-- Countdown Timer Banner -->
     <div id="checkout-timer-banner" style="background: #fff3cd; color: #856404; padding: 12px; border-radius: 8px; margin-bottom: 20px; display: flex; align-items: center; gap: 10px; border: 1px solid #ffeeba; font-weight: 500;">
-      <i class="ri-time-line" style="font-size: 20px;"></i>
+      <span aria-hidden="true" class="ri-time-line" style="font-size: 20px;"></span>
       <span>Items are reserved! Complete your purchase within <strong id="countdown-timer">10:00</strong> minutes.</span>
     </div>
     
@@ -89,7 +89,7 @@
         <!-- Contact Information -->
         <fieldset class="card">
           <legend class="card-title">
-            <i class="ri-user-3-line"></i> Contact Information
+            <span aria-hidden="true" class="ri-user-3-line"></span> Contact Information
           </legend>
 
         <div class="input-group">
@@ -142,10 +142,10 @@
 
           <div class="payment-tabs">
             <div class="payment-tab active" id="tabCOD" onclick="selectPayment('cod')">
-              <i class="ri-money-rupee-circle-line"></i> Cash on Delivery
+              <span aria-hidden="true" class="ri-money-rupee-circle-line"></span> Cash on Delivery
             </div>
             <div class="payment-tab" id="tabOnline" onclick="selectPayment('online')">
-              <i class="ri-bank-card-2-line"></i> Online Payment
+              <span aria-hidden="true" class="ri-bank-card-2-line"></span> Online Payment
             </div>
           </div>
 
@@ -204,10 +204,10 @@
         <!-- Preview and Totals -->
         <fieldset class="card">
           <legend class="card-title">
-            <i class="ri-shopping-bag-3-line"></i> Order Summary
+            <span aria-hidden="true" class="ri-shopping-bag-3-line"></span> Order Summary
           </legend>
           <div class="order-item">
-            <div class="item-thumb"><i class="ri-shirt-line"></i></div>
+            <div class="item-thumb"><span aria-hidden="true" class="ri-shirt-line"></span></div>
             <div class="item-info">
               <div class="item-name">Tropical Print Shirt</div>
               <div class="item-meta">H&M · Size L · Qty 2</div>
@@ -233,10 +233,10 @@
             </div>
           </div>
           <button type="submit" class="submit-btn">
-            <i class="ri-shield-check-line"></i> Place Your Order
+            <span aria-hidden="true" class="ri-shield-check-line"></span> Place Your Order
           </button>
           <div class="secure-badge">
-            <i class="ri-lock-line"></i> 100% Secure Checkout
+            <span aria-hidden="true" class="ri-lock-line"></span> 100% Secure Checkout
           </div>
         </fieldset>
       </div>
@@ -247,7 +247,7 @@
   <!-- ══ SUCCESS POPUP ══ -->
   <div class="success-overlay" id="successPopup">
     <div class="popup-box">
-      <div class="check-circle" aria-hidden="true"><i class="ri-check-line"></i></div>
+      <div class="check-circle" aria-hidden="true"><span aria-hidden="true" class="ri-check-line"></span></div>
       <h2>Order Successful!</h2>
       <p>Your order has been placed successfully. We'll send you a confirmation shortly.</p>
       <button class="popup-btn" onclick="window.location.href='shop.html'">Continue Shopping</button>

--- a/community.html
+++ b/community.html
@@ -256,21 +256,21 @@
       <!-- Contact Icon -->
       <li class="nav-icon">
         <a href="contact.html" aria-label="Contact">
-          <i class="ri-customer-service-2-line"></i>
+          <span aria-hidden="true" class="ri-customer-service-2-line"></span>
         </a>
       </li>
 
       <!-- Login Icon -->
       <li class="nav-icon">
         <a href="login.html" aria-label="Login">
-          <i class="ri-user-3-line"></i>
+          <span aria-hidden="true" class="ri-user-3-line"></span>
         </a>
       </li>
 
       <!-- Cart Icon -->
       <li class="nav-icon">
         <a href="cart.html" id="lg-bag" aria-label="Cart">
-          <i class="ri-shopping-bag-4-line"></i>
+          <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
         </a>
       </li>
 
@@ -281,7 +281,7 @@
           id="themeToggle"
           aria-label="Toggle dark mode"
         >
-          <i class="ri-moon-line" id="themeIcon"></i>
+          <span aria-hidden="true" class="ri-moon-line" id="themeIcon"></span>
         </button>
       </li>
 
@@ -292,7 +292,7 @@
         aria-label="Close menu"
         aria-hidden="false"
       >
-        <i class="fa-solid fa-xmark"></i>
+        <span aria-hidden="true" class="fa-solid fa-xmark"></span>
       </a>
 
     </ul>
@@ -303,12 +303,12 @@
 
     <!-- Login Icon -->
     <a href="login.html" aria-label="Login">
-      <i class="ri-user-3-line"></i>
+      <span aria-hidden="true" class="ri-user-3-line"></span>
     </a>
 
     <!-- Cart Icon -->
     <a href="cart.html" aria-label="Cart">
-      <i class="ri-shopping-bag-4-line"></i>
+      <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
     </a>
 
     <!-- Hamburger Menu -->
@@ -322,7 +322,7 @@
     ></i>
       <!-- Theme Toggle -->
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-        <i class="ri-moon-line" id="themeIconMobile"></i>
+        <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
       </button>
 
   </div>
@@ -340,7 +340,7 @@
     
     <label class="cara-upload-box" for="community-upload">
         <div class="cara-upload-content">
-            <i class="ri-camera-lens-fill cara-icon"></i>
+            <span aria-hidden="true" class="ri-camera-lens-fill cara-icon"></span>
             <h3 class="cara-title">Click to Upload Photo</h3>
             <p class="cara-text">PNG, JPG up to 5MB</p>
         </div>
@@ -348,7 +348,7 @@
     <div id="upload-success" style="display:none; color: green; margin-top: 15px; font-weight: bold; text-align: center;">Photo uploaded successfully!</div>
     </label>
     <div id="upload-success" style="display: none; color: #088178; font-weight: 600; margin-top: 15px; text-align: center;">
-        <i class="ri-checkbox-circle-fill"></i> Upload Successful! Your look is being reviewed.
+        <span aria-hidden="true" class="ri-checkbox-circle-fill"></span> Upload Successful! Your look is being reviewed.
     </div>
 </section>
 
@@ -432,7 +432,7 @@
         <h4>Follow us</h4>
         <div class="icon">
           <a href="https://x.com/JanaviPandole" target="_blank" rel="noopener noreferrer">
-            <i class="fa-brands fa-x-twitter"></i>
+            <span aria-hidden="true" class="fa-brands fa-x-twitter"></span>
           </a>
           <a href="https://github.com/janavipandole" target="_blank" rel="noopener noreferrer">
             <i class="fab fa-github"></i>

--- a/contact.html
+++ b/contact.html
@@ -452,21 +452,21 @@ footer .copyright {
       <!-- Contact Icon -->
       <li class="nav-icon">
         <a class="active" href="contact.html" aria-label="Contact">
-          <i class="ri-customer-service-2-line"></i>
+          <span aria-hidden="true" class="ri-customer-service-2-line"></span>
         </a>
       </li>
 
       <!-- Login Icon -->
       <li class="nav-icon">
         <a href="login.html" aria-label="Login">
-          <i class="ri-user-3-line"></i>
+          <span aria-hidden="true" class="ri-user-3-line"></span>
         </a>
       </li>
 
       <!-- Cart Icon -->
       <li class="nav-icon">
         <a href="cart.html" id="lg-bag" aria-label="Cart">
-          <i class="ri-shopping-bag-4-line"></i>
+          <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
         </a>
       </li>
 
@@ -477,7 +477,7 @@ footer .copyright {
           id="themeToggle"
           aria-label="Toggle dark mode"
         >
-          <i class="ri-moon-line" id="themeIcon"></i>
+          <span aria-hidden="true" class="ri-moon-line" id="themeIcon"></span>
         </button>
       </li>
 
@@ -488,7 +488,7 @@ footer .copyright {
         aria-label="Close menu"
         aria-hidden="false"
       >
-        <i class="fa-solid fa-xmark"></i>
+        <span aria-hidden="true" class="fa-solid fa-xmark"></span>
       </a>
 
     </ul>
@@ -499,12 +499,12 @@ footer .copyright {
 
     <!-- Login Icon -->
     <a href="login.html" aria-label="Login">
-      <i class="ri-user-3-line"></i>
+      <span aria-hidden="true" class="ri-user-3-line"></span>
     </a>
 
     <!-- Cart Icon -->
     <a href="cart.html" aria-label="Cart">
-      <i class="ri-shopping-bag-4-line"></i>
+      <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
     </a>
 
     <!-- Hamburger Menu -->
@@ -523,10 +523,10 @@ footer .copyright {
     <div class="mobile">
       <button class="theme-toggle" id="themeToggleMobile"
         aria-label="Toggle dark mode">
-        <i class="ri-moon-line" id="themeIconMobile"></i>
+        <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
       </button>
       <a href="cart.html" id="mobile-cart-icon">
-        <i class="ri-shopping-bag-4-line"></i>
+        <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
         <span class="cart-count" id="mobileCartCount">0</span>
       </a>
       <i class="fas fa-outdent" id="bar"></i>
@@ -679,19 +679,19 @@ footer .copyright {
   <h2 style="font-size: 32px; font-weight: 700; color: var(--text-primary); text-align: center; margin-bottom: 30px;">Frequently Asked Questions</h2>
   <div class="faq-accordion" style="max-width: 800px; margin: 0 auto; display: flex; flex-direction: column; gap: 15px;">
     <details class="faq-item" style="background: #f7f7f7; border: 1px solid #cde7d8; border-radius: 8px; overflow: hidden; padding: 10px;">
-      <summary class="faq-trigger" style="padding: 14px 20px; font-size: 16px; font-weight: 600; color: #222; cursor: pointer; display: flex; justify-content: space-between; align-items: center; list-style: none;">How long does shipping take? <i class="fa-solid fa-chevron-down"></i></summary>
+      <summary class="faq-trigger" style="padding: 14px 20px; font-size: 16px; font-weight: 600; color: #222; cursor: pointer; display: flex; justify-content: space-between; align-items: center; list-style: none;">How long does shipping take? <span aria-hidden="true" class="fa-solid fa-chevron-down"></span></summary>
       <div class="faq-content" style="padding: 10px 20px; font-size: 14px; color: #6c757d; line-height: 1.6; border-top: 1px solid #cde7d8; margin-top: 5px;">
         Standard shipping takes 3-5 business days. Express shipping is delivered in 1-2 business days.
       </div>
     </details>
     <details class="faq-item" style="background: #f7f7f7; border: 1px solid #cde7d8; border-radius: 8px; overflow: hidden; padding: 10px;">
-      <summary class="faq-trigger" style="padding: 14px 20px; font-size: 16px; font-weight: 600; color: #222; cursor: pointer; display: flex; justify-content: space-between; align-items: center; list-style: none;">What is your return policy? <i class="fa-solid fa-chevron-down"></i></summary>
+      <summary class="faq-trigger" style="padding: 14px 20px; font-size: 16px; font-weight: 600; color: #222; cursor: pointer; display: flex; justify-content: space-between; align-items: center; list-style: none;">What is your return policy? <span aria-hidden="true" class="fa-solid fa-chevron-down"></span></summary>
       <div class="faq-content" style="padding: 10px 20px; font-size: 14px; color: #6c757d; line-height: 1.6; border-top: 1px solid #cde7d8; margin-top: 5px;">
         We offer a 30-day return policy. Items must be in their original condition and packaging.
       </div>
     </details>
     <details class="faq-item" style="background: #f7f7f7; border: 1px solid #cde7d8; border-radius: 8px; overflow: hidden; padding: 10px;">
-      <summary class="faq-trigger" style="padding: 14px 20px; font-size: 16px; font-weight: 600; color: #222; cursor: pointer; display: flex; justify-content: space-between; align-items: center; list-style: none;">How do I track my order? <i class="fa-solid fa-chevron-down"></i></summary>
+      <summary class="faq-trigger" style="padding: 14px 20px; font-size: 16px; font-weight: 600; color: #222; cursor: pointer; display: flex; justify-content: space-between; align-items: center; list-style: none;">How do I track my order? <span aria-hidden="true" class="fa-solid fa-chevron-down"></span></summary>
       <div class="faq-content" style="padding: 10px 20px; font-size: 14px; color: #6c757d; line-height: 1.6; border-top: 1px solid #cde7d8; margin-top: 5px;">
         You can track your order using the Order Tracking page with your tracking number sent via email.
       </div>
@@ -728,7 +728,7 @@ footer .copyright {
               target="_blank"
               rel="noopener noreferrer"
             >
-              <i class="fa-brands fa-x-twitter"></i>
+              <span aria-hidden="true" class="fa-brands fa-x-twitter"></span>
             </a>
             <a
               href="https://github.com/janavipandole"
@@ -944,7 +944,7 @@ form.addEventListener("submit", function (e) {
     setTimeout(() => {
       btn.classList.remove("btn-loading");
       form.reset();
-      document.getElementById("form-status").innerHTML = `<div style="display: flex; align-items: center; gap: 8px; color: #088178; margin-top: 15px; font-weight: 600;"><i class="ri-checkbox-circle-line" style="font-size: 20px;"></i> Message sent successfully!</div>`;
+      document.getElementById("form-status").innerHTML = `<div style="display: flex; align-items: center; gap: 8px; color: #088178; margin-top: 15px; font-weight: 600;"><span aria-hidden="true" class="ri-checkbox-circle-line" style="font-size: 20px;"></span> Message sent successfully!</div>`;
     }, 1500);
   }
 });

--- a/contributors.html
+++ b/contributors.html
@@ -40,11 +40,11 @@
     <div id="navbar-container"></div>
 
     <div class="mobile">
-      <a href="cart.html"><i class="ri-shopping-bag-4-line"></i></a>
+      <a href="cart.html"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a>
       <i class="fas fa-outdent" id="bar"></i>
       <!-- Theme Toggle -->
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-        <i class="ri-moon-line" id="themeIconMobile"></i>
+        <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
       </button>
     </div>
   </section>
@@ -118,7 +118,7 @@
       <div class="icon">
 
         <a href="https://x.com/JanaviPandole" target="_blank">
-          <i class="fa-brands fa-x-twitter"></i>
+          <span aria-hidden="true" class="fa-brands fa-x-twitter"></span>
         </a>
 
         <a href="https://github.com/janavipandole" target="_blank">

--- a/crazy-deals.html
+++ b/crazy-deals.html
@@ -194,19 +194,19 @@
           <div class="mobile">
             <!-- Login Icon -->
             <a href="login.html" aria-label="Login">
-              <i class="ri-user-3-line"></i>
+              <span aria-hidden="true" class="ri-user-3-line"></span>
             </a>
 
             <!-- Cart Icon -->
             <a href="cart.html" aria-label="Cart">
-              <i class="ri-shopping-bag-4-line"></i>
+              <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
             </a>
 
             <!-- Hamburger Menu -->
             <i class="fas fa-outdent" id="bar" role="button" aria-label="Open menu" aria-expanded="false" tabindex="0"></i>
       <!-- Theme Toggle -->
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-        <i class="ri-moon-line" id="themeIconMobile"></i>
+        <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
       </button>
           </div>
         </section>
@@ -237,14 +237,14 @@
               <span>Nike</span>
             </div>
             <h5>Cartoon Astronaut T-Shirts</h5>
-            <div class="star"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
+            <div class="star"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span></div>
             <h4 style="display: flex; gap: 10px; justify-content: center; align-items: center;">
               <span style="color: #ef4444;">&#8377;1,249</span>
               <span style="text-decoration: line-through; font-size: 14px; color: #888; font-weight: normal;">&#8377;2,499</span>
             </h4>
             <div class="pro-action-bar">
              <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="event.stopPropagation(); buyNow('Cartoon Astronaut T-Shirts','₹1,249','images/products/f1.jpg',1,'M')">BUY NOW</button>
-              <a href="#" class="pro-cart-btn" aria-label="Add Cartoon Astronaut T-Shirts to cart" onclick="event.stopPropagation(); addToCart('Cartoon Astronaut T-Shirts','₹1,249','images/products/f1.jpg',1,'M'); return false;"><i class="ri-shopping-cart-2-line"></i></a>
+              <a href="#" class="pro-cart-btn" aria-label="Add Cartoon Astronaut T-Shirts to cart" onclick="event.stopPropagation(); addToCart('Cartoon Astronaut T-Shirts','₹1,249','images/products/f1.jpg',1,'M'); return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
             </div>
           </div>
         </div>
@@ -257,14 +257,14 @@
               <span>H&amp;M</span>
             </div>
             <h5>White Palm Leaf Casual Shirt</h5>
-            <div class="star"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
+            <div class="star"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span></div>
             <h4 style="display: flex; gap: 10px; justify-content: center; align-items: center;">
               <span style="color: #ef4444;">&#8377;649</span>
               <span style="text-decoration: line-through; font-size: 14px; color: #888; font-weight: normal;">&#8377;1,299</span>
             </h4>
             <div class="pro-action-bar">
              <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="event.stopPropagation(); buyNow('White Palm Leaf Casual Shirt','₹649','images/products/f2.jpg',1,'M')">BUY NOW</button>
-              <a href="#" class="pro-cart-btn" aria-label="Add White Palm Leaf Casual Shirt to cart" onclick="event.stopPropagation(); addToCart('White Palm Leaf Casual Shirt','₹649','images/products/f2.jpg',1,'M'); return false;"><i class="ri-shopping-cart-2-line"></i></a>
+              <a href="#" class="pro-cart-btn" aria-label="Add White Palm Leaf Casual Shirt to cart" onclick="event.stopPropagation(); addToCart('White Palm Leaf Casual Shirt','₹649','images/products/f2.jpg',1,'M'); return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
             </div>
           </div>
         </div>
@@ -277,14 +277,14 @@
               <span>Puma</span>
             </div>
             <h5>Pink Peony Patterned Shirt</h5>
-            <div class="star"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
+            <div class="star"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span></div>
             <h4 style="display: flex; gap: 10px; justify-content: center; align-items: center;">
               <span style="color: #ef4444;">&#8377;999</span>
               <span style="text-decoration: line-through; font-size: 14px; color: #888; font-weight: normal;">&#8377;1,999</span>
             </h4>
             <div class="pro-action-bar">
              <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="event.stopPropagation(); buyNow('Pink Peony Patterned Shirt','₹999','images/products/f5.jpg',1,'M')">BUY NOW</button>
-              <a href="#" class="pro-cart-btn" aria-label="Add Pink Peony Patterned Shirt to cart" onclick="event.stopPropagation(); addToCart('Pink Peony Patterned Shirt','₹999','images/products/f5.jpg',1,'M'); return false;"><i class="ri-shopping-cart-2-line"></i></a>
+              <a href="#" class="pro-cart-btn" aria-label="Add Pink Peony Patterned Shirt to cart" onclick="event.stopPropagation(); addToCart('Pink Peony Patterned Shirt','₹999','images/products/f5.jpg',1,'M'); return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
             </div>
           </div>
         </div>
@@ -297,14 +297,14 @@
               <span>Gap</span>
             </div>
             <h5>Dual-Tone Corduroy Shirt</h5>
-            <div class="star"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
+            <div class="star"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span></div>
             <h4 style="display: flex; gap: 10px; justify-content: center; align-items: center;">
               <span style="color: #ef4444;">&#8377;1,149</span>
               <span style="text-decoration: line-through; font-size: 14px; color: #888; font-weight: normal;">&#8377;2,299</span>
             </h4>
             <div class="pro-action-bar">
              <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="event.stopPropagation(); buyNow('Dual-Tone Corduroy Shirt','₹1,149','images/products/f6.jpg',1,'M')">BUY NOW</button>
-              <a href="#" class="pro-cart-btn" aria-label="Add Dual-Tone Corduroy Shirt to cart" onclick="event.stopPropagation(); addToCart('Dual-Tone Corduroy Shirt','₹1,149','images/products/f6.jpg',1,'M'); return false;"><i class="ri-shopping-cart-2-line"></i></a>
+              <a href="#" class="pro-cart-btn" aria-label="Add Dual-Tone Corduroy Shirt to cart" onclick="event.stopPropagation(); addToCart('Dual-Tone Corduroy Shirt','₹1,149','images/products/f6.jpg',1,'M'); return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
             </div>
           </div>
         </div>
@@ -326,7 +326,7 @@
         <img class="footer-logo" src="images/logo.png" alt="Cara Logo" />
       </div>
       <div class="footer-socials">
-        <a href="https://x.com/JanaviPandole" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-x-twitter"></i></a>
+        <a href="https://x.com/JanaviPandole" target="_blank" rel="noopener noreferrer"><span aria-hidden="true" class="fa-brands fa-x-twitter"></span></a>
         <a href="https://github.com/janavipandole" target="_blank" rel="noopener noreferrer"><i class="fab fa-github"></i></a>
         <a href="https://www.linkedin.com/in/janavi-pandole-80a7b2290" target="_blank" rel="noopener noreferrer"><i class="fab fa-linkedin"></i></a>
         <a href="https://www.youtube.com/@JanaviPandole" target="_blank" rel="noopener noreferrer"><i class="fab fa-youtube"></i></a>

--- a/deals.html
+++ b/deals.html
@@ -206,21 +206,21 @@
             <li><a href="about.html">About</a></li>
             <li><a href="contact.html">Contact</a></li>
             <li><a href="login.html">Login</a></li>
-            <li><a href="cart.html" id="lg-bag"><i class="ri-shopping-bag-4-line"></i></a></li>
+            <li><a href="cart.html" id="lg-bag"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a></li>
             <li>
                 <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
-                    <i class="ri-moon-line" id="themeIcon"></i>
+                    <span aria-hidden="true" class="ri-moon-line" id="themeIcon"></span>
                 </button>
             </li>
-            <a href="#" id="close"><i class="fa-solid fa-xmark"></i></a>
+            <a href="#" id="close"><span aria-hidden="true" class="fa-solid fa-xmark"></span></a>
         </ul>
     </div>
     <div class="mobile">
-        <a href="cart.html"><i class="ri-shopping-bag-4-line"></i></a>
+        <a href="cart.html"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a>
         <i class="fas fa-outdent" id="bar"></i>
       <!-- Theme Toggle -->
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-        <i class="ri-moon-line" id="themeIconMobile"></i>
+        <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
       </button>
     </div>
 </section>
@@ -242,25 +242,25 @@
 <!-- FEATURES SECTION -->
 <section class="deals-features">
     <div class="deal-card">
-        <i class="ri-shopping-bag-line"></i>
+        <span aria-hidden="true" class="ri-shopping-bag-line"></span>
         <h3>Pick One</h3>
         <p>Select your favourite product from the offer collection.</p>
     </div>
 
     <div class="deal-card">
-        <i class="ri-gift-line"></i>
+        <span aria-hidden="true" class="ri-gift-line"></span>
         <h3>Get One Free</h3>
         <p>Add another eligible product and enjoy the free deal.</p>
     </div>
 
     <div class="deal-card">
-        <i class="ri-price-tag-3-line"></i>
+        <span aria-hidden="true" class="ri-price-tag-3-line"></span>
         <h3>Best Value</h3>
         <p>Save more with special combo offers on selected items.</p>
     </div>
 
     <div class="deal-card">
-        <i class="ri-truck-line"></i>
+        <span aria-hidden="true" class="ri-truck-line"></span>
         <h3>Fast Delivery</h3>
         <p>Quick delivery with safe packaging and easy checkout.</p>
     </div>
@@ -281,10 +281,10 @@
             <div class="des">
                 <span>Cara</span>
                 <h5>Floral Summer Shirt Combo</h5>
-                <div class="star"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
+                <div class="star"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span></div>
                 <h4>$78 <span class="old-price">$120</span></h4>
             </div>
-            <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="cart"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
         </div>
 
         <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -293,10 +293,10 @@
             <div class="des">
                 <span>Cara</span>
                 <h5>Printed Casual Shirt Deal</h5>
-                <div class="star"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
+                <div class="star"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span></div>
                 <h4>$82 <span class="old-price">$130</span></h4>
             </div>
-            <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="cart"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
         </div>
 
         <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -305,10 +305,10 @@
             <div class="des">
                 <span>Cara</span>
                 <h5>Classic Floral Combo</h5>
-                <div class="star"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
+                <div class="star"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span></div>
                 <h4>$75 <span class="old-price">$115</span></h4>
             </div>
-            <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="cart"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
         </div>
 
         <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -317,10 +317,10 @@
             <div class="des">
                 <span>Cara</span>
                 <h5>Premium White Shirt Offer</h5>
-                <div class="star"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
+                <div class="star"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span></div>
                 <h4>$79 <span class="old-price">$125</span></h4>
             </div>
-            <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="cart"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
         </div>
 
     </div>

--- a/delivery.html
+++ b/delivery.html
@@ -480,7 +480,7 @@
     <!-- Print Details Utility -->
     <div style="max-width: 1200px; margin: 10px auto; padding: 0 20px; text-align: right;" class="no-print">
       <button onclick="window.print()" style="background: #088178; color: #fff; border: none; padding: 8px 16px; border-radius: 4px; cursor: pointer; font-weight: 500;">
-        <i class="ri-printer-line"></i> Print Shipping Policy
+        <span aria-hidden="true" class="ri-printer-line"></span> Print Shipping Policy
       </button>
     </div>
     <style>
@@ -502,15 +502,15 @@
     <!-- Mobile Navbar -->
     <div class="mobile">
       <a href="login.html" aria-label="Login">
-        <i class="ri-user-3-line"></i>
+        <span aria-hidden="true" class="ri-user-3-line"></span>
       </a>
       <a href="cart.html" aria-label="Cart">
-        <i class="ri-shopping-bag-4-line"></i>
+        <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
       </a>
       <i class="fas fa-outdent" id="bar" role="button" aria-label="Open menu" aria-expanded="false" tabindex="0"></i>
       <!-- Theme Toggle -->
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-        <i class="ri-moon-line" id="themeIconMobile"></i>
+        <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
       </button>
     </div>
   </section>
@@ -518,7 +518,7 @@
   <!-- BACK BUTTON -->
   <div class="back-btn-wrap">
     <button class="back-btn" onclick="history.back()" aria-label="Go back to previous page" style="background: transparent; border: none; font-family: inherit; font-size: inherit; cursor: pointer;">
-      <i class="fa-solid fa-arrow-left"></i> Back
+      <span aria-hidden="true" class="fa-solid fa-arrow-left"></span> Back
     </button>
   </div>
 
@@ -733,10 +733,10 @@
         <p><strong>Phone:</strong> +01 2222 365 / (+91) 01 2345 6789</p>
         <p><strong>Hours:</strong> 10:00 – 18:00, Mon – Sat</p>
         <div class="social-links">
-          <a href="https://x.com/JanaviPandole" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-x-twitter"></i></a>
-          <a href="https://github.com/janavipandole" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-github"></i></a>
-          <a href="https://www.linkedin.com/in/janavi-pandole-80a7b2290" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-linkedin-in"></i></a>
-          <a href="https://www.youtube.com/@JanaviPandole" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-youtube"></i></a>
+          <a href="https://x.com/JanaviPandole" target="_blank" rel="noopener noreferrer"><span aria-hidden="true" class="fa-brands fa-x-twitter"></span></a>
+          <a href="https://github.com/janavipandole" target="_blank" rel="noopener noreferrer"><span aria-hidden="true" class="fa-brands fa-github"></span></a>
+          <a href="https://www.linkedin.com/in/janavi-pandole-80a7b2290" target="_blank" rel="noopener noreferrer"><span aria-hidden="true" class="fa-brands fa-linkedin-in"></span></a>
+          <a href="https://www.youtube.com/@JanaviPandole" target="_blank" rel="noopener noreferrer"><span aria-hidden="true" class="fa-brands fa-youtube"></span></a>
         </div>
       </div>
 
@@ -783,7 +783,7 @@
 
   <!-- SCROLL TO TOP -->
   <button id="scroll-top" title="Back to top">
-    <i class="fa-solid fa-arrow-up"></i>
+    <span aria-hidden="true" class="fa-solid fa-arrow-up"></span>
   </button>
 
   <script>

--- a/deliveryInformation.html
+++ b/deliveryInformation.html
@@ -183,7 +183,7 @@
   <body>
     <!-- Floating Theme Toggle for Non-Standard Pages -->
     <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode" style="position: fixed; bottom: 20px; left: 20px; z-index: 9999; background: #088178; color: white; border: none; border-radius: 50%; width: 50px; height: 50px; cursor: pointer; box-shadow: 0 4px 10px rgba(0,0,0,0.3); display: flex; align-items: center; justify-content: center;">
-      <i class="ri-moon-line" id="themeIcon" style="font-size: 24px;"></i>
+      <span aria-hidden="true" class="ri-moon-line" id="themeIcon" style="font-size: 24px;"></span>
     </button>
 
     <section class="delivery-hero">

--- a/footware-collection.html
+++ b/footware-collection.html
@@ -216,26 +216,26 @@
 
                 <li>
                     <a href="cart.html" id="lg-bag">
-                        <i class="ri-shopping-bag-4-line"></i>
+                        <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
                     </a>
                 </li>
 
                 <li>
                     <button class="theme-toggle" id="themeToggle">
-                        <i class="ri-moon-line"></i>
+                        <span aria-hidden="true" class="ri-moon-line"></span>
                     </button>
                 </li>
 
-                <a href="#" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="#" id="close"><span aria-hidden="true" class="fa-solid fa-xmark"></span></a>
             </ul>
         </div>
 
         <div class="mobile">
-            <a href="cart.html"><i class="ri-shopping-bag-4-line"></i></a>
+            <a href="cart.html"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a>
             <i class="fas fa-outdent" id="bar"></i>
       <!-- Theme Toggle -->
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-        <i class="ri-moon-line" id="themeIconMobile"></i>
+        <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
       </button>
         </div>
     </section>
@@ -271,25 +271,25 @@
     <section class="footwear-features">
 
         <div class="foot-card">
-            <i class="ri-footprint-line"></i>
+            <span aria-hidden="true" class="ri-footprint-line"></span>
             <h3>Premium Comfort</h3>
             <p>Soft cushioning and lightweight feel for all-day comfort.</p>
         </div>
 
         <div class="foot-card">
-            <i class="ri-fire-line"></i>
+            <span aria-hidden="true" class="ri-fire-line"></span>
             <h3>Trending Styles</h3>
             <p>Modern streetwear and fashion-inspired shoe collections.</p>
         </div>
 
         <div class="foot-card">
-            <i class="ri-shield-check-line"></i>
+            <span aria-hidden="true" class="ri-shield-check-line"></span>
             <h3>Durable Quality</h3>
             <p>Built using premium materials for long-lasting durability.</p>
         </div>
 
         <div class="foot-card">
-            <i class="ri-truck-line"></i>
+            <span aria-hidden="true" class="ri-truck-line"></span>
             <h3>Fast Delivery</h3>
             <p>Quick delivery with secure packaging and easy returns.</p>
         </div>
@@ -325,17 +325,17 @@
                     <h5>Urban White Sneakers</h5>
 
                     <div class="star">
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
                     </div>
 
                     <h4>$89</h4>
                 </div>
 
-                <a href="#"><i class="ri-shopping-cart-2-line cart"></i></a>
+                <a href="#"><span aria-hidden="true" class="ri-shopping-cart-2-line cart"></span></a>
             </div>
 
 
@@ -350,17 +350,17 @@
                     <h5>Street Runner Shoes</h5>
 
                     <div class="star">
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
                     </div>
 
                     <h4>$95</h4>
                 </div>
 
-                <a href="#"><i class="ri-shopping-cart-2-line cart"></i></a>
+                <a href="#"><span aria-hidden="true" class="ri-shopping-cart-2-line cart"></span></a>
             </div>
 
 
@@ -375,17 +375,17 @@
                     <h5>Classic Beige Sneakers</h5>
 
                     <div class="star">
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
                     </div>
 
                     <h4>$99</h4>
                 </div>
 
-                <a href="#"><i class="ri-shopping-cart-2-line cart"></i></a>
+                <a href="#"><span aria-hidden="true" class="ri-shopping-cart-2-line cart"></span></a>
             </div>
 
 
@@ -400,17 +400,17 @@
                     <h5>Black Sports Sneakers</h5>
 
                     <div class="star">
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
                     </div>
 
                     <h4>$110</h4>
                 </div>
 
-                <a href="#"><i class="ri-shopping-cart-2-line cart"></i></a>
+                <a href="#"><span aria-hidden="true" class="ri-shopping-cart-2-line cart"></span></a>
             </div>
 
 
@@ -425,17 +425,17 @@
                     <h5>Chunky Fashion Sneakers</h5>
 
                     <div class="star">
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
                     </div>
 
                     <h4>$120</h4>
                 </div>
 
-                <a href="#"><i class="ri-shopping-cart-2-line cart"></i></a>
+                <a href="#"><span aria-hidden="true" class="ri-shopping-cart-2-line cart"></span></a>
             </div>
 
 
@@ -450,17 +450,17 @@
                     <h5>Air Flex Running Shoes</h5>
 
                     <div class="star">
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
                     </div>
 
                     <h4>$130</h4>
                 </div>
 
-                <a href="#"><i class="ri-shopping-cart-2-line cart"></i></a>
+                <a href="#"><span aria-hidden="true" class="ri-shopping-cart-2-line cart"></span></a>
             </div>
 
 
@@ -475,17 +475,17 @@
                     <h5>Luxury Leather Shoes</h5>
 
                     <div class="star">
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
                     </div>
 
                     <h4>$149</h4>
                 </div>
 
-                <a href="#"><i class="ri-shopping-cart-2-line cart"></i></a>
+                <a href="#"><span aria-hidden="true" class="ri-shopping-cart-2-line cart"></span></a>
             </div>
 
 
@@ -500,17 +500,17 @@
                     <h5>Minimal Casual Sneakers</h5>
 
                     <div class="star">
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
-                        <i class="ri-star-fill"></i>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
+                        <span aria-hidden="true" class="ri-star-fill"></span>
                     </div>
 
                     <h4>$105</h4>
                 </div>
 
-                <a href="#"><i class="ri-shopping-cart-2-line cart"></i></a>
+                <a href="#"><span aria-hidden="true" class="ri-shopping-cart-2-line cart"></span></a>
             </div>
 
 

--- a/forgotPassword.html
+++ b/forgotPassword.html
@@ -38,7 +38,7 @@
         <li><a href="login.html" id="login-btn">Login</a></li>
         <li>
           <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
-            <i class="ri-moon-line" id="themeIcon"></i>
+            <span aria-hidden="true" class="ri-moon-line" id="themeIcon"></span>
           </button>
         </li>
       </ul>

--- a/index.html
+++ b/index.html
@@ -152,27 +152,27 @@
         <!-- Contact Icon -->
         <li class="nav-icon">
           <a href="contact.html" aria-label="Contact">
-            <i class="ri-customer-service-2-line"></i>
+            <span aria-hidden="true" class="ri-customer-service-2-line"></span>
           </a>
         </li>
 
         <!-- Login Icon -->
         <li class="nav-icon">
           <a href="login.html" aria-label="Login">
-            <i class="ri-user-3-line"></i>
+            <span aria-hidden="true" class="ri-user-3-line"></span>
           </a>
         </li>
 
         <!-- Cart Icon -->
         <li class="nav-icon">
           <a class="active" href="cart.html" id="lg-bag" aria-label="Cart">
-            <i class="ri-shopping-bag-4-line"></i>
+            <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
           </a>
         </li>
 
           <div class="mobile">
-            <a href="wishlist.html" class="wishlist-nav-link" aria-label="Wishlist"><i class="ri-heart-line"></i><span class="wishlist-count hidden">0</span></a>
-            <a href="cart.html"><i class="ri-shopping-bag-4-line"></i></a>
+            <a href="wishlist.html" class="wishlist-nav-link" aria-label="Wishlist"><span aria-hidden="true" class="ri-heart-line"></span><span class="wishlist-count hidden">0</span></a>
+            <a href="cart.html"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a>
             <i class="fas fa-outdent" id="bar" role="button" aria-label="Open menu" aria-expanded="false" tabindex="0"></i>
           </div>
         </section>
@@ -187,13 +187,13 @@
         <!-- Theme Toggle -->
         <li class="nav-icon">
           <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
-            <i class="ri-moon-line" id="themeIcon"></i>
+            <span aria-hidden="true" class="ri-moon-line" id="themeIcon"></span>
           </button>
         </li>
 
         <!-- Close Button -->
         <a href="javascript:void(0)" id="close" aria-label="Close menu" aria-hidden="false">
-          <i class="fa-solid fa-xmark"></i>
+          <span aria-hidden="true" class="fa-solid fa-xmark"></span>
         </a>
 
       </ul>
@@ -204,16 +204,16 @@
 
       <!-- Login Icon -->
       <a href="login.html" aria-label="Login">
-        <i class="ri-user-3-line"></i>
+        <span aria-hidden="true" class="ri-user-3-line"></span>
       </a>
 
       <!-- Cart Icon -->
       <a href="cart.html" aria-label="Cart">
-        <i class="ri-shopping-bag-4-line"></i>
+        <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
       </a>
       <!-- Theme Toggle -->
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-        <i class="ri-moon-line" id="themeIconMobile"></i>
+        <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
       </button>
     </div>
   </section>
@@ -340,11 +340,11 @@
 
           <!-- Slider Controls -->
           <button class="slider-btn prev" aria-label="Previous Slide">
-            <i class="fa-solid fa-chevron-left"></i>
+            <span aria-hidden="true" class="fa-solid fa-chevron-left"></span>
           </button>
 
           <button class="slider-btn next" aria-label="Next Slide">
-            <i class="fa-solid fa-chevron-right"></i>
+            <span aria-hidden="true" class="fa-solid fa-chevron-right"></span>
           </button>
 
           <!-- Slider Indicators -->
@@ -405,13 +405,13 @@
             <span>Nike</span>
           </div>
           <h5>Cartoon Astronaut T-Shirts</h5>
-          <div class="star" aria-label="Rating: 4.5 out of 5"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-half-fill"></i><span class="rating-value">4.5</span></div>
+          <div class="star" aria-label="Rating: 4.5 out of 5"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-half-fill"></span><span class="rating-value">4.5</span></div>
           <h4>&#8377;2,499</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Cartoon Astronaut T-Shirts','₹2,499','images/products/f1.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Cartoon Astronaut T-Shirts','₹2,499','images/products/f1.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
-            <button type="button" class="wishlist-btn" data-product-name="Cartoon Astronaut T-Shirts" aria-label="Add Cartoon Astronaut T-Shirts to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:1, name:'Cartoon Astronaut T-Shirts', brand:'Nike', price:'₹2,499', image:'images/products/f1.jpg', currentPrice:2499, previousPrice:2499}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Cartoon Astronaut T-Shirts','₹2,499','images/products/f1.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Cartoon Astronaut T-Shirts','₹2,499','images/products/f1.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
+            <button type="button" class="wishlist-btn" data-product-name="Cartoon Astronaut T-Shirts" aria-label="Add Cartoon Astronaut T-Shirts to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:1, name:'Cartoon Astronaut T-Shirts', brand:'Nike', price:'₹2,499', image:'images/products/f1.jpg', currentPrice:2499, previousPrice:2499}, this)"><span aria-hidden="true" class="ri-heart-line" aria-hidden="true"></span></button>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Cartoon Astronaut T-Shirts','₹2,499','images/products/f1.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
           </div>
         </div>
       </div>
@@ -424,13 +424,13 @@
             <span>H&amp;M</span>
           </div>
           <h5>White Palm Leaf Casual Shirt</h5>
-          <div class="star" aria-label="Rating: 3.5 out of 5"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-half-fill"></i><i class="ri-star-line"></i><span class="rating-value">3.5</span></div>
+          <div class="star" aria-label="Rating: 3.5 out of 5"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-half-fill"></span><span aria-hidden="true" class="ri-star-line"></span><span class="rating-value">3.5</span></div>
           <h4>&#8377;1,299</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('White Palm Leaf Casual Shirt','₹1,299','images/products/f2.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('White Palm Leaf Casual Shirt','₹1,299','images/products/f2.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
-            <button type="button" class="wishlist-btn" data-product-name="White Palm Leaf Casual Shirt" aria-label="Add White Palm Leaf Casual Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:2, name:'White Palm Leaf Casual Shirt', brand:'H&amp;M', price:'₹1,299', image:'images/products/f2.jpg', currentPrice:1299, previousPrice:1299}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('White Palm Leaf Casual Shirt','₹1,299','images/products/f2.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('White Palm Leaf Casual Shirt','₹1,299','images/products/f2.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
+            <button type="button" class="wishlist-btn" data-product-name="White Palm Leaf Casual Shirt" aria-label="Add White Palm Leaf Casual Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:2, name:'White Palm Leaf Casual Shirt', brand:'H&amp;M', price:'₹1,299', image:'images/products/f2.jpg', currentPrice:1299, previousPrice:1299}, this)"><span aria-hidden="true" class="ri-heart-line" aria-hidden="true"></span></button>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('White Palm Leaf Casual Shirt','₹1,299','images/products/f2.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
           </div>
         </div>
       </div>
@@ -443,13 +443,13 @@
             <span>Zara</span>
           </div>
           <h5>Vintage Rose Garden Shirt</h5>
-          <div class="star" aria-label="Rating: 4.0 out of 5"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-line"></i><span class="rating-value">4.0</span></div>
+          <div class="star" aria-label="Rating: 4.0 out of 5"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-line"></span><span class="rating-value">4.0</span></div>
           <h4>&#8377;3,490</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Vintage Rose Garden Shirt','₹3,490','images/products/f3.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Vintage Rose Garden Shirt','₹3,490','images/products/f3.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
-            <button type="button" class="wishlist-btn" data-product-name="Vintage Rose Garden Shirt" aria-label="Add Vintage Rose Garden Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:3, name:'Vintage Rose Garden Shirt', brand:'Zara', price:'₹3,490', image:'images/products/f3.jpg', currentPrice:3490, previousPrice:3490}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Vintage Rose Garden Shirt','₹3,490','images/products/f3.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Vintage Rose Garden Shirt','₹3,490','images/products/f3.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
+            <button type="button" class="wishlist-btn" data-product-name="Vintage Rose Garden Shirt" aria-label="Add Vintage Rose Garden Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:3, name:'Vintage Rose Garden Shirt', brand:'Zara', price:'₹3,490', image:'images/products/f3.jpg', currentPrice:3490, previousPrice:3490}, this)"><span aria-hidden="true" class="ri-heart-line" aria-hidden="true"></span></button>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Vintage Rose Garden Shirt','₹3,490','images/products/f3.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
           </div>
         </div>
       </div>
@@ -462,13 +462,13 @@
             <span>Levi's</span>
           </div>
           <h5>Sakura Blossom Floral Shirt</h5>
-          <div class="star" aria-label="Rating: 5.0 out of 5"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><span class="rating-value">5.0</span></div>
+          <div class="star" aria-label="Rating: 5.0 out of 5"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span class="rating-value">5.0</span></div>
           <h4>&#8377;2,799</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Sakura Blossom Floral Shirt','₹2,799','images/products/f4.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sakura Blossom Floral Shirt','₹2,799','images/products/f4.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
-            <button type="button" class="wishlist-btn" data-product-name="Sakura Blossom Floral Shirt" aria-label="Add Sakura Blossom Floral Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:4, name:'Sakura Blossom Floral Shirt', brand:'Levi\'s', price:'₹2,799', image:'images/products/f4.jpg', currentPrice:2799, previousPrice:2799}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sakura Blossom Floral Shirt','₹2,799','images/products/f4.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sakura Blossom Floral Shirt','₹2,799','images/products/f4.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
+            <button type="button" class="wishlist-btn" data-product-name="Sakura Blossom Floral Shirt" aria-label="Add Sakura Blossom Floral Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:4, name:'Sakura Blossom Floral Shirt', brand:'Levi\'s', price:'₹2,799', image:'images/products/f4.jpg', currentPrice:2799, previousPrice:2799}, this)"><span aria-hidden="true" class="ri-heart-line" aria-hidden="true"></span></button>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sakura Blossom Floral Shirt','₹2,799','images/products/f4.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
           </div>
         </div>
       </div>
@@ -481,13 +481,13 @@
             <span>Puma</span>
           </div>
           <h5>Pink Peony Patterned Shirt</h5>
-          <div class="star" aria-label="Rating: 3.0 out of 5"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-line"></i><i class="ri-star-line"></i><span class="rating-value">3.0</span></div>
+          <div class="star" aria-label="Rating: 3.0 out of 5"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-line"></span><span aria-hidden="true" class="ri-star-line"></span><span class="rating-value">3.0</span></div>
           <h4>&#8377;1,999</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Pink Peony Patterned Shirt','₹1,999','images/products/f5.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Pink Peony Patterned Shirt','₹1,999','images/products/f5.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
-            <button type="button" class="wishlist-btn" data-product-name="Pink Peony Patterned Shirt" aria-label="Add Pink Peony Patterned Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:5, name:'Pink Peony Patterned Shirt', brand:'Puma', price:'₹1,999', image:'images/products/f5.jpg', currentPrice:1999, previousPrice:1999}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Pink Peony Patterned Shirt','₹1,999','images/products/f5.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Pink Peony Patterned Shirt','₹1,999','images/products/f5.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
+            <button type="button" class="wishlist-btn" data-product-name="Pink Peony Patterned Shirt" aria-label="Add Pink Peony Patterned Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:5, name:'Pink Peony Patterned Shirt', brand:'Puma', price:'₹1,999', image:'images/products/f5.jpg', currentPrice:1999, previousPrice:1999}, this)"><span aria-hidden="true" class="ri-heart-line" aria-hidden="true"></span></button>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Pink Peony Patterned Shirt','₹1,999','images/products/f5.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
           </div>
         </div>
       </div>
@@ -500,13 +500,13 @@
             <span>Gap</span>
           </div>
           <h5>Dual-Tone Corduroy Shirt</h5>
-          <div class="star" aria-label="Rating: 4.0 out of 5"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-line"></i><span class="rating-value">4.0</span></div>
+          <div class="star" aria-label="Rating: 4.0 out of 5"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-line"></span><span class="rating-value">4.0</span></div>
           <h4>&#8377;2,299</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Dual-Tone Corduroy Shirt','₹2,299','images/products/f6.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Dual-Tone Corduroy Shirt','₹2,299','images/products/f6.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
-            <button type="button" class="wishlist-btn" data-product-name="Dual-Tone Corduroy Shirt" aria-label="Add Dual-Tone Corduroy Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:6, name:'Dual-Tone Corduroy Shirt', brand:'Gap', price:'₹2,299', image:'images/products/f6.jpg', currentPrice:2299, previousPrice:2299}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Dual-Tone Corduroy Shirt','₹2,299','images/products/f6.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Dual-Tone Corduroy Shirt','₹2,299','images/products/f6.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
+            <button type="button" class="wishlist-btn" data-product-name="Dual-Tone Corduroy Shirt" aria-label="Add Dual-Tone Corduroy Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:6, name:'Dual-Tone Corduroy Shirt', brand:'Gap', price:'₹2,299', image:'images/products/f6.jpg', currentPrice:2299, previousPrice:2299}, this)"><span aria-hidden="true" class="ri-heart-line" aria-hidden="true"></span></button>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Dual-Tone Corduroy Shirt','₹2,299','images/products/f6.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
           </div>
         </div>
       </div>
@@ -519,13 +519,13 @@
             <span>Uniqlo</span>
           </div>
           <h5>Embroidered Linen Trousers</h5>
-          <div class="star" aria-label="Rating: 4.5 out of 5"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-half-fill"></i><span class="rating-value">4.5</span></div>
+          <div class="star" aria-label="Rating: 4.5 out of 5"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-half-fill"></span><span class="rating-value">4.5</span></div>
           <h4>&#8377;3,990</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Embroidered Linen Trousers','₹3,990','images/products/f7.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Embroidered Linen Trousers','₹3,990','images/products/f7.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
-            <button type="button" class="wishlist-btn" data-product-name="Embroidered Linen Trousers" aria-label="Add Embroidered Linen Trousers to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:7, name:'Embroidered Linen Trousers', brand:'Uniqlo', price:'₹3,990', image:'images/products/f7.jpg', currentPrice:3990, previousPrice:3990}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Embroidered Linen Trousers','₹3,990','images/products/f7.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Embroidered Linen Trousers','₹3,990','images/products/f7.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
+            <button type="button" class="wishlist-btn" data-product-name="Embroidered Linen Trousers" aria-label="Add Embroidered Linen Trousers to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:7, name:'Embroidered Linen Trousers', brand:'Uniqlo', price:'₹3,990', image:'images/products/f7.jpg', currentPrice:3990, previousPrice:3990}, this)"><span aria-hidden="true" class="ri-heart-line" aria-hidden="true"></span></button>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Embroidered Linen Trousers','₹3,990','images/products/f7.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
           </div>
         </div>
       </div>
@@ -538,13 +538,13 @@
             <span>Mango</span>
           </div>
           <h5>Cat Print Long Sleeve Blouse</h5>
-          <div class="star" aria-label="Rating: 3.5 out of 5"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-half-fill"></i><i class="ri-star-line"></i><span class="rating-value">3.5</span></div>
+          <div class="star" aria-label="Rating: 3.5 out of 5"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-half-fill"></span><span aria-hidden="true" class="ri-star-line"></span><span class="rating-value">3.5</span></div>
           <h4>&#8377;2,699</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Cat Print Long Sleeve Blouse','₹2,699','images/products/f8.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Cat Print Long Sleeve Blouse','₹2,699','images/products/f8.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
-            <button type="button" class="wishlist-btn" data-product-name="Cat Print Long Sleeve Blouse" aria-label="Add Cat Print Long Sleeve Blouse to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:8, name:'Cat Print Long Sleeve Blouse', brand:'Mango', price:'₹2,699', image:'images/products/f8.jpg', currentPrice:2699, previousPrice:2699}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Cat Print Long Sleeve Blouse','₹2,699','images/products/f8.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Cat Print Long Sleeve Blouse','₹2,699','images/products/f8.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
+            <button type="button" class="wishlist-btn" data-product-name="Cat Print Long Sleeve Blouse" aria-label="Add Cat Print Long Sleeve Blouse to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:8, name:'Cat Print Long Sleeve Blouse', brand:'Mango', price:'₹2,699', image:'images/products/f8.jpg', currentPrice:2699, previousPrice:2699}, this)"><span aria-hidden="true" class="ri-heart-line" aria-hidden="true"></span></button>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Cat Print Long Sleeve Blouse','₹2,699','images/products/f8.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
           </div>
         </div>
       </div>
@@ -571,13 +571,13 @@
             <span>Tommy Hilfiger</span>
           </div>
           <h5>Sky Blue Mandarin Collar Shirt</h5>
-          <div class="star" aria-label="Rating: 5.0 out of 5"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><span class="rating-value">5.0</span></div>
+          <div class="star" aria-label="Rating: 5.0 out of 5"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span class="rating-value">5.0</span></div>
           <h4>&#8377;4,499</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Sky Blue Mandarin Collar Shirt','₹4,499','images/products/n1.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sky Blue Mandarin Collar Shirt','₹4,499','images/products/n1.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
-            <button type="button" class="wishlist-btn" data-product-name="Sky Blue Mandarin Collar Shirt" aria-label="Add Sky Blue Mandarin Collar Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:9, name:'Sky Blue Mandarin Collar Shirt', brand:'Tommy Hilfiger', price:'₹4,499', image:'images/products/n1.jpg', currentPrice:4499, previousPrice:4499}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sky Blue Mandarin Collar Shirt','₹4,499','images/products/n1.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sky Blue Mandarin Collar Shirt','₹4,499','images/products/n1.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
+            <button type="button" class="wishlist-btn" data-product-name="Sky Blue Mandarin Collar Shirt" aria-label="Add Sky Blue Mandarin Collar Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:9, name:'Sky Blue Mandarin Collar Shirt', brand:'Tommy Hilfiger', price:'₹4,499', image:'images/products/n1.jpg', currentPrice:4499, previousPrice:4499}, this)"><span aria-hidden="true" class="ri-heart-line" aria-hidden="true"></span></button>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sky Blue Mandarin Collar Shirt','₹4,499','images/products/n1.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
           </div>
         </div>
       </div>
@@ -590,13 +590,13 @@
             <span>Ralph Lauren</span>
           </div>
           <h5>Navy Textured Formal Shirt</h5>
-          <div class="star" aria-label="Rating: 4.5 out of 5"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-half-fill"></i><span class="rating-value">4.5</span></div>
+          <div class="star" aria-label="Rating: 4.5 out of 5"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-half-fill"></span><span class="rating-value">4.5</span></div>
           <h4>&#8377;6,999</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Navy Textured Formal Shirt','₹6,999','images/products/n2.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Navy Textured Formal Shirt','₹6,999','images/products/n2.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
-            <button type="button" class="wishlist-btn" data-product-name="Navy Textured Formal Shirt" aria-label="Add Navy Textured Formal Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:10, name:'Navy Textured Formal Shirt', brand:'Ralph Lauren', price:'₹6,999', image:'images/products/n2.jpg', currentPrice:6999, previousPrice:6999}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Navy Textured Formal Shirt','₹6,999','images/products/n2.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Navy Textured Formal Shirt','₹6,999','images/products/n2.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
+            <button type="button" class="wishlist-btn" data-product-name="Navy Textured Formal Shirt" aria-label="Add Navy Textured Formal Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:10, name:'Navy Textured Formal Shirt', brand:'Ralph Lauren', price:'₹6,999', image:'images/products/n2.jpg', currentPrice:6999, previousPrice:6999}, this)"><span aria-hidden="true" class="ri-heart-line" aria-hidden="true"></span></button>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Navy Textured Formal Shirt','₹6,999','images/products/n2.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
           </div>
         </div>
       </div>
@@ -609,13 +609,13 @@
             <span>Calvin Klein</span>
           </div>
           <h5>Classic White Cotton Shirt</h5>
-          <div class="star" aria-label="Rating: 4.0 out of 5"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-line"></i><span class="rating-value">4.0</span></div>
+          <div class="star" aria-label="Rating: 4.0 out of 5"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-line"></span><span class="rating-value">4.0</span></div>
           <h4>&#8377;5,499</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Classic White Cotton Shirt','₹5,499','images/products/n3.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Classic White Cotton Shirt','₹5,499','images/products/n3.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
-            <button type="button" class="wishlist-btn" data-product-name="Classic White Cotton Shirt" aria-label="Add Classic White Cotton Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:11, name:'Classic White Cotton Shirt', brand:'Calvin Klein', price:'₹5,499', image:'images/products/n3.jpg', currentPrice:5499, previousPrice:5499}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Classic White Cotton Shirt','₹5,499','images/products/n3.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Classic White Cotton Shirt','₹5,499','images/products/n3.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
+            <button type="button" class="wishlist-btn" data-product-name="Classic White Cotton Shirt" aria-label="Add Classic White Cotton Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:11, name:'Classic White Cotton Shirt', brand:'Calvin Klein', price:'₹5,499', image:'images/products/n3.jpg', currentPrice:5499, previousPrice:5499}, this)"><span aria-hidden="true" class="ri-heart-line" aria-hidden="true"></span></button>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Classic White Cotton Shirt','₹5,499','images/products/n3.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
           </div>
         </div>
 
@@ -689,13 +689,13 @@
             <span>Zara</span>
           </div>
           <h5>Sandstone Tactical Utility Shirt</h5>
-          <div class="star" aria-label="Rating: 3.5 out of 5"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-half-fill"></i><i class="ri-star-line"></i><span class="rating-value">3.5</span></div>
+          <div class="star" aria-label="Rating: 3.5 out of 5"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-half-fill"></span><span aria-hidden="true" class="ri-star-line"></span><span class="rating-value">3.5</span></div>
           <h4>&#8377;3,990</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Sandstone Tactical Utility Shirt','₹3,990','images/products/n4.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sandstone Tactical Utility Shirt','₹3,990','images/products/n4.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
-            <button type="button" class="wishlist-btn" data-product-name="Sandstone Tactical Utility Shirt" aria-label="Add Sandstone Tactical Utility Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:12, name:'Sandstone Tactical Utility Shirt', brand:'Zara', price:'₹3,990', image:'images/products/n4.jpg', currentPrice:3990, previousPrice:3990}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sandstone Tactical Utility Shirt','₹3,990','images/products/n4.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sandstone Tactical Utility Shirt','₹3,990','images/products/n4.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
+            <button type="button" class="wishlist-btn" data-product-name="Sandstone Tactical Utility Shirt" aria-label="Add Sandstone Tactical Utility Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:12, name:'Sandstone Tactical Utility Shirt', brand:'Zara', price:'₹3,990', image:'images/products/n4.jpg', currentPrice:3990, previousPrice:3990}, this)"><span aria-hidden="true" class="ri-heart-line" aria-hidden="true"></span></button>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Sandstone Tactical Utility Shirt','₹3,990','images/products/n4.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
           </div>
         </div>
       </div>
@@ -708,13 +708,13 @@
             <span>Nike</span>
           </div>
           <h5>Denim Blue Everyday Shirt</h5>
-          <div class="star" aria-label="Rating: 4.0 out of 5"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-line"></i><span class="rating-value">4.0</span></div>
+          <div class="star" aria-label="Rating: 4.0 out of 5"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-line"></span><span class="rating-value">4.0</span></div>
           <h4>&#8377;2,799</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Denim Blue Everyday Shirt','₹2,799','images/products/n5.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Denim Blue Everyday Shirt','₹2,799','images/products/n5.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
-            <button type="button" class="wishlist-btn" data-product-name="Denim Blue Everyday Shirt" aria-label="Add Denim Blue Everyday Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:13, name:'Denim Blue Everyday Shirt', brand:'Nike', price:'₹2,799', image:'images/products/n5.jpg', currentPrice:2799, previousPrice:2799}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Denim Blue Everyday Shirt','₹2,799','images/products/n5.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Denim Blue Everyday Shirt','₹2,799','images/products/n5.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
+            <button type="button" class="wishlist-btn" data-product-name="Denim Blue Everyday Shirt" aria-label="Add Denim Blue Everyday Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:13, name:'Denim Blue Everyday Shirt', brand:'Nike', price:'₹2,799', image:'images/products/n5.jpg', currentPrice:2799, previousPrice:2799}, this)"><span aria-hidden="true" class="ri-heart-line" aria-hidden="true"></span></button>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Denim Blue Everyday Shirt','₹2,799','images/products/n5.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
           </div>
         </div>
       </div>
@@ -727,13 +727,13 @@
             <span>Levi's</span>
           </div>
           <h5>Vertical Stripe Chino Shorts</h5>
-          <div class="star" aria-label="Rating: 3.0 out of 5"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-line"></i><i class="ri-star-line"></i><span class="rating-value">3.0</span></div>
+          <div class="star" aria-label="Rating: 3.0 out of 5"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-line"></span><span aria-hidden="true" class="ri-star-line"></span><span class="rating-value">3.0</span></div>
           <h4>&#8377;2,499</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Vertical Stripe Chino Shorts','₹2,499','images/products/n6.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Vertical Stripe Chino Shorts','₹2,499','images/products/n6.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
-            <button type="button" class="wishlist-btn" data-product-name="Vertical Stripe Chino Shorts" aria-label="Add Vertical Stripe Chino Shorts to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:14, name:'Vertical Stripe Chino Shorts', brand:'Levi\'s', price:'₹2,499', image:'images/products/n6.jpg', currentPrice:2499, previousPrice:2499}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Vertical Stripe Chino Shorts','₹2,499','images/products/n6.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Vertical Stripe Chino Shorts','₹2,499','images/products/n6.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
+            <button type="button" class="wishlist-btn" data-product-name="Vertical Stripe Chino Shorts" aria-label="Add Vertical Stripe Chino Shorts to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:14, name:'Vertical Stripe Chino Shorts', brand:'Levi\'s', price:'₹2,499', image:'images/products/n6.jpg', currentPrice:2499, previousPrice:2499}, this)"><span aria-hidden="true" class="ri-heart-line" aria-hidden="true"></span></button>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Vertical Stripe Chino Shorts','₹2,499','images/products/n6.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
           </div>
         </div>
       </div>
@@ -746,13 +746,13 @@
             <span>Uniqlo</span>
           </div>
           <h5>Khaki Safari Work Shirt</h5>
-          <div class="star" aria-label="Rating: 4.5 out of 5"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-half-fill"></i><span class="rating-value">4.5</span></div>
+          <div class="star" aria-label="Rating: 4.5 out of 5"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-half-fill"></span><span class="rating-value">4.5</span></div>
           <h4>&#8377;3,499</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Khaki Safari Work Shirt','₹3,499','images/products/n7.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Khaki Safari Work Shirt','₹3,499','images/products/n7.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
-            <button type="button" class="wishlist-btn" data-product-name="Khaki Safari Work Shirt" aria-label="Add Khaki Safari Work Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:15, name:'Khaki Safari Work Shirt', brand:'Uniqlo', price:'₹3,499', image:'images/products/n7.jpg', currentPrice:3499, previousPrice:3499}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Khaki Safari Work Shirt','₹3,499','images/products/n7.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Khaki Safari Work Shirt','₹3,499','images/products/n7.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
+            <button type="button" class="wishlist-btn" data-product-name="Khaki Safari Work Shirt" aria-label="Add Khaki Safari Work Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:15, name:'Khaki Safari Work Shirt', brand:'Uniqlo', price:'₹3,499', image:'images/products/n7.jpg', currentPrice:3499, previousPrice:3499}, this)"><span aria-hidden="true" class="ri-heart-line" aria-hidden="true"></span></button>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Khaki Safari Work Shirt','₹3,499','images/products/n7.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
           </div>
         </div>
       </div>
@@ -765,13 +765,13 @@
             <span>Puma</span>
           </div>
           <h5>Deep Charcoal Casual Shirt</h5>
-          <div class="star" aria-label="Rating: 3.5 out of 5"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-half-fill"></i><i class="ri-star-line"></i><span class="rating-value">3.5</span></div>
+          <div class="star" aria-label="Rating: 3.5 out of 5"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-half-fill"></span><span aria-hidden="true" class="ri-star-line"></span><span class="rating-value">3.5</span></div>
           <h4>&#8377;1,799</h4>
           <div class="pro-action-bar">
            <button class="pro-buy-btn" aria-label="Buy Cartoon Astronaut T-Shirts" onclick="buyNow('Deep Charcoal Casual Shirt','₹1,799','images/products/n8.jpg',1,'M')">BUY NOW</button>
-            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Deep Charcoal Casual Shirt','₹1,799','images/products/n8.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
-            <button type="button" class="wishlist-btn" data-product-name="Deep Charcoal Casual Shirt" aria-label="Add Deep Charcoal Casual Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:16, name:'Deep Charcoal Casual Shirt', brand:'Puma', price:'₹1,799', image:'images/products/n8.jpg', currentPrice:1799, previousPrice:1799}, this)"><i class="ri-heart-line" aria-hidden="true"></i></button>
-            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Deep Charcoal Casual Shirt','₹1,799','images/products/n8.jpg',1,'M');return false;"><i class="ri-shopping-cart-2-line"></i></a>
+            <a href="#" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Deep Charcoal Casual Shirt','₹1,799','images/products/n8.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
+            <button type="button" class="wishlist-btn" data-product-name="Deep Charcoal Casual Shirt" aria-label="Add Deep Charcoal Casual Shirt to wishlist" title="Add to wishlist" aria-pressed="false" onclick="event.stopPropagation(); toggleWishlistItem({id:16, name:'Deep Charcoal Casual Shirt', brand:'Puma', price:'₹1,799', image:'images/products/n8.jpg', currentPrice:1799, previousPrice:1799}, this)"><span aria-hidden="true" class="ri-heart-line" aria-hidden="true"></span></button>
+            <a href="javascript:void(0)" class="pro-cart-btn" aria-label="Add to cart" onclick="event.stopPropagation();addToCart('Deep Charcoal Casual Shirt','₹1,799','images/products/n8.jpg',1,'M');return false;"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
           </div>
         </div>
       </div>
@@ -828,7 +828,7 @@
         <h4>Follow us</h4>
         <div class="icon">
           <a href="https://x.com/JanaviPandole" target="_blank" rel="noopener noreferrer" aria-label="X (formerly Twitter)">
-            <i class="fa-brands fa-x-twitter"></i>
+            <span aria-hidden="true" class="fa-brands fa-x-twitter"></span>
           </a>
           <a href="https://github.com/janavipandole" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
             <i class="fab fa-github"></i>

--- a/license.html
+++ b/license.html
@@ -133,20 +133,20 @@
                 <li><a href="blog.html">Blog</a></li>
                 <li><a href="about.html">About</a></li>
                 <li><a href="contact.html">Contact</a></li>
-                <li><a href="cart.html" id="lg-bag"><i class="ri-shopping-bag-4-line"></i></a></li>
+                <li><a href="cart.html" id="lg-bag"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a></li>
                 <li>
                     <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
-                        <i class="ri-moon-line" id="themeIcon"></i>
+                        <span aria-hidden="true" class="ri-moon-line" id="themeIcon"></span>
                     </button>
                 </li>
                 <li><a href="login.html" id="login-btn">Login</a></li>
-                <a href="#" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="#" id="close"><span aria-hidden="true" class="fa-solid fa-xmark"></span></a>
             </ul>
         </div>
       <div class="mobile">
-    <a href="cart.html"><i class="ri-shopping-bag-4-line"></i></a>
+    <a href="cart.html"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a>
     <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-        <i class="ri-moon-line" id="themeIconMobile"></i>
+        <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
     </button>
     <i class="fas fa-outdent" id="bar"></i>
 </div>
@@ -204,7 +204,7 @@
             <div class="follow">
                 <h4>Follow us</h4>
                 <div class="icon">
-                    <a href="https://x.com/JanaviPandole"><i class="fa-brands fa-x-twitter"></i></a>
+                    <a href="https://x.com/JanaviPandole"><span aria-hidden="true" class="fa-brands fa-x-twitter"></span></a>
                     <a href="https://github.com/janavipandole"><i class="fab fa-github"></i></a>
                     <a href="https://www.linkedin.com/in/janavi-pandole-80a7b2290" target="_blank" rel="noopener noreferrer">
                         <i class="fab fa-linkedin"></i>

--- a/login.html
+++ b/login.html
@@ -26,19 +26,19 @@
     </a>
     <div id="navbar-container"></div>
     <div class="mobile">
-      <a href="login.html" aria-label="Login"><i class="ri-user-3-line"></i></a>
-      <a href="cart.html" aria-label="Cart"><i class="ri-shopping-bag-4-line"></i></a>
+      <a href="login.html" aria-label="Login"><span aria-hidden="true" class="ri-user-3-line"></span></a>
+      <a href="cart.html" aria-label="Cart"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a>
       <i class="fas fa-outdent" id="bar" role="button" aria-label="Open menu" aria-expanded="false" tabindex="0"></i>
       <!-- Theme Toggle -->
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-        <i class="ri-moon-line" id="themeIconMobile"></i>
+        <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
       </button>
     </div>
   </section>
 <<<<<<< fix/login-register-flow
 =======
   <div id="login-container">
-    <button class="back-btn" onclick="history.back()" aria-label="Back to Shop"><i class="ri-arrow-left-line"></i> Back
+    <button class="back-btn" onclick="history.back()" aria-label="Back to Shop"><span aria-hidden="true" class="ri-arrow-left-line"></span> Back
       to Shop</button>
     <div class="login-box">
       <h2>Welcome Back!</h2>
@@ -105,7 +105,7 @@
                 aria-required="true"
               />
               <button type="button" id="togglePassword" class="toggle_password" aria-label="Show password">
-                <i class="ri-eye-line" id="toggleIcon" aria-hidden="true"></i>
+                <span aria-hidden="true" class="ri-eye-line" id="toggleIcon" aria-hidden="true"></span>
               </button>
             </div>
             <!-- Inline error for wrong password -->
@@ -117,7 +117,7 @@
             <label class="role-option">
               <input type="radio" name="loginRole" value="USER" aria-label="Login as User" checked />
               <span class="role-card">
-                <i class="ri-user-3-line"></i>
+                <span aria-hidden="true" class="ri-user-3-line"></span>
                 <strong>User</strong>
                 <small>Shop &amp; browse</small>
               </span>
@@ -125,7 +125,7 @@
             <label class="role-option">
               <input type="radio" name="loginRole" value="ADMIN" aria-label="Login as Admin" />
               <span class="role-card">
-                <i class="ri-shield-user-line"></i>
+                <span aria-hidden="true" class="ri-shield-user-line"></span>
                 <strong>Admin</strong>
                 <small>Manage store</small>
               </span>
@@ -157,7 +157,7 @@
             <div class="captcha-row">
               <canvas id="captcha-canvas" width="150" height="40"></canvas>
               <button type="button" id="captcha-refresh" aria-label="Refresh Captcha">
-                <i class="ri-refresh-line"></i>
+                <span aria-hidden="true" class="ri-refresh-line"></span>
               </button>
             </div>
             <input type="text" id="captcha-input" class="input-field" placeholder="Enter the code above" autocomplete="off" />

--- a/outfit-compatibility.html
+++ b/outfit-compatibility.html
@@ -267,13 +267,13 @@
         <img id="siteLogo" loading="lazy" src="images/logo.png" alt="Cara Logo" style="height:50px;min-width:120px;object-fit:contain;" />
       </a>
       <div id="navbar-container"></div>
-      <a href="cart.html"><i class="ri-shopping-bag-4-line"></i></a>
+      <a href="cart.html"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a>
     </div>
   </header>
 
   <main class="compat-page">
     <div class="compat-hero">
-      <h1><i class="ri-t-shirt-line" style="color:#6366f1;"></i> Outfit Compatibility Checker</h1>
+      <h1><span aria-hidden="true" class="ri-t-shirt-line" style="color:#6366f1;"></span> Outfit Compatibility Checker</h1>
       <p>Check if your top and bottom pieces work together — colour harmony, style matching, and occasion suitability all in one click.</p>
     </div>
 
@@ -282,7 +282,7 @@
         <p class="section-label">Your Outfit</p>
         <div class="item-grid">
           <div class="item-col">
-            <h3><i class="ri-shirt-line"></i> Top</h3>
+            <h3><span aria-hidden="true" class="ri-shirt-line"></span> Top</h3>
             <label class="field-label" for="top-item">Item description</label>
             <input type="text" id="top-item" placeholder="e.g. white dress shirt, blue hoodie" required />
             <label class="field-label" for="top-color">Colour</label>
@@ -306,7 +306,7 @@
             </div>
           </div>
           <div class="item-col">
-            <h3><i class="ri-scissors-cut-line"></i> Bottom</h3>
+            <h3><span aria-hidden="true" class="ri-scissors-cut-line"></span> Bottom</h3>
             <label class="field-label" for="bottom-item">Item description</label>
             <input type="text" id="bottom-item" placeholder="e.g. black jeans, khaki chinos" required />
             <label class="field-label" for="bottom-color">Colour</label>
@@ -346,21 +346,21 @@
         </div>
 
         <div class="btn-row">
-          <button type="submit" class="btn-check"><i class="ri-magic-line"></i> Check Compatibility</button>
-          <button type="button" id="reset-btn" class="btn-reset"><i class="ri-refresh-line"></i> Reset</button>
+          <button type="submit" class="btn-check"><span aria-hidden="true" class="ri-magic-line"></span> Check Compatibility</button>
+          <button type="button" id="reset-btn" class="btn-reset"><span aria-hidden="true" class="ri-refresh-line"></span> Reset</button>
         </div>
       </form>
     </div>
 
     <div id="result-section">
       <div class="result-card">
-        <h2><i class="ri-bar-chart-2-line" style="color:#6366f1;"></i> Your Results</h2>
+        <h2><span aria-hidden="true" class="ri-bar-chart-2-line" style="color:#6366f1;"></span> Your Results</h2>
         <div id="result-area"></div>
       </div>
     </div>
 
     <div class="info-banner">
-      <i class="ri-information-line"></i>
+      <span aria-hidden="true" class="ri-information-line"></span>
       <span>This tool analyses colour harmony and style cohesion based on widely accepted fashion principles. Results are suggestions — personal style always wins!</span>
     </div>
   </main>

--- a/privacy.html
+++ b/privacy.html
@@ -278,10 +278,10 @@
               id="themeToggle"
               aria-label="Toggle dark mode"
             >
-              <i class="ri-moon-line" id="themeIcon"></i>
+              <span aria-hidden="true" class="ri-moon-line" id="themeIcon"></span>
             </button>
           </li>
-          <a href="#" id="close"><i class="fa-solid fa-xmark"></i></a>
+          <a href="#" id="close"><span aria-hidden="true" class="fa-solid fa-xmark"></span></a>
         </ul>
       </div>
       <div class="mobile">
@@ -290,10 +290,10 @@
           id="themeToggleMobile"
           aria-label="Toggle dark mode"
         >
-          <i class="ri-moon-line" id="themeIconMobile"></i>
+          <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
         </button>
         <a href="cart.html" id="mobile-cart-icon">
-          <i class="ri-shopping-bag-4-line"></i>
+          <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
           <span class="cart-count" id="mobileCartCount">0</span>
         </a>
         <i class="fas fa-outdent" id="bar"></i>
@@ -308,7 +308,7 @@
     <!-- Policy Content -->
     <main id="policy-page">
       <button onclick="javascript:history.back()" class="back-btn" aria-label="Go back to previous page" style="border: none; font-family: inherit; font-size: inherit;">
-        <i class="ri-arrow-left-line"></i> Back
+        <span aria-hidden="true" class="ri-arrow-left-line"></span> Back
       </button>
 
       <h1>Privacy Policy</h1>
@@ -458,7 +458,7 @@
           <h4>Follow us</h4>
           <div class="icon">
             <a href="https://x.com/JanaviPandole" target="_blank" rel="noopener noreferrer">
-              <i class="fa-brands fa-x-twitter"></i>
+              <span aria-hidden="true" class="fa-brands fa-x-twitter"></span>
             </a>
             <a href="https://github.com/janavipandole" target="_blank" rel="noopener noreferrer">
               <i class="fab fa-github"></i>

--- a/promotions.html
+++ b/promotions.html
@@ -79,12 +79,12 @@
       <div class="mobile">
         <!-- Login Icon -->
         <a href="login.html" aria-label="Login">
-          <i class="ri-user-3-line"></i>
+          <span aria-hidden="true" class="ri-user-3-line"></span>
         </a>
 
         <!-- Cart Icon -->
         <a href="cart.html" aria-label="Cart">
-          <i class="ri-shopping-bag-4-line"></i>
+          <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
         </a>
 
         <!-- Hamburger Menu -->
@@ -98,7 +98,7 @@
         ></i>
       <!-- Theme Toggle -->
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-        <i class="ri-moon-line" id="themeIconMobile"></i>
+        <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
       </button>
       </div>
     </section>
@@ -118,7 +118,7 @@
 
         <div class="perk-box">
           <h4>
-            <i class="ri-gift-line" style="color: var(--accent)"></i> Monthly
+            <span aria-hidden="true" class="ri-gift-line" style="color: var(--accent)"></span> Monthly
             Freebies
           </h4>
           <p>
@@ -129,7 +129,7 @@
 
         <div class="perk-box">
           <h4>
-            <i class="ri-percent-line" style="color: var(--accent)"></i> Custom
+            <span aria-hidden="true" class="ri-percent-line" style="color: var(--accent)"></span> Custom
             Discount Codes
           </h4>
           <p>
@@ -140,7 +140,7 @@
 
         <div class="perk-box">
           <h4>
-            <i class="ri-star-smile-line" style="color: var(--accent)"></i>
+            <span aria-hidden="true" class="ri-star-smile-line" style="color: var(--accent)"></span>
             Featured Spotlights
           </h4>
           <p>
@@ -208,7 +208,7 @@
           document.getElementById('discount-popup').style.display = 'none';
         "
       >
-        <i class="ri-close-line"></i>
+        <span aria-hidden="true" class="ri-close-line"></span>
       </button>
       <h4 id="popup-title">Surprise Gift! <i class="fas fa-gift"></i></h4>
       <p id="promo-text">
@@ -250,7 +250,7 @@
               target="_blank"
               rel="noopener noreferrer"
             >
-              <i class="fa-brands fa-x-twitter"></i>
+              <span aria-hidden="true" class="fa-brands fa-x-twitter"></span>
             </a>
             <a
               href="https://github.com/janavipandole"

--- a/register.html
+++ b/register.html
@@ -65,25 +65,25 @@
           <li><a href="community.html">Community</a></li>
           <li><a href="promotions.html">Promotions</a></li>
           <li class="nav-icon">
-            <a href="contact.html" aria-label="Contact"><i class="ri-customer-service-2-line"></i></a>
+            <a href="contact.html" aria-label="Contact"><span aria-hidden="true" class="ri-customer-service-2-line"></span></a>
           </li>
           <li class="nav-icon">
-            <a class="active" href="login.html" aria-label="Login"><i class="ri-user-3-line"></i></a>
+            <a class="active" href="login.html" aria-label="Login"><span aria-hidden="true" class="ri-user-3-line"></span></a>
           </li>
           <li class="nav-icon">
-            <a href="cart.html" id="lg-bag" aria-label="Cart"><i class="ri-shopping-bag-4-line"></i></a>
+            <a href="cart.html" id="lg-bag" aria-label="Cart"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a>
           </li>
           <li class="nav-icon">
             <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
-              <i class="ri-moon-line" id="themeIcon"></i>
+              <span aria-hidden="true" class="ri-moon-line" id="themeIcon"></span>
             </button>
           </li>
-          <a href="#" id="close" aria-label="Close menu"><i class="fa-solid fa-xmark"></i></a>
+          <a href="#" id="close" aria-label="Close menu"><span aria-hidden="true" class="fa-solid fa-xmark"></span></a>
         </ul>
       </div>
       <div class="mobile">
-        <a href="login.html" aria-label="Login"><i class="ri-user-3-line"></i></a>
-        <a href="cart.html" aria-label="Cart"><i class="ri-shopping-bag-4-line"></i></a>
+        <a href="login.html" aria-label="Login"><span aria-hidden="true" class="ri-user-3-line"></span></a>
+        <a href="cart.html" aria-label="Cart"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a>
         <i class="fas fa-outdent" id="bar" role="button" aria-label="Open menu" aria-expanded="false" tabindex="0"></i>
 <<<<<<< fix/login-register-flow
       </div>
@@ -91,7 +91,7 @@
 =======
       <!-- Theme Toggle -->
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-        <i class="ri-moon-line" id="themeIconMobile"></i>
+        <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
       </button>
     </div>
 </section>
@@ -155,7 +155,7 @@
                   autocomplete="new-password"
                 />
                 <button type="button" id="togglePassword" class="toggle-eye" aria-label="Toggle password visibility">
-                  <i class="ri-eye-line" id="registerToggleIcon"></i>
+                  <span aria-hidden="true" class="ri-eye-line" id="registerToggleIcon"></span>
                 </button>
               </div>
               <small>Use at least 8 characters with a number.</small>
@@ -175,7 +175,7 @@
                   autocomplete="new-password"
                 />
                 <button type="button" id="confirmTogglePassword" class="toggle-eye" aria-label="Toggle confirm password visibility">
-                  <i class="ri-eye-line" id="confirmToggleIcon"></i>
+                  <span aria-hidden="true" class="ri-eye-line" id="confirmToggleIcon"></span>
                 </button>
               </div>
               <!-- confirmHint shows live "match / no match" as they type -->
@@ -226,7 +226,7 @@
           <img class="footer-logo" src="images/logo.png" alt="Cara Logo" />
         </div>
         <div class="footer-socials">
-          <a href="https://x.com/JanaviPandole" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-x-twitter"></i></a>
+          <a href="https://x.com/JanaviPandole" target="_blank" rel="noopener noreferrer"><span aria-hidden="true" class="fa-brands fa-x-twitter"></span></a>
           <a href="https://github.com/janavipandole" target="_blank" rel="noopener noreferrer"><i class="fab fa-github"></i></a>
           <a href="https://www.linkedin.com/in/janavi-pandole-80a7b2290" target="_blank" rel="noopener noreferrer"><i class="fab fa-linkedin"></i></a>
           <a href="https://www.youtube.com/@JanaviPandole" target="_blank" rel="noopener noreferrer"><i class="fab fa-youtube"></i></a>

--- a/shop.html
+++ b/shop.html
@@ -64,30 +64,30 @@
           <li><a href="try-on.html">Try-On</a></li>
           <li><a href="community.html">Community</a></li>
           <li><a href="promotions.html">Promotions</a></li>
-          <li class="nav-icon"><a href="contact.html" aria-label="Contact"><i class="ri-customer-service-2-line"></i></a></li>
-          <li class="nav-icon"><a href="login.html" aria-label="Login"><i class="ri-user-3-line"></i></a></li>
+          <li class="nav-icon"><a href="contact.html" aria-label="Contact"><span aria-hidden="true" class="ri-customer-service-2-line"></span></a></li>
+          <li class="nav-icon"><a href="login.html" aria-label="Login"><span aria-hidden="true" class="ri-user-3-line"></span></a></li>
           <li class="nav-icon">
             <a href="wishlist.html" class="wishlist-nav-link" aria-label="Wishlist">
-              <i class="ri-heart-line"></i>
+              <span aria-hidden="true" class="ri-heart-line"></span>
               <span class="wishlist-count hidden">0</span>
             </a>
           </li>
-          <li class="nav-icon"><a href="cart.html" id="lg-bag" aria-label="Cart"><i class="ri-shopping-bag-4-line"></i></a></li>
-          <li class="nav-icon"><button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode"><i class="ri-moon-line" id="themeIcon"></i></button></li>
-          <a href="javascript:void(0)" id="close" aria-label="Close menu"><i class="fa-solid fa-xmark"></i></a>
+          <li class="nav-icon"><a href="cart.html" id="lg-bag" aria-label="Cart"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a></li>
+          <li class="nav-icon"><button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode"><span aria-hidden="true" class="ri-moon-line" id="themeIcon"></span></button></li>
+          <a href="javascript:void(0)" id="close" aria-label="Close menu"><span aria-hidden="true" class="fa-solid fa-xmark"></span></a>
         </ul>
       </div>
       <div class="mobile">
-        <a href="login.html" aria-label="Login"><i class="ri-user-3-line"></i></a>
+        <a href="login.html" aria-label="Login"><span aria-hidden="true" class="ri-user-3-line"></span></a>
         <a href="wishlist.html" class="wishlist-nav-link" aria-label="Wishlist">
-          <i class="ri-heart-line"></i>
+          <span aria-hidden="true" class="ri-heart-line"></span>
           <span class="wishlist-count hidden">0</span>
         </a>
-        <a href="cart.html" aria-label="Cart"><i class="ri-shopping-bag-4-line"></i></a>
+        <a href="cart.html" aria-label="Cart"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a>
         <i class="fas fa-outdent" id="bar" role="button" aria-label="Open menu" aria-expanded="false" tabindex="0"></i>
       <!-- Theme Toggle -->
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-        <i class="ri-moon-line" id="themeIconMobile"></i>
+        <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
       </button>
       </div>
     </section>
@@ -164,7 +164,7 @@
       <label for="searchInput" class="sr-only" style="position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); border: 0;">Search Products</label>
       <input type="text" id="searchInput" placeholder="Search products..." />
       <button id="searchBtn" aria-label="Search">
-        <i class="ri-search-line"></i>
+        <span aria-hidden="true" class="ri-search-line"></span>
       </button>
     </div>
   </div>
@@ -216,7 +216,7 @@
 </section>
     <section id="product1" class="section-p1">
       <div class="sort-container" aria-label="Sort products list">
-        <label class="sort-label" for="sort-price"><i class="ri-sorting-asc"></i> Sort by</label>
+        <label class="sort-label" for="sort-price"><span aria-hidden="true" class="ri-sorting-asc"></span> Sort by</label>
         <div class="sort-select-wrap">
           <select id="sort-price" class="sort-dropdown">
             <option value="default">Default Sorting</option>
@@ -226,7 +226,7 @@
             <option value="rating-low">Rating: Low to High</option>
             <option value="newest">Newest</option>
           </select>
-          <i class="ri-arrow-down-s-line sort-chevron" aria-hidden="true"></i>
+          <span aria-hidden="true" class="ri-arrow-down-s-line sort-chevron" aria-hidden="true"></span>
         </div>
       <div class="pro-container" id="shop-container"></div>
     </section>
@@ -248,7 +248,7 @@
     <!-- <footer class="section-p1">
     <section id="product1" class="section-p1">
       <div class="sort-container" aria-label="Sort products list">
-        <label class="sort-label" for="sort-price"><i class="ri-sorting-asc"></i> Sort by</label>
+        <label class="sort-label" for="sort-price"><span aria-hidden="true" class="ri-sorting-asc"></span> Sort by</label>
         <div class="sort-select-wrap">
           <select id="sort-price" class="sort-dropdown">
             <option value="default">Default Sorting</option>
@@ -258,7 +258,7 @@
             <option value="rating-low">Rating: Low to High</option>
             <option value="newest">Newest</option>
           </select>
-          <i class="ri-arrow-down-s-line sort-chevron" aria-hidden="true"></i>
+          <span aria-hidden="true" class="ri-arrow-down-s-line sort-chevron" aria-hidden="true"></span>
         </div>
       </div>
       <div class="pro-container" id="shop-container"></div>
@@ -308,7 +308,7 @@
         <h4>Follow us</h4>
         <div class="icon">
           <a href="https://x.com/JanaviPandole" target="_blank" rel="noopener noreferrer" aria-label="X (formerly Twitter)">
-            <i class="fa-brands fa-x-twitter"></i>
+            <span aria-hidden="true" class="fa-brands fa-x-twitter"></span>
           </a>
           <a href="https://github.com/janavipandole" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
             <i class="fab fa-github"></i>

--- a/singleProduct.html
+++ b/singleProduct.html
@@ -68,30 +68,30 @@
         <li><a href="promotions.html">Promotions</a></li>
         <li>
           <a href="wishlist.html" class="wishlist-nav-link" aria-label="Wishlist">
-            <i class="ri-heart-line"></i>
+            <span aria-hidden="true" class="ri-heart-line"></span>
             <span class="wishlist-count hidden">0</span>
           </a>
         </li>
-        <li><a href="cart.html" id="lg-bag" aria-label="Cart"><i class="ri-shopping-bag-4-line"></i></a></li>
+        <li><a href="cart.html" id="lg-bag" aria-label="Cart"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a></li>
         <li>
           <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
-            <i class="ri-moon-line" id="themeIcon"></i>
+            <span aria-hidden="true" class="ri-moon-line" id="themeIcon"></span>
           </button>
         </li>
 
-        <a href="#" id="close" aria-label="Close menu"><i class="fa-solid fa-xmark"></i></a>
+        <a href="#" id="close" aria-label="Close menu"><span aria-hidden="true" class="fa-solid fa-xmark"></span></a>
       </ul>
     </div>
     <div class="mobile">
       <a href="wishlist.html" class="wishlist-nav-link" aria-label="Wishlist">
-        <i class="ri-heart-line"></i>
+        <span aria-hidden="true" class="ri-heart-line"></span>
         <span class="wishlist-count hidden">0</span>
       </a>
-      <a href="cart.html" aria-label="Cart"><i class="ri-shopping-bag-4-line"></i></a>
+      <a href="cart.html" aria-label="Cart"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a>
       <i class="fas fa-outdent" id="bar"></i>
       <!-- Theme Toggle -->
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-        <i class="ri-moon-line" id="themeIconMobile"></i>
+        <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
       </button>
     </div>
     <button onclick="history.back()" class="back-btn" aria-label="Go back">Back</button>
@@ -216,12 +216,12 @@
         <div class="cart-action-group">
           <div class="quantity-selector">
             <button type="button" class="qty-btn minus" onclick="updateQty(-1)" aria-label="Decrease quantity">
-              <i class="fa-solid fa-minus"></i>
+              <span aria-hidden="true" class="fa-solid fa-minus"></span>
             </button>
             <input id="product-quantity" type="number" value="1" min="1" readonly title="Product quantity"
               aria-label="Product quantity">
             <button type="button" class="qty-btn plus" onclick="updateQty(1)" aria-label="Increase quantity">
-              <i class="fa-solid fa-plus"></i>
+              <span aria-hidden="true" class="fa-solid fa-plus"></span>
             </button>
           </div>
           <button class="normal" onclick="handleAddToCart()">Add to Cart</button>
@@ -235,7 +235,7 @@
             aria-pressed="false"
             aria-label="Add product to wishlist"
           >
-            <i class="ri-heart-line" aria-hidden="true"></i>
+            <span aria-hidden="true" class="ri-heart-line" aria-hidden="true"></span>
             <span>Wishlist</span>
           </button>
           <button class="normal" style="background: var(--accent); color: white; margin-left: 10px;"
@@ -271,11 +271,11 @@
       <div style="background: #f9f9f9; padding: 25px; border-radius: 8px; border: 1px solid #eee;">
         <h3 style="font-size: 32px; margin: 0; color: #222;">4.8</h3>
         <div style="color: #ffbd27; font-size: 18px; margin: 8px 0;">
-          <i class="ri-star-fill"></i>
-          <i class="ri-star-fill"></i>
-          <i class="ri-star-fill"></i>
-          <i class="ri-star-fill"></i>
-          <i class="ri-star-half-fill"></i>
+          <span aria-hidden="true" class="ri-star-fill"></span>
+          <span aria-hidden="true" class="ri-star-fill"></span>
+          <span aria-hidden="true" class="ri-star-fill"></span>
+          <span aria-hidden="true" class="ri-star-fill"></span>
+          <span aria-hidden="true" class="ri-star-half-fill"></span>
         </div>
         <p style="margin: 0; font-size: 14px; color: #555;">Based on 124 reviews</p>
       </div>
@@ -287,11 +287,11 @@
           <div>
             <label style="display: block; font-weight: 600; margin-bottom: 5px;">Rating:</label>
             <div id="star-rating-selector" style="display: flex; gap: 5px; font-size: 24px; color: #ccc; cursor: pointer;">
-              <i class="ri-star-line" data-rating="1" onclick="setRating(1)"></i>
-              <i class="ri-star-line" data-rating="2" onclick="setRating(2)"></i>
-              <i class="ri-star-line" data-rating="3" onclick="setRating(3)"></i>
-              <i class="ri-star-line" data-rating="4" onclick="setRating(4)"></i>
-              <i class="ri-star-line" data-rating="5" onclick="setRating(5)"></i>
+              <span aria-hidden="true" class="ri-star-line" data-rating="1" onclick="setRating(1)"></span>
+              <span aria-hidden="true" class="ri-star-line" data-rating="2" onclick="setRating(2)"></span>
+              <span aria-hidden="true" class="ri-star-line" data-rating="3" onclick="setRating(3)"></span>
+              <span aria-hidden="true" class="ri-star-line" data-rating="4" onclick="setRating(4)"></span>
+              <span aria-hidden="true" class="ri-star-line" data-rating="5" onclick="setRating(5)"></span>
             </div>
             <input type="hidden" id="review-rating" value="0">
           </div>
@@ -370,9 +370,9 @@
         let starHtml = '';
         for (let i = 0; i < 5; i++) {
           if (i < review.rating) {
-            starHtml += '<i class="ri-star-fill" style="color: #ffbd27;"></i>';
+            starHtml += '<span aria-hidden="true" class="ri-star-fill" style="color: #ffbd27;"></span>';
           } else {
-            starHtml += '<i class="ri-star-line" style="color: #ccc;"></i>';
+            starHtml += '<span aria-hidden="true" class="ri-star-line" style="color: #ccc;"></span>';
           }
         }
 
@@ -386,7 +386,7 @@
           <div style="display: flex; justify-content: space-between; align-items: center;">
             <h4 style="margin: 0; font-size: 16px;">
               ${sanitizeHTML(review.name)} 
-              ${review.verified ? '<span style="color: #088178; font-size: 12px; margin-left: 8px;"><i class="ri-checkbox-circle-fill"></i> Verified Buyer</span>' : ''}
+              ${review.verified ? '<span style="color: #088178; font-size: 12px; margin-left: 8px;"><span aria-hidden="true" class="ri-checkbox-circle-fill"></span> Verified Buyer</span>' : ''}
             </h4>
             <span style="font-size: 12px; color: #777;">${dateStr}</span>
           </div>
@@ -415,7 +415,7 @@
       const status = document.getElementById('review-status');
       
       if (currentRating === 0) {
-        status.innerHTML = `<span style="color: #ef4444;"><i class="ri-error-warning-line"></i> Please select a star rating.</span>`;
+        status.innerHTML = `<span style="color: #ef4444;"><span aria-hidden="true" class="ri-error-warning-line"></span> Please select a star rating.</span>`;
         return;
       }
 
@@ -434,7 +434,7 @@
       document.getElementById('review-sort').value = 'recent';
       sortReviews();
 
-      status.innerHTML = `<span style="color: #088178;"><i class="ri-checkbox-circle-line"></i> Thank you! Review submitted successfully.</span>`;
+      status.innerHTML = `<span style="color: #088178;"><span aria-hidden="true" class="ri-checkbox-circle-line"></span> Thank you! Review submitted successfully.</span>`;
       
       document.getElementById('review-form').reset();
       setRating(0);
@@ -473,7 +473,7 @@
         <h4>Follow us</h4>
         <div class="icon">
           <a href="https://x.com/JanaviPandole" target="_blank" rel="noopener noreferrer">
-            <i class="fa-brands fa-x-twitter"></i>
+            <span aria-hidden="true" class="fa-brands fa-x-twitter"></span>
           </a>
           <a href="https://github.com/janavipandole" target="_blank" rel="noopener noreferrer">
             <i class="fab fa-github"></i>

--- a/terms.html
+++ b/terms.html
@@ -163,21 +163,21 @@
       <!-- Contact Icon -->
       <li class="nav-icon">
         <a href="contact.html" aria-label="Contact">
-          <i class="ri-customer-service-2-line"></i>
+          <span aria-hidden="true" class="ri-customer-service-2-line"></span>
         </a>
       </li>
 
       <!-- Login Icon -->
       <li class="nav-icon">
         <a href="login.html" aria-label="Login">
-          <i class="ri-user-3-line"></i>
+          <span aria-hidden="true" class="ri-user-3-line"></span>
         </a>
       </li>
 
       <!-- Cart Icon -->
       <li class="nav-icon">
         <a href="cart.html" id="lg-bag" aria-label="Cart">
-          <i class="ri-shopping-bag-4-line"></i>
+          <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
         </a>
       </li>
 
@@ -188,7 +188,7 @@
           id="themeToggle"
           aria-label="Toggle dark mode"
         >
-          <i class="ri-moon-line" id="themeIcon"></i>
+          <span aria-hidden="true" class="ri-moon-line" id="themeIcon"></span>
         </button>
       </li>
 
@@ -199,7 +199,7 @@
         aria-label="Close menu"
         aria-hidden="false"
       >
-        <i class="fa-solid fa-xmark"></i>
+        <span aria-hidden="true" class="fa-solid fa-xmark"></span>
       </a>
 
     </ul>
@@ -210,12 +210,12 @@
 
     <!-- Login Icon -->
     <a href="login.html" aria-label="Login">
-      <i class="ri-user-3-line"></i>
+      <span aria-hidden="true" class="ri-user-3-line"></span>
     </a>
 
     <!-- Cart Icon -->
     <a href="cart.html" aria-label="Cart">
-      <i class="ri-shopping-bag-4-line"></i>
+      <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
     </a>
 
     <!-- Hamburger Menu -->
@@ -229,7 +229,7 @@
     ></i>
       <!-- Theme Toggle -->
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-        <i class="ri-moon-line" id="themeIconMobile"></i>
+        <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
       </button>
 
   </div>
@@ -265,7 +265,7 @@
       <!-- Main Terms Texts -->
       <div class="terms-content-wrap">
         <button onclick="javascript:history.back()" class="back-btn" aria-label="Go back to previous page" style="border: none; font-family: inherit; font-size: inherit; display: inline-flex; align-items: center; gap: 8px; margin-bottom: 25px; background: #088178; color: #fff; padding: 8px 18px; border-radius: 4px; font-weight: 600; cursor: pointer;">
-          <i class="ri-arrow-left-line"></i> Back
+          <span aria-hidden="true" class="ri-arrow-left-line"></span> Back
         </button>
 
         <h1 style="font-size: 32px; font-weight: 700; margin-bottom: 8px;">Terms &amp; Conditions</h1>
@@ -418,7 +418,7 @@
           <h4>Follow us</h4>
           <div class="icon">
             <a href="https://x.com/JanaviPandole" target="_blank" rel="noopener noreferrer">
-              <i class="fa-brands fa-x-twitter"></i>
+              <span aria-hidden="true" class="fa-brands fa-x-twitter"></span>
             </a>
             <a href="https://github.com/janavipandole" target="_blank" rel="noopener noreferrer">
               <i class="fab fa-github"></i>

--- a/track-order.html
+++ b/track-order.html
@@ -87,21 +87,21 @@
       <!-- Contact Icon -->
       <li class="nav-icon">
         <a href="contact.html" aria-label="Contact">
-          <i class="ri-customer-service-2-line"></i>
+          <span aria-hidden="true" class="ri-customer-service-2-line"></span>
         </a>
       </li>
 
       <!-- Login Icon -->
       <li class="nav-icon">
         <a href="login.html" aria-label="Login">
-          <i class="ri-user-3-line"></i>
+          <span aria-hidden="true" class="ri-user-3-line"></span>
         </a>
       </li>
 
       <!-- Cart Icon -->
       <li class="nav-icon">
         <a href="cart.html" id="lg-bag" aria-label="Cart">
-          <i class="ri-shopping-bag-4-line"></i>
+          <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
         </a>
       </li>
 
@@ -112,7 +112,7 @@
           id="themeToggle"
           aria-label="Toggle dark mode"
         >
-          <i class="ri-moon-line" id="themeIcon"></i>
+          <span aria-hidden="true" class="ri-moon-line" id="themeIcon"></span>
         </button>
       </li>
 
@@ -123,7 +123,7 @@
         aria-label="Close menu"
         aria-hidden="false"
       >
-        <i class="fa-solid fa-xmark"></i>
+        <span aria-hidden="true" class="fa-solid fa-xmark"></span>
       </a>
 
     </ul>
@@ -134,12 +134,12 @@
 
     <!-- Login Icon -->
     <a href="login.html" aria-label="Login">
-      <i class="ri-user-3-line"></i>
+      <span aria-hidden="true" class="ri-user-3-line"></span>
     </a>
 
     <!-- Cart Icon -->
     <a href="cart.html" aria-label="Cart">
-      <i class="ri-shopping-bag-4-line"></i>
+      <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
     </a>
 
     <!-- Hamburger Menu -->
@@ -153,7 +153,7 @@
     ></i>
       <!-- Theme Toggle -->
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-        <i class="ri-moon-line" id="themeIconMobile"></i>
+        <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
       </button>
 
   </div>
@@ -174,7 +174,7 @@
       <!-- Lookup Form Card -->
       <div class="track-form-card">
         <div class="track-form-header">
-          <i class="ri-map-pin-time-line"></i>
+          <span aria-hidden="true" class="ri-map-pin-time-line"></span>
           <h2>Order Lookup</h2>
           <p>Enter your Order ID and the email you used at checkout.</p>
         </div>
@@ -182,7 +182,7 @@
         <form class="track-form" id="trackOrderForm" novalidate>
           <div class="form-group">
             <label for="orderId">
-              <i class="ri-hashtag"></i> Order ID
+              <span aria-hidden="true" class="ri-hashtag"></span> Order ID
             </label>
             <input
               type="text"
@@ -197,7 +197,7 @@
 
           <div class="form-group">
             <label for="orderEmail">
-              <i class="ri-mail-line"></i> Email Address
+              <span aria-hidden="true" class="ri-mail-line"></span> Email Address
             </label>
             <input
               type="email"
@@ -210,7 +210,7 @@
           </div>
 
           <button type="submit" class="track-btn" id="trackBtn">
-            <i class="ri-search-line"></i>
+            <span aria-hidden="true" class="ri-search-line"></span>
             <span>Track Order</span>
             <div class="btn-loader" id="btnLoader"></div>
           </button>
@@ -218,7 +218,7 @@
 
         <!-- Demo hint -->
         <div class="demo-hint">
-          <i class="ri-information-line"></i>
+          <span aria-hidden="true" class="ri-information-line"></span>
           <span>Demo: Use Order ID <strong>CARA-20261234</strong> with any email to see a sample result.</span>
         </div>
       </div>
@@ -233,7 +233,7 @@
             <strong id="resultOrderId">CARA-20261234</strong>
           </div>
           <div class="order-status-badge" id="statusBadge">
-            <i class="ri-truck-line"></i>
+            <span aria-hidden="true" class="ri-truck-line"></span>
             <span id="statusText">In Transit</span>
           </div>
         </div>
@@ -241,28 +241,28 @@
         <!-- Order Details Row -->
         <div class="order-details-grid">
           <div class="detail-item">
-            <i class="ri-calendar-line"></i>
+            <span aria-hidden="true" class="ri-calendar-line"></span>
             <div>
               <span class="detail-label">Order Date</span>
               <span class="detail-value" id="orderDate">May 14, 2026</span>
             </div>
           </div>
           <div class="detail-item">
-            <i class="ri-truck-line"></i>
+            <span aria-hidden="true" class="ri-truck-line"></span>
             <div>
               <span class="detail-label">Carrier</span>
               <span class="detail-value" id="orderCarrier">FedEx Express</span>
             </div>
           </div>
           <div class="detail-item">
-            <i class="ri-barcode-line"></i>
+            <span aria-hidden="true" class="ri-barcode-line"></span>
             <div>
               <span class="detail-label">Tracking No.</span>
               <span class="detail-value" id="trackingNo">7489 2091 3847</span>
             </div>
           </div>
           <div class="detail-item">
-            <i class="ri-map-pin-2-line"></i>
+            <span aria-hidden="true" class="ri-map-pin-2-line"></span>
             <div>
               <span class="detail-label">Est. Delivery</span>
               <span class="detail-value" id="estDelivery">May 20, 2026</span>
@@ -277,7 +277,7 @@
 
             <div class="timeline-step completed" id="step-ordered" aria-label="Step 1: Order Placed (Completed)">
               <div class="step-icon">
-                <i class="ri-shopping-bag-check-line"></i>
+                <span aria-hidden="true" class="ri-shopping-bag-check-line"></span>
               </div>
               <div class="step-content">
                 <h4>Order Placed</h4>
@@ -288,7 +288,7 @@
 
             <div class="timeline-step completed" id="step-packed" aria-label="Step 2: Order Packed (Completed)">
               <div class="step-icon">
-                <i class="ri-archive-2-line"></i>
+                <span aria-hidden="true" class="ri-archive-2-line"></span>
               </div>
               <div class="step-content">
                 <h4>Order Packed</h4>
@@ -299,7 +299,7 @@
 
             <div class="timeline-step completed" id="step-shipped" aria-label="Step 3: Shipped (Completed)">
               <div class="step-icon">
-                <i class="ri-send-plane-line"></i>
+                <span aria-hidden="true" class="ri-send-plane-line"></span>
               </div>
               <div class="step-content">
                 <h4>Shipped</h4>
@@ -310,7 +310,7 @@
 
             <div class="timeline-step active" id="step-transit" aria-current="step" aria-label="Step 4: In Transit (Current Step)">
               <div class="step-icon">
-                <i class="ri-truck-line"></i>
+                <span aria-hidden="true" class="ri-truck-line"></span>
               </div>
               <div class="step-content">
                 <h4>In Transit</h4>
@@ -321,7 +321,7 @@
 
             <div class="timeline-step" id="step-delivered" aria-label="Step 5: Delivered (Pending)">
               <div class="step-icon">
-                <i class="ri-home-check-line"></i>
+                <span aria-hidden="true" class="ri-home-check-line"></span>
               </div>
               <div class="step-content">
                 <h4>Delivered</h4>
@@ -363,24 +363,24 @@
         <!-- Actions -->
         <div class="result-actions">
           <button class="action-btn secondary" onclick="resetTracker()">
-            <i class="ri-arrow-left-line"></i> Track Another Order
+            <span aria-hidden="true" class="ri-arrow-left-line"></span> Track Another Order
           </button>
           <a href="contact.html" class="action-btn primary">
-            <i class="ri-customer-service-2-line"></i> Contact Support
+            <span aria-hidden="true" class="ri-customer-service-2-line"></span> Contact Support
           </a>
         </div>
       </div>
 
       <!-- Error Card (hidden by default) -->
       <div class="track-error-card" id="trackError">
-        <i class="ri-error-warning-line"></i>
+        <span aria-hidden="true" class="ri-error-warning-line"></span>
         <h3>Order Not Found</h3>
         <p>
           We couldn't find an order matching that ID and email. Please double-check your
           confirmation email and try again.
         </p>
         <button class="action-btn secondary" onclick="resetTracker()">
-          <i class="ri-arrow-left-line"></i> Try Again
+          <span aria-hidden="true" class="ri-arrow-left-line"></span> Try Again
         </button>
       </div>
 
@@ -394,7 +394,7 @@
         <div class="faq-item">
           <div class="faq-question" onclick="toggleFaq(this)">
             <span>Where is my Order ID?</span>
-            <i class="ri-add-line"></i>
+            <span aria-hidden="true" class="ri-add-line"></span>
           </div>
           <div class="faq-answer">
             Your Order ID (e.g. CARA-20261234) is included in the confirmation
@@ -406,7 +406,7 @@
         <div class="faq-item">
           <div class="faq-question" onclick="toggleFaq(this)">
             <span>How long does shipping take?</span>
-            <i class="ri-add-line"></i>
+            <span aria-hidden="true" class="ri-add-line"></span>
           </div>
           <div class="faq-answer">
             Standard shipping takes 5–7 business days. Express shipping takes
@@ -418,7 +418,7 @@
         <div class="faq-item">
           <div class="faq-question" onclick="toggleFaq(this)">
             <span>My tracking hasn't updated. What should I do?</span>
-            <i class="ri-add-line"></i>
+            <span aria-hidden="true" class="ri-add-line"></span>
           </div>
           <div class="faq-answer">
             Tracking updates can sometimes take 24–48 hours to reflect after a
@@ -430,7 +430,7 @@
         <div class="faq-item">
           <div class="faq-question" onclick="toggleFaq(this)">
             <span>My order shows "Delivered" but I didn't receive it.</span>
-            <i class="ri-add-line"></i>
+            <span aria-hidden="true" class="ri-add-line"></span>
           </div>
           <div class="faq-answer">
             Please check with your neighbours and around your property for the
@@ -458,7 +458,7 @@
           <h4>Follow us</h4>
           <div class="icon">
             <a href="https://x.com/JanaviPandole" target="_blank" rel="noopener noreferrer">
-              <i class="fa-brands fa-x-twitter"></i>
+              <span aria-hidden="true" class="fa-brands fa-x-twitter"></span>
             </a>
             <a href="https://github.com/janavipandole" target="_blank" rel="noopener noreferrer">
               <i class="fab fa-github"></i>

--- a/try-on.html
+++ b/try-on.html
@@ -550,21 +550,21 @@
       <!-- Contact Icon -->
       <li class="nav-icon">
         <a href="contact.html" aria-label="Contact">
-          <i class="ri-customer-service-2-line"></i>
+          <span aria-hidden="true" class="ri-customer-service-2-line"></span>
         </a>
       </li>
 
       <!-- Login Icon -->
       <li class="nav-icon">
         <a href="login.html" aria-label="Login">
-          <i class="ri-user-3-line"></i>
+          <span aria-hidden="true" class="ri-user-3-line"></span>
         </a>
       </li>
 
       <!-- Cart Icon -->
       <li class="nav-icon">
         <a href="cart.html" id="lg-bag" aria-label="Cart">
-          <i class="ri-shopping-bag-4-line"></i>
+          <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
         </a>
       </li>
 
@@ -575,7 +575,7 @@
           id="themeToggle"
           aria-label="Toggle dark mode"
         >
-          <i class="ri-moon-line" id="themeIcon"></i>
+          <span aria-hidden="true" class="ri-moon-line" id="themeIcon"></span>
         </button>
       </li>
 
@@ -586,7 +586,7 @@
         aria-label="Close menu"
         aria-hidden="false"
       >
-        <i class="fa-solid fa-xmark"></i>
+        <span aria-hidden="true" class="fa-solid fa-xmark"></span>
       </a>
 
     </ul>
@@ -597,12 +597,12 @@
 
     <!-- Login Icon -->
     <a href="login.html" aria-label="Login">
-      <i class="ri-user-3-line"></i>
+      <span aria-hidden="true" class="ri-user-3-line"></span>
     </a>
 
     <!-- Cart Icon -->
     <a href="cart.html" aria-label="Cart">
-      <i class="ri-shopping-bag-4-line"></i>
+      <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
     </a>
 
     <!-- Hamburger Menu -->
@@ -621,10 +621,10 @@
             <!-- <div class="mobile">
             <button class="theme-toggle" id="themeToggleMobile"
                 aria-label="Toggle dark mode">
-                <i class="ri-moon-line" id="themeIconMobile"></i>
+                <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
             </button>
             <a href="cart.html" id="mobile-cart-icon">
-                <i class="ri-shopping-bag-4-line"></i>
+                <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
                 <span class="cart-count" id="mobileCartCount">0</span>
             </a>
             <i class="fas fa-outdent" id="bar"></i>
@@ -654,37 +654,37 @@
         <div class="tryon-layout">
             <!-- Left: Controls -->
             <div class="controls">
-                <h2><i class="ri-magic-line"></i> AI Virtual Try-On</h2>
+                <h2><span aria-hidden="true" class="ri-magic-line"></span> AI Virtual Try-On</h2>
                 <p>Use your camera or upload a photo. Our AI detects your body shape and fits the clothing on you.</p>
                 
                 <!-- Step 1: Input Mode -->
                 <h3>1. Choose Input</h3>
                 <div class="mode-toggle">
                     <button class="mode-btn active" id="btn-camera" onclick="switchMode('camera')">
-                        <i class="ri-camera-line"></i> Camera
+                        <span aria-hidden="true" class="ri-camera-line"></span> Camera
                     </button>
                     <button class="mode-btn" id="btn-upload" onclick="switchMode('upload')">
-                        <i class="ri-upload-cloud-2-line"></i> Upload
+                        <span aria-hidden="true" class="ri-upload-cloud-2-line"></span> Upload
                     </button>
                 </div>
 
                 <!-- Camera Controls -->
                 <div class="camera-area visible" id="camera-area">
                     <button class="camera-btn" id="open-camera-btn" onclick="openCamera()">
-                        <i class="ri-camera-line"></i> Open Camera
+                        <span aria-hidden="true" class="ri-camera-line"></span> Open Camera
                     </button>
                     <button class="camera-btn capture" id="capture-btn" style="display:none;" onclick="capturePhoto()">
-                        <i class="ri-camera-switch-line"></i> Capture Photo
+                        <span aria-hidden="true" class="ri-camera-switch-line"></span> Capture Photo
                     </button>
                     <button class="camera-btn" id="stop-camera-btn" style="display:none;" onclick="stopCamera()">
-                        <i class="ri-close-circle-line"></i> Stop Camera
+                        <span aria-hidden="true" class="ri-close-circle-line"></span> Stop Camera
                     </button>
                 </div>
 
                 <!-- Upload Controls -->
                 <div class="upload-area" id="upload-area">
                     <label class="upload-btn">
-                        <i class="ri-upload-cloud-2-line"></i>
+                        <span aria-hidden="true" class="ri-upload-cloud-2-line"></span>
                         <span id="upload-text">Click to upload full-body photo</span>
                         <input type="file" id="photo-upload" accept="image/*">
                     </label>
@@ -700,7 +700,7 @@
 
                 <!-- Step 3: Generate -->
                 <button class="action-btn" id="generate-btn" disabled>
-                    <i class="ri-sparkling-fill"></i> Generate AI Try-On
+                    <span aria-hidden="true" class="ri-sparkling-fill"></span> Generate AI Try-On
                 </button>
             </div>
 
@@ -731,15 +731,15 @@
                 <!-- Scanning Animation -->
                 <div class="scanning-container" id="scanner">
                     <div class="scanner-line"></div>
-                    <i class="ri-focus-3-line" style="font-size: 60px; color: var(--accent); animation: pulse 1s infinite alternate;"></i>
+                    <span aria-hidden="true" class="ri-focus-3-line" style="font-size: 60px; color: var(--accent); animation: pulse 1s infinite alternate;"></span>
                     <div class="ai-text" id="ai-status">DETECTING BODY...</div>
                 </div>
                 
                 <!-- Share Controls -->
                 <div class="share-controls" id="share-controls">
-                    <button class="share-btn" onclick="downloadResult()"><i class="ri-download-2-line"></i> Download</button>
-                    <button class="share-btn" onclick="shareResult()"><i class="ri-share-line"></i> Share</button>
-                    <button class="share-btn" onclick="resetTryOn()"><i class="ri-refresh-line"></i> Retry</button>
+                    <button class="share-btn" onclick="downloadResult()"><span aria-hidden="true" class="ri-download-2-line"></span> Download</button>
+                    <button class="share-btn" onclick="shareResult()"><span aria-hidden="true" class="ri-share-line"></span> Share</button>
+                    <button class="share-btn" onclick="resetTryOn()"><span aria-hidden="true" class="ri-refresh-line"></span> Retry</button>
                 </div>
             </div>
         </div>
@@ -763,7 +763,7 @@
         <h4>Follow us</h4>
         <div class="icon">
           <a href="https://x.com/JanaviPandole" target="_blank" rel="noopener noreferrer">
-            <i class="fa-brands fa-x-twitter"></i>
+            <span aria-hidden="true" class="fa-brands fa-x-twitter"></span>
           </a>
           <a href="https://github.com/janavipandole" target="_blank" rel="noopener noreferrer">
             <i class="fab fa-github"></i>

--- a/tshirt.html
+++ b/tshirt.html
@@ -199,21 +199,21 @@
                 <li><a href="about.html">About</a></li>
                 <li><a href="contact.html">Contact</a></li>
                 <li><a href="login.html">Login</a></li>
-                <li><a href="cart.html" id="lg-bag"><i class="ri-shopping-bag-4-line"></i></a></li>
+                <li><a href="cart.html" id="lg-bag"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a></li>
                 <li>
                     <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
-                        <i class="ri-moon-line" id="themeIcon"></i>
+                        <span aria-hidden="true" class="ri-moon-line" id="themeIcon"></span>
                     </button>
                 </li>
-                <a href="#" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="#" id="close"><span aria-hidden="true" class="fa-solid fa-xmark"></span></a>
             </ul>
         </div>
         <div class="mobile">
-            <a href="cart.html"><i class="ri-shopping-bag-4-line"></i></a>
+            <a href="cart.html"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a>
             <i class="fas fa-outdent" id="bar"></i>
       <!-- Theme Toggle -->
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-        <i class="ri-moon-line" id="themeIconMobile"></i>
+        <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
       </button>
         </div>
     </section>
@@ -233,25 +233,25 @@
 
     <section class="tshirt-features">
         <div class="tshirt-feature">
-            <i class="ri-t-shirt-line"></i>
+            <span aria-hidden="true" class="ri-t-shirt-line"></span>
             <h3>Premium Cotton</h3>
             <p>Soft and comfortable fabric.</p>
         </div>
 
         <div class="tshirt-feature">
-            <i class="ri-palette-line"></i>
+            <span aria-hidden="true" class="ri-palette-line"></span>
             <h3>Vibrant Prints</h3>
             <p>Modern and unique designs.</p>
         </div>
 
         <div class="tshirt-feature">
-            <i class="ri-shield-check-line"></i>
+            <span aria-hidden="true" class="ri-shield-check-line"></span>
             <h3>Long Lasting</h3>
             <p>Quality print and fabric finish.</p>
         </div>
 
         <div class="tshirt-feature">
-            <i class="ri-leaf-line"></i>
+            <span aria-hidden="true" class="ri-leaf-line"></span>
             <h3>Lightweight</h3>
             <p>Perfect for daily wear.</p>
         </div>
@@ -272,11 +272,11 @@
                 <div class="des">
                     <span>Cara</span>
                     <h5>Beyond Limits Graphic Tee</h5>
-                    <div class="star"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i
-                            class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
+                    <div class="star"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><i
+                            class="ri-star-fill"></i><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span></div>
                     <h4>$29.99</h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -285,11 +285,11 @@
                 <div class="des">
                     <span>Cara</span>
                     <h5>Inner Peace Printed Tee</h5>
-                    <div class="star"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i
-                            class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
+                    <div class="star"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><i
+                            class="ri-star-fill"></i><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span></div>
                     <h4>$27.99</h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -298,11 +298,11 @@
                 <div class="des">
                     <span>Cara</span>
                     <h5>Lost In Nature T-Shirt</h5>
-                    <div class="star"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i
-                            class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
+                    <div class="star"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><i
+                            class="ri-star-fill"></i><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span></div>
                     <h4>$29.99</h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -311,11 +311,11 @@
                 <div class="des">
                     <span>Cara</span>
                     <h5>Stay Kind Casual Tee</h5>
-                    <div class="star"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i
-                            class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
+                    <div class="star"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><i
+                            class="ri-star-fill"></i><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span></div>
                     <h4>$26.99</h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -324,11 +324,11 @@
                 <div class="des">
                     <span>Cara</span>
                     <h5>Bright Future Purple Tee</h5>
-                    <div class="star"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i
-                            class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
+                    <div class="star"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><i
+                            class="ri-star-fill"></i><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span></div>
                     <h4>$28.99</h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -337,11 +337,11 @@
                 <div class="des">
                     <span>Cara</span>
                     <h5>Create Reality T-Shirt</h5>
-                    <div class="star"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i
-                            class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
+                    <div class="star"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><i
+                            class="ri-star-fill"></i><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span></div>
                     <h4>$30.99</h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -350,11 +350,11 @@
                 <div class="des">
                     <span>Cara</span>
                     <h5>Smiley Drip White Tee</h5>
-                    <div class="star"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i
-                            class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
+                    <div class="star"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><i
+                            class="ri-star-fill"></i><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span></div>
                     <h4>$27.99</h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -363,11 +363,11 @@
                 <div class="des">
                     <span>Cara</span>
                     <h5>Evolve Everyday Tee</h5>
-                    <div class="star"><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i
-                            class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i></div>
+                    <div class="star"><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><i
+                            class="ri-star-fill"></i><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span></div>
                     <h4>$29.99</h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
             </div>
 
         </div>

--- a/winter-collection.html
+++ b/winter-collection.html
@@ -253,19 +253,19 @@
           <div class="mobile">
             <!-- Login Icon -->
             <a href="login.html" aria-label="Login">
-              <i class="ri-user-3-line"></i>
+              <span aria-hidden="true" class="ri-user-3-line"></span>
             </a>
 
             <!-- Cart Icon -->
             <a href="cart.html" aria-label="Cart">
-              <i class="ri-shopping-bag-4-line"></i>
+              <span aria-hidden="true" class="ri-shopping-bag-4-line"></span>
             </a>
 
             <!-- Hamburger Menu -->
             <i class="fas fa-outdent" id="bar" role="button" aria-label="Open menu" aria-expanded="false" tabindex="0"></i>
       <!-- Theme Toggle -->
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-        <i class="ri-moon-line" id="themeIconMobile"></i>
+        <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
       </button>
           </div>
         </section>
@@ -467,7 +467,7 @@
       </div>
 
       <div class="footer-socials">
-        <a href="https://x.com/JanaviPandole" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-x-twitter"></i></a>
+        <a href="https://x.com/JanaviPandole" target="_blank" rel="noopener noreferrer"><span aria-hidden="true" class="fa-brands fa-x-twitter"></span></a>
         <a href="https://github.com/janavipandole" target="_blank" rel="noopener noreferrer"><i class="fab fa-github"></i></a>
         <a href="https://www.linkedin.com/in/janavi-pandole-80a7b2290" target="_blank" rel="noopener noreferrer"><i class="fab fa-linkedin"></i></a>
         <a href="https://www.youtube.com/@JanaviPandole" target="_blank" rel="noopener noreferrer"><i class="fab fa-youtube"></i></a>

--- a/winter-sale.html
+++ b/winter-sale.html
@@ -229,22 +229,22 @@
                 <li><a href="about.html">About</a></li>
                 <li><a href="contact.html">Contact</a></li>
                 <li><a href="login.html">Login</a></li>
-                <li><a href="cart.html" id="lg-bag"><i class="ri-shopping-bag-4-line"></i></a></li>
+                <li><a href="cart.html" id="lg-bag"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a></li>
                 <li>
                     <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
-                        <i class="ri-moon-line" id="themeIcon"></i>
+                        <span aria-hidden="true" class="ri-moon-line" id="themeIcon"></span>
                     </button>
                 </li>
-                <a href="#" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="#" id="close"><span aria-hidden="true" class="fa-solid fa-xmark"></span></a>
             </ul>
         </div>
 
         <div class="mobile">
-            <a href="cart.html"><i class="ri-shopping-bag-4-line"></i></a>
+            <a href="cart.html"><span aria-hidden="true" class="ri-shopping-bag-4-line"></span></a>
             <i class="fas fa-outdent" id="bar"></i>
       <!-- Theme Toggle -->
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
-        <i class="ri-moon-line" id="themeIconMobile"></i>
+        <span aria-hidden="true" class="ri-moon-line" id="themeIconMobile"></span>
       </button>
         </div>
     </section>
@@ -269,19 +269,19 @@
 
     <section class="winter-features">
         <div class="winter-card">
-            <i class="ri-fire-line"></i>
+            <span aria-hidden="true" class="ri-fire-line"></span>
             <h3>Hot Winter Deals</h3>
             <p>Save more on selected jackets, hoodies, and warm outfits.</p>
         </div>
 
         <div class="winter-card">
-            <i class="ri-t-shirt-line"></i>
+            <span aria-hidden="true" class="ri-t-shirt-line"></span>
             <h3>Premium Comfort</h3>
             <p>Soft, stylish, and comfortable clothing for winter days.</p>
         </div>
 
         <div class="winter-card">
-            <i class="ri-truck-line"></i>
+            <span aria-hidden="true" class="ri-truck-line"></span>
             <h3>Fast Delivery</h3>
             <p>Get your favorite winter collection delivered quickly.</p>
         </div>
@@ -298,12 +298,12 @@
                     <span>Nike</span>
                     <h5>Winter Hoodie Collection</h5>
                     <div class="star">
-                        <i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i
-                            class="ri-star-fill"></i><i class="ri-star-fill"></i>
+                        <span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><i
+                            class="ri-star-fill"></i><span aria-hidden="true" class="ri-star-fill"></span>
                     </div>
                     <h4>$65 <span class="old-price">$120</span></h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -313,12 +313,12 @@
                     <span>Adidas</span>
                     <h5>Premium Sweatshirt</h5>
                     <div class="star">
-                        <i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i
-                            class="ri-star-fill"></i><i class="ri-star-fill"></i>
+                        <span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><i
+                            class="ri-star-fill"></i><span aria-hidden="true" class="ri-star-fill"></span>
                     </div>
                     <h4>$72 <span class="old-price">$115</span></h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -328,12 +328,12 @@
                     <span>Puma</span>
                     <h5>Classic Wool Jacket</h5>
                     <div class="star">
-                        <i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i
-                            class="ri-star-fill"></i><i class="ri-star-fill"></i>
+                        <span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><i
+                            class="ri-star-fill"></i><span aria-hidden="true" class="ri-star-fill"></span>
                     </div>
                     <h4>$89 <span class="old-price">$150</span></h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -343,12 +343,12 @@
                     <span>Zara</span>
                     <h5>Oversized Winter Hoodie</h5>
                     <div class="star">
-                        <i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i
-                            class="ri-star-fill"></i><i class="ri-star-fill"></i>
+                        <span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><i
+                            class="ri-star-fill"></i><span aria-hidden="true" class="ri-star-fill"></span>
                     </div>
                     <h4>$78 <span class="old-price">$105</span></h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -358,12 +358,12 @@
                     <span>H&M</span>
                     <h5>Winter Casual Shirt</h5>
                     <div class="star">
-                        <i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i
-                            class="ri-star-fill"></i><i class="ri-star-fill"></i>
+                        <span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><i
+                            class="ri-star-fill"></i><span aria-hidden="true" class="ri-star-fill"></span>
                     </div>
                     <h4>$69 <span class="old-price">$99</span></h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -373,12 +373,12 @@
                     <span>Roadster</span>
                     <h5>Snow Edition Jacket</h5>
                     <div class="star">
-                        <i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i
-                            class="ri-star-fill"></i><i class="ri-star-fill"></i>
+                        <span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><i
+                            class="ri-star-fill"></i><span aria-hidden="true" class="ri-star-fill"></span>
                     </div>
                     <h4>$95 <span class="old-price">$180</span></h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -388,12 +388,12 @@
                     <span>Levis</span>
                     <h5>Streetwear Winter Combo</h5>
                     <div class="star">
-                        <i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i
-                            class="ri-star-fill"></i><i class="ri-star-fill"></i>
+                        <span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><i
+                            class="ri-star-fill"></i><span aria-hidden="true" class="ri-star-fill"></span>
                     </div>
                     <h4>$84 <span class="old-price">$110</span></h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
             </div>
 
             <div class="pro" onclick="window.location.href='singleProduct.html';">
@@ -403,12 +403,12 @@
                     <span>Allen Solly</span>
                     <h5>Modern Winter Fit</h5>
                     <div class="star">
-                        <i class="ri-star-fill"></i><i class="ri-star-fill"></i><i class="ri-star-fill"></i><i
-                            class="ri-star-fill"></i><i class="ri-star-fill"></i>
+                        <span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><span aria-hidden="true" class="ri-star-fill"></span><i
+                            class="ri-star-fill"></i><span aria-hidden="true" class="ri-star-fill"></span>
                     </div>
                     <h4>$76 <span class="old-price">$125</span></h4>
                 </div>
-                <a href="#" class="cart"><i class="ri-shopping-cart-2-line"></i></a>
+                <a href="#" class="cart"><span aria-hidden="true" class="ri-shopping-cart-2-line"></span></a>
             </div>
 
         </div>

--- a/wishlist.html
+++ b/wishlist.html
@@ -479,14 +479,14 @@
     <header class="header-section">
         <div class="header-inner">
             <div>
-                <span class="wishlist-eyebrow"><i class="ri-heart-fill" aria-hidden="true"></i> Curated picks</span>
+                <span class="wishlist-eyebrow"><span aria-hidden="true" class="ri-heart-fill" aria-hidden="true"></span> Curated picks</span>
                 <h1>Wishlist</h1>
                 <p>Keep your favorite Cara pieces in one polished place, then move them to cart when the moment feels right.</p>
             </div>
-                <a href="shop.html" class="btn-secondary"><i class="ri-arrow-left-line" aria-hidden="true"></i> Back to Shop</a>
-                <button id="clearAllBtn" class="btn-danger-outline" onclick="clearWishlist()"><i class="ri-delete-bin-6-line" aria-hidden="true"></i> Clear All</button>
+                <a href="shop.html" class="btn-secondary"><span aria-hidden="true" class="ri-arrow-left-line" aria-hidden="true"></span> Back to Shop</a>
+                <button id="clearAllBtn" class="btn-danger-outline" onclick="clearWishlist()"><span aria-hidden="true" class="ri-delete-bin-6-line" aria-hidden="true"></span> Clear All</button>
                 <button class="theme-toggle btn-secondary" id="themeToggle" aria-label="Toggle dark mode" style="padding: 8px 12px; border-radius: 999px;">
-                  <i class="ri-moon-line" id="themeIcon"></i>
+                  <span aria-hidden="true" class="ri-moon-line" id="themeIcon"></span>
                 </button>
             </div>
         </div>
@@ -501,7 +501,7 @@
     <!-- Wishlist Sharing Utility -->
     <div style="max-width: 1200px; margin: 20px auto; padding: 0 20px; text-align: center;">
       <button onclick="shareWishlist()" style="background: #088178; color: #fff; border: none; padding: 10px 20px; border-radius: 4px; cursor: pointer; font-weight: 600; font-size: 16px;">
-        <i class="ri-share-line"></i> Copy Shareable Wishlist Link
+        <span aria-hidden="true" class="ri-share-line"></span> Copy Shareable Wishlist Link
       </button>
     </div>
     <script>
@@ -516,7 +516,7 @@
     </script>
     <!-- Global Toast Component -->
     <div id="toast">
-        <i class="ri-checkbox-circle-line" style="color: #088178; font-size: 20px;"></i>
+        <span aria-hidden="true" class="ri-checkbox-circle-line" style="color: #088178; font-size: 20px;"></span>
         <span id="toast-msg">Item added to cart!</span>
     </div>
 
@@ -610,7 +610,7 @@
                 wishlistContainer.style.display = 'block';
                 wishlistContainer.innerHTML = `
                     <div class="empty-state">
-                        <i class="ri-heart-pulse-line"></i>
+                        <span aria-hidden="true" class="ri-heart-pulse-line"></span>
                         <h2>Your wishlist is empty</h2>
                         <p>Explore our premium collections and add products you love to your personal wishlist!</p>
                         <a href="shop.html">Start Shopping</a>
@@ -634,7 +634,7 @@
 
                     const savedPill = document.createElement("span");
                     savedPill.className = "saved-pill";
-                    savedPill.innerHTML = '<i class="ri-heart-fill" aria-hidden="true"></i> Saved';
+                    savedPill.innerHTML = '<span aria-hidden="true" class="ri-heart-fill" aria-hidden="true"></span> Saved';
 
                     media.append(image, savedPill);
                     card.appendChild(media);
@@ -667,14 +667,14 @@
                     cartButton.className = "add-to-cart-btn";
                     cartButton.type = "button";
                     cartButton.setAttribute("aria-label", `Add ${product.name} to cart`);
-                    cartButton.innerHTML = '<i class="ri-shopping-cart-2-line" aria-hidden="true"></i> Add to Cart';
+                    cartButton.innerHTML = '<span aria-hidden="true" class="ri-shopping-cart-2-line" aria-hidden="true"></span> Add to Cart';
                     cartButton.addEventListener("click", () => moveToCart(index));
 
                     const removeButton = document.createElement("button");
                     removeButton.className = "remove-icon-btn";
                     removeButton.type = "button";
                     removeButton.setAttribute("aria-label", `Remove ${product.name} from wishlist`);
-                    removeButton.innerHTML = '<i class="ri-delete-bin-line" aria-hidden="true"></i>';
+                    removeButton.innerHTML = '<span aria-hidden="true" class="ri-delete-bin-line" aria-hidden="true"></span>';
                     removeButton.addEventListener("click", () => removeItem(index));
 
                     actions.append(cartButton, removeButton);


### PR DESCRIPTION
Closes #2507.

### Description
This PR addresses a widespread semantic HTML issue by replacing the use of `<i>` tags for rendering icons (FontAwesome, Remix Icons) with standard `<span>` tags.

### Changes Made
- Scanned the entire HTML codebase.
- Replaced instances of `<i class="fa-...>` and `<i class="ri-...>` with `<span aria-hidden="true" class="...">`.
- Replaced the closing `</i>` tags with `</span>`.

### Impact
- **Semantic Correctness:** According to HTML5 standards, the `<i>` element represents a span of text in an alternate voice or mood (like idiomatic text, technical terms, or taxonomic designations). It was historically misused for icons due to its short tag name. Switching to `<span>` correctly identifies the element as a generic container.
- **Accessibility:** Adding `aria-hidden="true"` to these decorative icon spans ensures that screen readers safely ignore them, preventing them from trying to read out confusing class names or raw unicode characters to visually impaired users.
