### PR TITLE
fix(promotions): improve discount popup text contrast in dark mode

### DIFF
--- a/promotions.css
+++ b/promotions.css
@@ -135,6 +135,17 @@
 #discount-popup h4 { margin: 0 0 8px 0; font-size: 20px; }
 #discount-popup .close-btn { position: absolute; top: 8px; right: 10px; cursor: pointer; font-size: 18px; }
 
+#discount-popup h4,
+#discount-popup p,
+#discount-popup i {
+    color: #fff;
+}
+
+#discount-popup .copy-code {
+    background: #fff;
+    color: var(--accent);
+}
+
 .copy-code {
   background: #fff;
   color: var(--accent);


### PR DESCRIPTION
# PR Description

## Summary of Changes

This PR fixes a dark mode readability issue in the **Surprise Gift** popup on the Promotions page.

The popup text now maintains sufficient contrast against the background in dark mode, improving readability while preserving the existing appearance in light mode.

## Related Issue

Fixes #2518 

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update

## Verification & Testing

### Local Verification

* [x] Built successfully locally
* [x] Verified the popup text is clearly readable in both light and dark modes.
* [x] Console has zero errors or warnings.

### Devices/Browsers Tested

* [x] Chrome (Desktop)
* [ ] Safari (Mobile)
* [ ] Firefox

## Checklist

* [x] Code follows project styling guidelines.
* [x] Changes are fully responsive and accessible.
* [x] Improved text contrast for better readability in dark mode.
* [x] No extraneous logs or debug code left.
* [ ] Documentation updated accordingly.

## Additional Notes

* Updated the popup text styling to ensure adequate contrast in dark mode.
* Preserved the existing popup layout, animations, and functionality.
* No changes were made to the popup behavior or user interactions.
