### PR TITLE
feat: implement server-side wishlist API with toggle, list, check endpoints and localStorage migration

### DIFF
--- a/backend/alembic/versions/d2e3f4a5b6c7_add_wishlist_items_table.py
+++ b/backend/alembic/versions/d2e3f4a5b6c7_add_wishlist_items_table.py
@@ -1,0 +1,62 @@
+"""Add server-side wishlist model and migration
+
+Revision ID: d2e3f4a5b6c7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-06-27 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd2e3f4a5b6c7'
+down_revision: Union[str, Sequence[str], None] = 'a1b2c3d4e5f6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create the wishlist_items table with a unique constraint preventing duplicates."""
+    op.create_table(
+        'wishlist_items',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('product_id', sa.Integer(), nullable=False),
+        sa.Column('added_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ['product_id'],
+            ['products.id'],
+            name='fk_wishlist_items_product_id',
+            ondelete='CASCADE',
+        ),
+        sa.ForeignKeyConstraint(
+            ['user_id'],
+            ['users.id'],
+            name='fk_wishlist_items_user_id',
+            ondelete='CASCADE',
+        ),
+        sa.PrimaryKeyConstraint('id'),
+        # Prevent a user from adding the same product twice
+        sa.UniqueConstraint('user_id', 'product_id', name='uq_wishlist_user_product'),
+    )
+    op.create_index(
+        'ix_wishlist_items_id',
+        'wishlist_items',
+        ['id'],
+        unique=False,
+    )
+    op.create_index(
+        'ix_wishlist_items_user_id',
+        'wishlist_items',
+        ['user_id'],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_wishlist_items_user_id', table_name='wishlist_items')
+    op.drop_index('ix_wishlist_items_id', table_name='wishlist_items')
+    op.drop_table('wishlist_items')

--- a/backend/app/api/wishlist.py
+++ b/backend/app/api/wishlist.py
@@ -1,0 +1,162 @@
+"""
+Wishlist API endpoints.
+
+All endpoints require an authenticated session (JWT cookie).
+
+Routes:
+  GET    /api/wishlist/          — return paginated wishlist for the current user
+  POST   /api/wishlist/{product_id} — toggle: add if absent, remove if already present
+  DELETE /api/wishlist/{product_id} — explicit remove (idempotent)
+  GET    /api/wishlist/check/{product_id} — check if a product is in the wishlist
+"""
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.exc import IntegrityError
+
+from .. import models
+from ..database import get_db
+from .auth import get_current_user
+
+router = APIRouter()
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _get_wishlist_item(
+    db: Session, user_id: int, product_id: int
+) -> models.WishlistItem | None:
+    return (
+        db.query(models.WishlistItem)
+        .filter(
+            models.WishlistItem.user_id == user_id,
+            models.WishlistItem.product_id == product_id,
+        )
+        .first()
+    )
+
+
+def _serialize_item(item: models.WishlistItem) -> dict:
+    p = item.product
+    return {
+        "wishlist_item_id": item.id,
+        "added_at": item.added_at.isoformat() if item.added_at else "",
+        "product": {
+            "id": p.id,
+            "name": p.name,
+            "brand": p.brand,
+            "price": p.price,
+            "img": p.img,
+            "rating": p.rating,
+            "category": p.category,
+            "subcategory": p.subcategory,
+            "color": p.color,
+            "style": p.style,
+            "stock": p.stock,
+        },
+    }
+
+
+# ── Endpoints ─────────────────────────────────────────────────────────────────
+
+@router.get("/")
+def list_wishlist(
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+) -> dict:
+    """Return a paginated list of products saved in the authenticated user's wishlist."""
+    query = (
+        db.query(models.WishlistItem)
+        .options(joinedload(models.WishlistItem.product))
+        .filter(models.WishlistItem.user_id == current_user.id)
+        .order_by(models.WishlistItem.added_at.desc())
+    )
+    total = query.count()
+    items = query.offset((page - 1) * page_size).limit(page_size).all()
+
+    return {
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+        "items": [_serialize_item(i) for i in items],
+    }
+
+
+@router.post("/{product_id}")
+def toggle_wishlist(
+    product_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> dict:
+    """
+    Toggle a product in the user's wishlist.
+    - If the product is NOT in the wishlist, it is added.
+    - If the product IS already in the wishlist, it is removed.
+
+    Returns the new state so the frontend can update the UI without a
+    separate check call.
+    """
+    product = db.query(models.Product).filter(models.Product.id == product_id).first()
+    if not product:
+        raise HTTPException(status_code=404, detail="Product not found.")
+
+    existing = _get_wishlist_item(db, current_user.id, product_id)
+
+    if existing:
+        db.delete(existing)
+        db.commit()
+        return {"action": "removed", "product_id": product_id, "in_wishlist": False}
+
+    new_item = models.WishlistItem(
+        user_id=current_user.id,
+        product_id=product_id,
+        added_at=datetime.now(timezone.utc),
+    )
+    try:
+        db.add(new_item)
+        db.commit()
+        db.refresh(new_item)
+    except IntegrityError:
+        # Race condition: another request already inserted the same row
+        db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail="Product is already in your wishlist.",
+        )
+
+    return {"action": "added", "product_id": product_id, "in_wishlist": True}
+
+
+@router.delete("/{product_id}")
+def remove_from_wishlist(
+    product_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> dict:
+    """
+    Explicitly remove a product from the wishlist.
+    Idempotent — returns success even if the item was not present.
+    """
+    item = _get_wishlist_item(db, current_user.id, product_id)
+    if item:
+        db.delete(item)
+        db.commit()
+    return {"message": "Product removed from wishlist.", "product_id": product_id}
+
+
+@router.get("/check/{product_id}")
+def check_wishlist(
+    product_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> dict:
+    """
+    Lightweight endpoint to check whether a specific product is in the
+    authenticated user's wishlist — used by product detail and listing pages
+    to set the heart icon state without fetching the entire wishlist.
+    """
+    item = _get_wishlist_item(db, current_user.id, product_id)
+    return {"product_id": product_id, "in_wishlist": item is not None}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -51,8 +51,9 @@ def root():
     return {"message": "Cara AI Outfit Recommendation API is running."}
 
 # Include routers here later
-from .api import recommendation, products, auth, orders
+from .api import recommendation, products, auth, orders, wishlist
 app.include_router(recommendation.router, prefix="/api/outfit", tags=["outfit"])
 app.include_router(products.router, prefix="/api/products", tags=["products"])
-app.include_router(auth.router,prefix="/api/auth",tags=["auth"])
+app.include_router(auth.router, prefix="/api/auth", tags=["auth"])
 app.include_router(orders.router, prefix="/api/orders", tags=["orders"])
+app.include_router(wishlist.router, prefix="/api/wishlist", tags=["wishlist"])

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -65,3 +65,36 @@ class OrderItem(Base):
     quantity = Column(Integer, nullable=False)
     price = Column(Float, nullable=False)
     order = relationship("Order")
+
+
+class WishlistItem(Base):
+    """Server-side wishlist entry scoped to an authenticated user."""
+    __tablename__ = "wishlist_items"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    product_id = Column(
+        Integer,
+        ForeignKey("products.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    added_at = Column(
+        DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    user = relationship("User")
+    product = relationship("Product")
+
+    # Prevent a user from adding the same product to their wishlist twice
+    __table_args__ = (
+        __import__("sqlalchemy").UniqueConstraint(
+            "user_id", "product_id", name="uq_wishlist_user_product"
+        ),
+    )

--- a/backend/tests/test_wishlist.py
+++ b/backend/tests/test_wishlist.py
@@ -1,0 +1,162 @@
+"""
+Tests for the server-side wishlist API.
+
+Covers:
+  - GET  /api/wishlist/         — returns paginated list for authenticated user
+  - POST /api/wishlist/{id}     — adds product when not in wishlist
+  - POST /api/wishlist/{id}     — removes product when already in wishlist (toggle)
+  - DELETE /api/wishlist/{id}   — removes product idempotently
+  - GET  /api/wishlist/check/{id} — returns correct in_wishlist boolean
+  - All endpoints require authentication (401 when unauthenticated)
+  - Products of user A are not visible to user B
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _auth(client: TestClient, suffix: str) -> None:
+    """Register and log in a fresh user; session cookie is set automatically."""
+    client.post(
+        "/api/auth/register",
+        json={
+            "username": f"wishuser_{suffix}",
+            "email": f"wishuser_{suffix}@test.com",
+            "password": "Password1@",
+        },
+    )
+    client.post(
+        "/api/auth/login",
+        json={"email": f"wishuser_{suffix}@test.com", "password": "Password1@"},
+    )
+
+
+def _first_product_id(client: TestClient) -> int:
+    resp = client.get("/api/products/?limit=1")
+    products = resp.json()
+    if not products:
+        pytest.skip("No products seeded in test DB.")
+    return products[0]["id"]
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+class TestWishlistAuth:
+    def test_list_requires_auth(self, client: TestClient):
+        client.cookies.clear()
+        resp = client.get("/api/wishlist/")
+        assert resp.status_code == 401
+
+    def test_toggle_requires_auth(self, client: TestClient):
+        client.cookies.clear()
+        resp = client.post("/api/wishlist/1")
+        assert resp.status_code == 401
+
+    def test_delete_requires_auth(self, client: TestClient):
+        client.cookies.clear()
+        resp = client.delete("/api/wishlist/1")
+        assert resp.status_code == 401
+
+    def test_check_requires_auth(self, client: TestClient):
+        client.cookies.clear()
+        resp = client.get("/api/wishlist/check/1")
+        assert resp.status_code == 401
+
+
+class TestWishlistCRUD:
+    def test_empty_wishlist_on_fresh_account(self, client: TestClient):
+        _auth(client, "empty")
+        resp = client.get("/api/wishlist/")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 0
+        assert body["items"] == []
+
+    def test_toggle_adds_product(self, client: TestClient):
+        _auth(client, "add")
+        pid = _first_product_id(client)
+        resp = client.post(f"/api/wishlist/{pid}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["action"] == "added"
+        assert body["in_wishlist"] is True
+        assert body["product_id"] == pid
+
+    def test_toggle_removes_product_on_second_call(self, client: TestClient):
+        _auth(client, "toggle")
+        pid = _first_product_id(client)
+        client.post(f"/api/wishlist/{pid}")          # add
+        resp = client.post(f"/api/wishlist/{pid}")   # remove
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["action"] == "removed"
+        assert body["in_wishlist"] is False
+
+    def test_wishlist_list_after_add(self, client: TestClient):
+        _auth(client, "list")
+        pid = _first_product_id(client)
+        client.post(f"/api/wishlist/{pid}")
+        resp = client.get("/api/wishlist/")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] >= 1
+        product_ids = [i["product"]["id"] for i in body["items"]]
+        assert pid in product_ids
+
+    def test_delete_removes_item(self, client: TestClient):
+        _auth(client, "delete")
+        pid = _first_product_id(client)
+        client.post(f"/api/wishlist/{pid}")
+        del_resp = client.delete(f"/api/wishlist/{pid}")
+        assert del_resp.status_code == 200
+        # Wishlist should now be empty
+        list_resp = client.get("/api/wishlist/")
+        assert list_resp.json()["total"] == 0
+
+    def test_delete_is_idempotent(self, client: TestClient):
+        """Deleting a product not in the wishlist should still return 200."""
+        _auth(client, "idem")
+        pid = _first_product_id(client)
+        resp = client.delete(f"/api/wishlist/{pid}")
+        assert resp.status_code == 200
+
+    def test_check_returns_false_when_not_in_wishlist(self, client: TestClient):
+        _auth(client, "check_false")
+        pid = _first_product_id(client)
+        resp = client.get(f"/api/wishlist/check/{pid}")
+        assert resp.status_code == 200
+        assert resp.json()["in_wishlist"] is False
+
+    def test_check_returns_true_after_add(self, client: TestClient):
+        _auth(client, "check_true")
+        pid = _first_product_id(client)
+        client.post(f"/api/wishlist/{pid}")
+        resp = client.get(f"/api/wishlist/check/{pid}")
+        assert resp.status_code == 200
+        assert resp.json()["in_wishlist"] is True
+
+    def test_nonexistent_product_returns_404(self, client: TestClient):
+        _auth(client, "notfound")
+        resp = client.post("/api/wishlist/999999")
+        assert resp.status_code == 404
+
+    def test_pagination_params_respected(self, client: TestClient):
+        _auth(client, "paginate")
+        resp = client.get("/api/wishlist/?page=1&page_size=5")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["page"] == 1
+        assert body["page_size"] == 5
+
+    def test_user_isolation(self, client: TestClient):
+        """User A's wishlist should not be visible to User B."""
+        _auth(client, "isolate_a")
+        pid = _first_product_id(client)
+        client.post(f"/api/wishlist/{pid}")
+
+        _auth(client, "isolate_b")
+        resp = client.get("/api/wishlist/")
+        body = resp.json()
+        # User B's wishlist should be empty
+        assert body["total"] == 0

--- a/js/wishlist-sync.js
+++ b/js/wishlist-sync.js
@@ -1,0 +1,215 @@
+/**
+ * wishlist-sync.js
+ * Synchronises the Cara wishlist between localStorage (for unauthenticated users)
+ * and the server-side API (for authenticated users with a session cookie).
+ *
+ * Behaviour:
+ *  - On page load, checks if the user is logged in via /api/auth/me.
+ *  - If authenticated:
+ *      1. Fetches server wishlist and merges any pending localStorage items.
+ *      2. Replaces all heart / save-button UI with server state.
+ *      3. Clears the localStorage wishlist after migration.
+ *  - If not authenticated:
+ *      - Falls back to localStorage wishlist (existing behaviour, untouched).
+ *
+ * Integration:
+ *  1. Include this script in wishlist.html and singleProduct.html after the DOM.
+ *  2. Call `WishlistSync.toggle(productId)` from product buttons instead of
+ *     directly writing to localStorage.
+ *  3. Call `WishlistSync.isInWishlist(productId)` to read current state.
+ */
+
+const WishlistSync = (() => {
+  'use strict';
+
+  const STORAGE_KEY = 'cara_wishlist';
+  const API_BASE = '/api/wishlist';
+  let _authenticated = null;   // null = unknown, true/false after check
+  let _serverState = new Set(); // product ids in server wishlist
+
+  // ── Private helpers ────────────────────────────────────────────────────────
+
+  function _localGet() {
+    try {
+      return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+    } catch {
+      return [];
+    }
+  }
+
+  function _localSet(ids) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+  }
+
+  function _localAdd(id) {
+    const ids = _localGet();
+    if (!ids.includes(id)) {
+      ids.push(id);
+      _localSet(ids);
+    }
+  }
+
+  function _localRemove(id) {
+    _localSet(_localGet().filter((i) => i !== id));
+  }
+
+  function _apiFetch(path, method = 'GET') {
+    return fetch(`${API_BASE}${path}`, {
+      method,
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // ── Check authentication ────────────────────────────────────────────────────
+
+  async function _checkAuth() {
+    if (_authenticated !== null) return _authenticated;
+    try {
+      const resp = await fetch('/api/auth/me', { credentials: 'include' });
+      _authenticated = resp.ok;
+    } catch {
+      _authenticated = false;
+    }
+    return _authenticated;
+  }
+
+  // ── Load server wishlist into _serverState ────────────────────────────────
+
+  async function _loadServerState() {
+    try {
+      let page = 1;
+      const pageSize = 100;
+      while (true) {
+        const resp = await _apiFetch(`/?page=${page}&page_size=${pageSize}`);
+        if (!resp.ok) break;
+        const body = await resp.json();
+        body.items.forEach((item) => _serverState.add(item.product.id));
+        if (page * pageSize >= body.total) break;
+        page++;
+      }
+    } catch (err) {
+      console.warn('[WishlistSync] Failed to load server state:', err);
+    }
+  }
+
+  // ── Migrate localStorage items to server ───────────────────────────────────
+
+  async function _migratePendingItems() {
+    const pendingIds = _localGet();
+    if (pendingIds.length === 0) return;
+
+    await Promise.allSettled(
+      pendingIds.map((id) =>
+        _apiFetch(`/${id}`, 'POST').then(async (resp) => {
+          if (resp.ok) {
+            const body = await resp.json();
+            if (body.in_wishlist) _serverState.add(id);
+          }
+        }),
+      ),
+    );
+
+    // Clear localStorage wishlist after successful migration
+    _localSet([]);
+    console.info(`[WishlistSync] Migrated ${pendingIds.length} pending item(s) to server.`);
+  }
+
+  // ── Update all heart/save buttons on the current page ─────────────────────
+
+  function _refreshUI() {
+    document.querySelectorAll('[data-wishlist-id]').forEach((btn) => {
+      const id = parseInt(btn.dataset.wishlistId, 10);
+      const active = isInWishlist(id);
+      btn.classList.toggle('wishlisted', active);
+      btn.setAttribute('aria-pressed', String(active));
+      btn.setAttribute('aria-label', active ? 'Remove from wishlist' : 'Add to wishlist');
+    });
+  }
+
+  // ── Public API ─────────────────────────────────────────────────────────────
+
+  /**
+   * Initialise WishlistSync.
+   * Must be called once on DOMContentLoaded.
+   */
+  async function init() {
+    const authed = await _checkAuth();
+    if (authed) {
+      await _loadServerState();
+      await _migratePendingItems();
+    }
+    _refreshUI();
+  }
+
+  /**
+   * Toggle a product in the wishlist.
+   * @param {number} productId
+   * @returns {Promise<boolean>} New in_wishlist state.
+   */
+  async function toggle(productId) {
+    const authed = await _checkAuth();
+
+    if (!authed) {
+      // Unauthenticated: operate on localStorage
+      const ids = _localGet();
+      const idx = ids.indexOf(productId);
+      if (idx === -1) {
+        _localAdd(productId);
+        _refreshUI();
+        return true;
+      } else {
+        _localRemove(productId);
+        _refreshUI();
+        return false;
+      }
+    }
+
+    // Authenticated: call server toggle endpoint
+    try {
+      const resp = await _apiFetch(`/${productId}`, 'POST');
+      if (!resp.ok) {
+        throw new Error(`Wishlist toggle failed: ${resp.status}`);
+      }
+      const body = await resp.json();
+      if (body.in_wishlist) {
+        _serverState.add(productId);
+      } else {
+        _serverState.delete(productId);
+      }
+      _refreshUI();
+      return body.in_wishlist;
+    } catch (err) {
+      console.error('[WishlistSync] Toggle error:', err);
+      throw err;
+    }
+  }
+
+  /**
+   * Check whether a product is currently in the wishlist.
+   * Synchronous — use after init() has resolved.
+   * @param {number} productId
+   * @returns {boolean}
+   */
+  function isInWishlist(productId) {
+    if (_authenticated) {
+      return _serverState.has(productId);
+    }
+    return _localGet().includes(productId);
+  }
+
+  /**
+   * Return the total number of items in the wishlist.
+   * @returns {number}
+   */
+  function count() {
+    if (_authenticated) return _serverState.size;
+    return _localGet().length;
+  }
+
+  // Expose as module
+  return { init, toggle, isInWishlist, count };
+})();
+
+// Auto-initialise on DOMContentLoaded
+document.addEventListener('DOMContentLoaded', () => WishlistSync.init());


### PR DESCRIPTION
Closes #2541 

### Summary
Implements a full wishlist REST API for authenticated users. Anonymous wishlists stored in localStorage are automatically migrated and synchronized on login.

### Changes Made
- **Models**: Added `WishlistItem` DB schema and model relations in `models.py`.
- **Migrations**: Created Alembic migration script `d2e3f4a5b6c7_add_wishlist_items_table.py`.
- **APIs**: Implemented `/api/wishlist/` routes in `api/wishlist.py` and registered it in `main.py`.
- **Frontend**: Wrote `js/wishlist-sync.js` to bridge localStorage and server state.
- **Tests**: Created `tests/test_wishlist.py` verifying isolation, toggle logic, and pagination.
