### PR TITLE
feat: add paginated order history and detail endpoints with audit trail

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,77 @@
+name: Backend Python CI
+
+on:
+  push:
+    branches:
+      - main
+      - 'enhancement/**'
+      - 'fix/**'
+      - 'feature/**'
+    paths:
+      - 'backend/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'backend/**'
+
+jobs:
+  backend-test:
+    name: Lint & Test Backend
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Check for Alembic migration consistency
+        env:
+          SECRET_KEY: ci-test-secret-key-not-used-in-prod
+          DATABASE_URL: sqlite:///./test_ci.db
+        run: |
+          alembic upgrade head
+          echo "Alembic migrations applied successfully."
+
+      - name: Run pytest
+        env:
+          SECRET_KEY: ci-test-secret-key-not-used-in-prod
+          DATABASE_URL: sqlite:///./test_ci.db
+        run: |
+          pytest tests/ -v --tb=short
+
+  lint-backend:
+    name: Python Lint (Ruff)
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Ruff
+        run: pip install ruff
+
+      - name: Run Ruff linter
+        run: ruff check . --output-format=github

--- a/backend/alembic/versions/c1d2e3f4a5b6_add_user_id_to_orders.py
+++ b/backend/alembic/versions/c1d2e3f4a5b6_add_user_id_to_orders.py
@@ -1,0 +1,80 @@
+"""Add user_id FK to orders and create order_status_history table
+
+Revision ID: c1d2e3f4a5b6
+Revises: a1b2c3d4e5f6
+Create Date: 2026-06-27 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c1d2e3f4a5b6'
+down_revision: Union[str, Sequence[str], None] = 'a1b2c3d4e5f6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema: link orders to the authenticated user and track status events."""
+    # Add nullable user_id FK to existing orders table so existing rows are preserved
+    with op.batch_alter_table('orders', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column('user_id', sa.Integer(), nullable=True)
+        )
+        batch_op.create_index('ix_orders_user_id', ['user_id'], unique=False)
+        batch_op.create_foreign_key(
+            'fk_orders_user_id_users',
+            'users',
+            ['user_id'],
+            ['id'],
+        )
+
+    # Create a dedicated audit table for status transitions so the frontend
+    # timeline page can replay the full journey of every order.
+    op.create_table(
+        'order_status_history',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('order_id', sa.Integer(), nullable=False),
+        sa.Column('status', sa.String(length=50), nullable=False),
+        sa.Column(
+            'changed_at',
+            sa.DateTime(),
+            nullable=False,
+        ),
+        sa.Column('note', sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ['order_id'],
+            ['orders.id'],
+            name='fk_order_status_history_order_id',
+            ondelete='CASCADE',
+        ),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(
+        'ix_order_status_history_id',
+        'order_status_history',
+        ['id'],
+        unique=False,
+    )
+    op.create_index(
+        'ix_order_status_history_order_id',
+        'order_status_history',
+        ['order_id'],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index('ix_order_status_history_order_id', table_name='order_status_history')
+    op.drop_index('ix_order_status_history_id', table_name='order_status_history')
+    op.drop_table('order_status_history')
+
+    with op.batch_alter_table('orders', schema=None) as batch_op:
+        batch_op.drop_constraint('fk_orders_user_id_users', type_='foreignkey')
+        batch_op.drop_index('ix_orders_user_id')
+        batch_op.drop_column('user_id')

--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -1,16 +1,51 @@
-from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.orm import Session
+from datetime import datetime, timezone
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session, joinedload
 from .. import models, schemas
 from ..database import get_db
 from .auth import get_current_user
 
 router = APIRouter()
 
+
+def _serialize_order(order: models.Order) -> dict:
+    """Convert a SQLAlchemy Order row into a dict suitable for OrderOut."""
+    return {
+        "id": order.id,
+        "full_name": order.full_name,
+        "email": order.email,
+        "address": order.address,
+        "city": order.city,
+        "zip_code": order.zip_code,
+        "total_amount": order.total_amount,
+        "status": order.status,
+        "created_at": order.created_at.isoformat() if order.created_at else "",
+        "items": [
+            {
+                "id": it.id,
+                "product_name": it.product_name,
+                "quantity": it.quantity,
+                "price": it.price,
+            }
+            for it in (order.items or [])
+        ],
+        "status_history": [
+            {
+                "id": sh.id,
+                "status": sh.status,
+                "changed_at": sh.changed_at.isoformat() if sh.changed_at else "",
+                "note": sh.note,
+            }
+            for sh in (order.status_history or [])
+        ],
+    }
+
+
 @router.post("/", status_code=201)
 def create_order(
-    order_data: schemas.OrderCreate, 
+    order_data: schemas.OrderCreate,
     db: Session = Depends(get_db),
-    current_user: models.User = Depends(get_current_user)
+    current_user: models.User = Depends(get_current_user),
 ):
     subtotal = 0.0
     db_items = []
@@ -23,17 +58,16 @@ def create_order(
         if not db_product:
             raise HTTPException(
                 status_code=400,
-                detail=f"Product not found: {item.product_name}"
+                detail=f"Product not found: {item.product_name}",
             )
-            
+
         if db_product.stock < item.quantity:
             raise HTTPException(
                 status_code=400,
-                detail=f"Insufficient stock for product: {item.product_name}"
+                detail=f"Insufficient stock for product: {item.product_name}",
             )
 
         db_product.stock -= item.quantity
-
         real_price = db_product.price
         subtotal += real_price * item.quantity
 
@@ -41,7 +75,7 @@ def create_order(
             models.OrderItem(
                 product_name=item.product_name,
                 quantity=item.quantity,
-                price=real_price
+                price=real_price,
             )
         )
 
@@ -58,40 +92,102 @@ def create_order(
         coupon_code = order_data.coupon.strip().upper()
 
         if coupon_code not in valid_coupons:
-            raise HTTPException(
-                status_code=400,
-                detail="Invalid coupon code"
-            )
+            raise HTTPException(status_code=400, detail="Invalid coupon code")
 
-        discount = round(
-            subtotal * valid_coupons[coupon_code] / 100,
-            2
-        )
-
+        discount = round(subtotal * valid_coupons[coupon_code] / 100, 2)
 
     grand_total = max(0, subtotal + tax + shipping - discount)
 
     new_order = models.Order(
+        user_id=current_user.id,          # link to authenticated user
         full_name=order_data.fullName,
-        email=current_user.email,  # Force email to match authenticated user
+        email=current_user.email,          # force email to match authenticated user
         address=order_data.address,
         city=order_data.city,
         zip_code=order_data.zip,
         total_amount=grand_total,
-        status="CONFIRMED"
+        status="CONFIRMED",
     )
 
     db.add(new_order)
-    db.commit()
-    db.refresh(new_order)
+    db.flush()  # flush so new_order.id is available before committing
+
+    # Persist initial status event in audit trail
+    initial_event = models.OrderStatusHistory(
+        order_id=new_order.id,
+        status="CONFIRMED",
+        changed_at=datetime.now(timezone.utc),
+        note="Order placed and confirmed.",
+    )
+    db.add(initial_event)
 
     for db_item in db_items:
         db_item.order_id = new_order.id
         db.add(db_item)
 
     db.commit()
+    db.refresh(new_order)
 
     return {
         "message": "Order created successfully",
-        "order_id": new_order.id
+        "order_id": new_order.id,
     }
+
+
+@router.get("/my-orders", response_model=schemas.PaginatedOrdersResponse)
+def list_my_orders(
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+    page: int = Query(default=1, ge=1, description="Page number (1-indexed)"),
+    page_size: int = Query(default=10, ge=1, le=50, description="Items per page"),
+    status: str | None = Query(default=None, description="Filter by status (e.g. CONFIRMED, SHIPPED)"),
+):
+    """Return a paginated, optionally filtered list of the current user's orders."""
+    query = (
+        db.query(models.Order)
+        .options(
+            joinedload(models.Order.items),
+            joinedload(models.Order.status_history),
+        )
+        .filter(models.Order.user_id == current_user.id)
+    )
+
+    if status:
+        query = query.filter(models.Order.status == status.upper())
+
+    total = query.count()
+    offset = (page - 1) * page_size
+    orders = query.order_by(models.Order.created_at.desc()).offset(offset).limit(page_size).all()
+
+    return {
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+        "orders": [_serialize_order(o) for o in orders],
+    }
+
+
+@router.get("/{order_id}", response_model=schemas.OrderOut)
+def get_order_detail(
+    order_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    """Retrieve full detail for a single order that belongs to the authenticated user."""
+    order = (
+        db.query(models.Order)
+        .options(
+            joinedload(models.Order.items),
+            joinedload(models.Order.status_history),
+        )
+        .filter(
+            models.Order.id == order_id,
+            models.Order.user_id == current_user.id,
+        )
+        .first()
+    )
+
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found.")
+
+    return _serialize_order(order)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -32,26 +32,39 @@ class Interaction(Base):
 
 class User(Base):
     __tablename__ = "users"
- 
+
     id = Column(Integer, primary_key=True, index=True)
     username = Column(String, unique=True, index=True, nullable=False)
     email = Column(String, unique=True, index=True, nullable=False)
     hashed_password = Column(String, nullable=False)
-    role            = Column(String, default="USER", nullable=False) 
+    role = Column(String, default="USER", nullable=False)
     is_active = Column(Boolean, default=True)
-    created_at = Column(DateTime,  default=lambda: datetime.now(timezone.utc))
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+
+    orders = relationship("Order", back_populates="user")
 
 class Order(Base):
     __tablename__ = "orders"
     id = Column(Integer, primary_key=True, index=True)
+    # Nullable FK so legacy rows created before auth was wired up are not orphaned
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True, index=True)
     full_name = Column(String, nullable=False)
     email = Column(String, nullable=False)
     address = Column(String, nullable=False)
     city = Column(String, nullable=False)
     zip_code = Column(String, nullable=False)
     total_amount = Column(Float, nullable=False)
-    status = Column(String, default="PENDING")
-    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    status = Column(String, default="PENDING", index=True)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), index=True)
+
+    user = relationship("User", back_populates="orders")
+    items = relationship("OrderItem", back_populates="order", cascade="all, delete-orphan")
+    status_history = relationship(
+        "OrderStatusHistory",
+        back_populates="order",
+        cascade="all, delete-orphan",
+        order_by="OrderStatusHistory.changed_at",
+    )
 
 class OrderItem(Base):
     __tablename__ = "order_items"
@@ -59,9 +72,32 @@ class OrderItem(Base):
     order_id = Column(
         Integer,
         ForeignKey("orders.id"),
-        nullable=False
+        nullable=False,
+        index=True,
     )
     product_name = Column(String, nullable=False)
     quantity = Column(Integer, nullable=False)
     price = Column(Float, nullable=False)
-    order = relationship("Order")
+    order = relationship("Order", back_populates="items")
+
+
+class OrderStatusHistory(Base):
+    """Immutable audit trail of every status change for an order."""
+    __tablename__ = "order_status_history"
+
+    id = Column(Integer, primary_key=True, index=True)
+    order_id = Column(
+        Integer,
+        ForeignKey("orders.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    status = Column(String(50), nullable=False)
+    changed_at = Column(
+        DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+    note = Column(String, nullable=True)
+
+    order = relationship("Order", back_populates="status_history")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -113,3 +113,50 @@ class OrderCreate(BaseModel):
     zip: str
     items: list[OrderItemCreate]
     coupon: Optional[str] = None
+
+
+# -- Order History Response Schemas --
+
+class OrderStatusHistoryOut(BaseModel):
+    id: int
+    status: str
+    changed_at: str
+    note: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
+class OrderItemOut(BaseModel):
+    id: int
+    product_name: str
+    quantity: int
+    price: float
+
+    class Config:
+        from_attributes = True
+
+
+class OrderOut(BaseModel):
+    """Full representation of a single order, including its line items and audit trail."""
+    id: int
+    full_name: str
+    email: str
+    address: str
+    city: str
+    zip_code: str
+    total_amount: float
+    status: str
+    created_at: str
+    items: list[OrderItemOut] = []
+    status_history: list[OrderStatusHistoryOut] = []
+
+    class Config:
+        from_attributes = True
+
+
+class PaginatedOrdersResponse(BaseModel):
+    total: int
+    page: int
+    page_size: int
+    orders: list[OrderOut]

--- a/backend/tests/test_orders.py
+++ b/backend/tests/test_orders.py
@@ -1,0 +1,202 @@
+"""
+Tests for order history and order detail endpoints.
+
+Covers:
+  - POST /api/orders/  — order creation stores user_id and writes initial status event
+  - GET  /api/orders/my-orders — paginated list returns only the authed user's orders
+  - GET  /api/orders/{id} — returns full detail including items and status_history
+  - GET  /api/orders/{id} — 404 when order belongs to a different user
+  - GET  /api/orders/my-orders?status=CONFIRMED — status filter works correctly
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _register_and_login(client: TestClient, suffix: str) -> str:
+    """Register a new user and return a session cookie jar (via client)."""
+    client.post(
+        "/api/auth/register",
+        json={
+            "username": f"orderuser_{suffix}",
+            "email": f"orderuser_{suffix}@test.com",
+            "password": "Password1@",
+        },
+    )
+    resp = client.post(
+        "/api/auth/login",
+        json={
+            "email": f"orderuser_{suffix}@test.com",
+            "password": "Password1@",
+        },
+    )
+    assert resp.status_code == 200, f"Login failed: {resp.text}"
+    return resp.cookies.get("access_token", "")
+
+
+def _seed_product(client: TestClient) -> dict:
+    """Return an existing product from the catalog so order tests are self-contained."""
+    resp = client.get("/api/products/?limit=1")
+    assert resp.status_code == 200
+    products = resp.json()
+    if products:
+        return products[0]
+    pytest.skip("No products in test database — seed products first.")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestOrderCreation:
+    def test_create_order_authenticated(self, client: TestClient):
+        """Authenticated user can place an order and receives order_id."""
+        _register_and_login(client, "create")
+        product = _seed_product(client)
+
+        resp = client.post(
+            "/api/orders/",
+            json={
+                "fullName": "Test Buyer",
+                "email": "orderuser_create@test.com",
+                "address": "123 Main St",
+                "city": "Mumbai",
+                "zip": "400001",
+                "items": [{"product_name": product["name"], "quantity": 1}],
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert "order_id" in data
+        assert isinstance(data["order_id"], int)
+
+    def test_create_order_unauthenticated_rejected(self, client: TestClient):
+        """Unauthenticated requests to place an order must return 401."""
+        client.cookies.clear()
+        resp = client.post(
+            "/api/orders/",
+            json={
+                "fullName": "Ghost",
+                "email": "ghost@test.com",
+                "address": "Nowhere",
+                "city": "Nowhere",
+                "zip": "000000",
+                "items": [],
+            },
+        )
+        assert resp.status_code == 401
+
+
+class TestOrderHistory:
+    def test_list_my_orders_returns_paginated_response(self, client: TestClient):
+        """GET /api/orders/my-orders returns total, page, page_size and orders list."""
+        _register_and_login(client, "hist")
+        resp = client.get("/api/orders/my-orders")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert "total" in body
+        assert "page" in body
+        assert "page_size" in body
+        assert "orders" in body
+        assert isinstance(body["orders"], list)
+
+    def test_list_my_orders_does_not_expose_other_users_orders(self, client: TestClient):
+        """Orders of user A must not appear in user B's history."""
+        # User A places an order
+        _register_and_login(client, "userA")
+        product = _seed_product(client)
+        client.post(
+            "/api/orders/",
+            json={
+                "fullName": "User A",
+                "email": "orderuser_userA@test.com",
+                "address": "A Street",
+                "city": "Delhi",
+                "zip": "110001",
+                "items": [{"product_name": product["name"], "quantity": 1}],
+            },
+        )
+
+        # User B logs in and checks their history
+        _register_and_login(client, "userB")
+        resp = client.get("/api/orders/my-orders")
+        assert resp.status_code == 200
+        body = resp.json()
+        # User B should see zero orders (they just registered)
+        for order in body["orders"]:
+            assert order["email"] == "orderuser_userB@test.com"
+
+    def test_status_filter(self, client: TestClient):
+        """Status filter returns only orders matching the requested status."""
+        _register_and_login(client, "filter")
+        resp = client.get("/api/orders/my-orders?status=CONFIRMED")
+        assert resp.status_code == 200
+        body = resp.json()
+        for order in body["orders"]:
+            assert order["status"] == "CONFIRMED"
+
+    def test_pagination_params(self, client: TestClient):
+        """page and page_size query params are reflected in the response."""
+        _register_and_login(client, "page")
+        resp = client.get("/api/orders/my-orders?page=1&page_size=5")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["page"] == 1
+        assert body["page_size"] == 5
+
+
+class TestOrderDetail:
+    def test_order_detail_includes_items_and_history(self, client: TestClient):
+        """GET /api/orders/{id} returns items[] and status_history[]."""
+        _register_and_login(client, "detail")
+        product = _seed_product(client)
+        create_resp = client.post(
+            "/api/orders/",
+            json={
+                "fullName": "Detail User",
+                "email": "orderuser_detail@test.com",
+                "address": "Detail St",
+                "city": "Pune",
+                "zip": "411001",
+                "items": [{"product_name": product["name"], "quantity": 1}],
+            },
+        )
+        assert create_resp.status_code == 201
+        order_id = create_resp.json()["order_id"]
+
+        detail_resp = client.get(f"/api/orders/{order_id}")
+        assert detail_resp.status_code == 200
+        body = detail_resp.json()
+        assert body["id"] == order_id
+        assert isinstance(body["items"], list)
+        assert len(body["items"]) >= 1
+        assert isinstance(body["status_history"], list)
+        assert len(body["status_history"]) >= 1
+        assert body["status_history"][0]["status"] == "CONFIRMED"
+
+    def test_order_detail_cross_user_returns_404(self, client: TestClient):
+        """A user cannot fetch another user's order by ID — must get 404."""
+        # Owner places an order
+        _register_and_login(client, "owner")
+        product = _seed_product(client)
+        create_resp = client.post(
+            "/api/orders/",
+            json={
+                "fullName": "Owner",
+                "email": "orderuser_owner@test.com",
+                "address": "Owner Rd",
+                "city": "Chennai",
+                "zip": "600001",
+                "items": [{"product_name": product["name"], "quantity": 1}],
+            },
+        )
+        assert create_resp.status_code == 201
+        order_id = create_resp.json()["order_id"]
+
+        # Attacker tries to access owner's order
+        _register_and_login(client, "attacker")
+        resp = client.get(f"/api/orders/{order_id}")
+        assert resp.status_code == 404


### PR DESCRIPTION
Closes #2537 

### Summary
Implements a server-side order history query interface scoped to the currently authenticated user. Adds database relations, status log tables, and migrations to back the functionality.

### Changes Made
- **Models**: Updated `models.py` to link `Order` to `User` and created the `OrderStatusHistory` model.
- **Migrations**: Added Alembic version file `c1d2e3f4a5b6_add_user_id_to_orders.py`.
- **APIs**: Enhanced `api/orders.py` with paginated retrieval and order details routes.
- **Tests**: Created `tests/test_orders.py` verifying authentication checks and data isolation.