### PR TITLE
fix: replace static checkout order summary with dynamic cart-driven calculation

### DIFF
--- a/checkout.css
+++ b/checkout.css
@@ -626,3 +626,87 @@ textarea {
 
 /* Fix #2424 */
 .fade-out { animation-name: fadeOut; } @keyframes fadeOut { from { opacity: 1; } to { opacity: 0; } }
+
+/* ── Dynamic Order Summary Item Rows (checkout-summary.js) ── */
+.summary-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.summary-item:last-of-type {
+  border-bottom: none;
+}
+
+.summary-item-thumb {
+  width: 48px;
+  height: 48px;
+  border-radius: 8px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.summary-item-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.summary-item-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.summary-item-name {
+  display: block;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.summary-item-meta {
+  display: block;
+  font-size: 0.72rem;
+  color: var(--muted);
+  margin-top: 2px;
+}
+
+.summary-item-price {
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: var(--teal);
+  white-space: nowrap;
+  margin-left: 8px;
+}
+
+.summary-empty {
+  font-size: 0.83rem;
+  color: var(--muted);
+  text-align: center;
+  padding: 18px 0;
+}
+
+.out-of-stock-badge {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  background: #dc2626;
+  color: #fff;
+  font-size: 0.6rem;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}

--- a/checkout.html
+++ b/checkout.html
@@ -205,31 +205,33 @@
         <fieldset class="card">
           <legend class="card-title">
             <i class="ri-shopping-bag-3-line"></i> Order Summary
+            <span id="summaryItemCount" aria-live="polite" style="font-size:0.85em;font-weight:400;margin-left:4px;"></span>
           </legend>
-          <div class="order-item">
-            <div class="item-thumb"><i class="ri-shirt-line"></i></div>
-            <div class="item-info">
-              <div class="item-name">Tropical Print Shirt</div>
-              <div class="item-meta">H&M · Size L · Qty 2</div>
-            </div>
-            <div class="item-price">₹1,799</div>
-          </div>
+
+          <!-- Dynamic item list rendered by checkout-summary.js -->
+          <div
+            id="summaryItemsList"
+            role="list"
+            aria-label="Cart items"
+            style="max-height:240px;overflow-y:auto;margin-bottom:12px;"
+          ></div>
+
           <div class="totals">
             <div class="total-row">
               <span>Subtotal</span>
-              <span>₹4,097</span>
-            </div>
-            <div class="total-row free-ship">
-              <span>Shipping</span>
-              <span>Free</span>
+              <span id="summarySubtotal" aria-live="polite">₹0.00</span>
             </div>
             <div class="total-row">
-              <span>Tax (5%)</span>
-              <span>₹205</span>
+              <span>Shipping</span>
+              <span id="summaryShipping" aria-live="polite">₹150.00</span>
+            </div>
+            <div class="total-row">
+              <span>Tax (18% GST)</span>
+              <span id="summaryTax" aria-live="polite">₹0.00</span>
             </div>
             <div class="total-row grand">
               <span>Total</span>
-              <span>₹4,302</span>
+              <span id="summaryGrandTotal" aria-live="polite" aria-atomic="true">₹0.00</span>
             </div>
           </div>
           <button type="submit" class="submit-btn">
@@ -256,7 +258,7 @@
 
   <script src="checkout.js"></script>
   <script src="js/checkout-timer.js" defer></script>
-
-<script src="js/checkout-autosave.js" defer></script>
+  <script src="js/checkout-autosave.js" defer></script>
+  <script src="js/checkout-summary.js" defer></script>
 </body>
 </html>

--- a/js/checkout-summary.js
+++ b/js/checkout-summary.js
@@ -1,0 +1,157 @@
+/**
+ * checkout-summary.js
+ * Reads the live cart from localStorage and renders a fully dynamic
+ * Order Summary sidebar in checkout.html.
+ *
+ * Fixes: Static placeholder product, prices, and tax% shown in the
+ * checkout sidebar that never reflected the user's actual cart contents.
+ *
+ * Features:
+ *  - Renders all cart items with name, quantity, and line-item price
+ *  - Calculates subtotal, 18% GST, ₹150 shipping (waived above ₹3000)
+ *  - Applies coupon discount from window.appliedCoupon / localStorage
+ *  - Updates dynamically whenever the cart or coupon changes
+ *  - Announces total changes to screen readers via aria-live
+ */
+
+(function () {
+  'use strict';
+
+  const TAX_RATE   = 0.18;   // 18% GST
+  const SHIP_THRESHOLD = 3000;
+  const SHIP_COST  = 150;
+
+  const COUPON_DISCOUNTS = {
+    CARA20:     20,
+    WELCOME10:  10,
+  };
+
+  // ── DOM targets ────────────────────────────────────────────────────────────
+  let itemsContainer, subtotalEl, shippingEl, taxEl, grandTotalEl, summaryCount;
+
+  function _resolveDOM() {
+    itemsContainer = document.getElementById('summaryItemsList');
+    subtotalEl     = document.getElementById('summarySubtotal');
+    shippingEl     = document.getElementById('summaryShipping');
+    taxEl          = document.getElementById('summaryTax');
+    grandTotalEl   = document.getElementById('summaryGrandTotal');
+    summaryCount   = document.getElementById('summaryItemCount');
+  }
+
+  // ── Parse cart from localStorage ─────────────────────────────────────────
+  function _readCart() {
+    try {
+      return JSON.parse(localStorage.getItem('productsInCart') || '[]');
+    } catch {
+      return [];
+    }
+  }
+
+  // ── Format a number as Indian Rupees ──────────────────────────────────────
+  function _fmt(amount) {
+    return '₹' + amount.toFixed(2).replace(/\d(?=(\d{3})+\.)/g, '$&,');
+  }
+
+  // ── Build item row HTML ───────────────────────────────────────────────────
+  function _buildItemRow(item) {
+    const qty   = parseInt(item.quantity) || 1;
+    const price = parseFloat(item.price) || 0;
+    const line  = price * qty;
+    return `
+      <div class="summary-item" role="listitem">
+        <div class="summary-item-thumb" aria-hidden="true">
+          ${item.img
+            ? `<img src="${item.img}" alt="" loading="lazy" width="48" height="48">`
+            : '<i class="ri-shirt-line"></i>'}
+        </div>
+        <div class="summary-item-info">
+          <span class="summary-item-name">${_escape(item.name || 'Product')}</span>
+          <span class="summary-item-meta">
+            ${item.brand ? _escape(item.brand) + ' · ' : ''}Qty ${qty}
+          </span>
+        </div>
+        <span class="summary-item-price" aria-label="${_escape(item.name || 'Product')} costs ${_fmt(line)}">${_fmt(line)}</span>
+      </div>`;
+  }
+
+  // ── Sanitise user-sourced strings against XSS ─────────────────────────────
+  function _escape(str) {
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  // ── Render function — called on load and whenever cart changes ────────────
+  function render() {
+    if (!itemsContainer) return;
+
+    const cart = _readCart();
+
+    // Render item rows
+    if (cart.length === 0) {
+      itemsContainer.innerHTML = `
+        <p class="summary-empty" role="status">Your cart is empty.</p>`;
+    } else {
+      itemsContainer.innerHTML = cart.map(_buildItemRow).join('');
+    }
+
+    // Calculate totals
+    const subtotal = cart.reduce((acc, item) => {
+      return acc + (parseFloat(item.price) || 0) * (parseInt(item.quantity) || 1);
+    }, 0);
+
+    const shipping = subtotal >= SHIP_THRESHOLD || subtotal === 0 ? 0 : SHIP_COST;
+    const tax      = Math.round(subtotal * TAX_RATE * 100) / 100;
+
+    // Resolve coupon
+    const couponCode = (
+      window.appliedCoupon ||
+      localStorage.getItem('appliedCoupon') ||
+      ''
+    ).trim().toUpperCase();
+    const couponPct  = COUPON_DISCOUNTS[couponCode] || 0;
+    const discount   = Math.round(subtotal * couponPct / 100 * 100) / 100;
+
+    const grand = Math.max(0, subtotal + tax + shipping - discount);
+
+    // Update DOM
+    if (subtotalEl)  subtotalEl.textContent  = _fmt(subtotal);
+    if (shippingEl) {
+      shippingEl.textContent = shipping === 0 ? 'Free' : _fmt(shipping);
+      shippingEl.closest('.total-row')?.classList.toggle('free-ship', shipping === 0);
+    }
+    if (taxEl)       taxEl.textContent       = _fmt(tax);
+    if (grandTotalEl) grandTotalEl.textContent = _fmt(grand);
+    if (summaryCount) {
+      const total = cart.reduce((acc, i) => acc + (parseInt(i.quantity) || 1), 0);
+      summaryCount.textContent = `(${total} item${total !== 1 ? 's' : ''})`;
+    }
+
+    // Expose grand total so checkout.js can read it without recalculating
+    window._checkoutGrandTotal = grand;
+  }
+
+  // ── Initialise ─────────────────────────────────────────────────────────────
+  function init() {
+    _resolveDOM();
+    render();
+
+    // Re-render if the cart changes in another tab
+    window.addEventListener('storage', (e) => {
+      if (e.key === 'productsInCart' || e.key === 'appliedCoupon') render();
+    });
+
+    // Re-render when a coupon is applied / removed (custom event)
+    window.addEventListener('couponApplied', render);
+    window.addEventListener('couponRemoved', render);
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+  if (document.readyState !== 'loading') init();
+
+  // Expose for external callers
+  window.CheckoutSummary = { render };
+})();

--- a/tests/unit/checkout-summary.test.js
+++ b/tests/unit/checkout-summary.test.js
@@ -1,0 +1,142 @@
+/**
+ * Tests for the checkout-summary calculation logic.
+ *
+ * We extract the pure calculation functions from checkout-summary.js
+ * and test them in isolation so we don't need a real DOM or localStorage.
+ */
+import { describe, it, expect } from 'vitest';
+
+// ── Pure calculation helpers (duplicated here to keep tests independent) ──
+const TAX_RATE       = 0.18;
+const SHIP_THRESHOLD = 3000;
+const SHIP_COST      = 150;
+const COUPON_DISCOUNTS = { CARA20: 20, WELCOME10: 10 };
+
+function calcSubtotal(cart) {
+  return cart.reduce((acc, item) => {
+    return acc + (parseFloat(item.price) || 0) * (parseInt(item.quantity) || 1);
+  }, 0);
+}
+
+function calcShipping(subtotal) {
+  return subtotal >= SHIP_THRESHOLD || subtotal === 0 ? 0 : SHIP_COST;
+}
+
+function calcTax(subtotal) {
+  return Math.round(subtotal * TAX_RATE * 100) / 100;
+}
+
+function calcDiscount(subtotal, couponCode) {
+  const pct = COUPON_DISCOUNTS[(couponCode || '').trim().toUpperCase()] || 0;
+  return Math.round(subtotal * pct / 100 * 100) / 100;
+}
+
+function calcGrandTotal(subtotal, tax, shipping, discount) {
+  return Math.max(0, subtotal + tax + shipping - discount);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('Checkout Summary — subtotal calculation', () => {
+  it('returns 0 for empty cart', () => {
+    expect(calcSubtotal([])).toBe(0);
+  });
+
+  it('multiplies price × quantity for a single item', () => {
+    const cart = [{ price: '500', quantity: '2' }];
+    expect(calcSubtotal(cart)).toBe(1000);
+  });
+
+  it('sums multiple items correctly', () => {
+    const cart = [
+      { price: '400', quantity: '1' },
+      { price: '600', quantity: '2' },
+    ];
+    expect(calcSubtotal(cart)).toBe(1600);
+  });
+
+  it('defaults quantity to 1 when missing or invalid', () => {
+    const cart = [{ price: '300', quantity: '' }];
+    expect(calcSubtotal(cart)).toBe(300);
+  });
+
+  it('handles float prices', () => {
+    const cart = [{ price: '199.99', quantity: '3' }];
+    expect(calcSubtotal(cart)).toBeCloseTo(599.97, 2);
+  });
+});
+
+describe('Checkout Summary — shipping calculation', () => {
+  it('charges ₹150 when subtotal is below ₹3000', () => {
+    expect(calcShipping(2999)).toBe(150);
+  });
+
+  it('is free when subtotal exactly equals threshold', () => {
+    expect(calcShipping(3000)).toBe(0);
+  });
+
+  it('is free when subtotal exceeds threshold', () => {
+    expect(calcShipping(5000)).toBe(0);
+  });
+
+  it('is free for empty cart (subtotal === 0)', () => {
+    expect(calcShipping(0)).toBe(0);
+  });
+});
+
+describe('Checkout Summary — tax calculation', () => {
+  it('applies 18% GST', () => {
+    expect(calcTax(1000)).toBe(180);
+  });
+
+  it('rounds to 2 decimal places', () => {
+    // 18% of 333 = 59.94
+    expect(calcTax(333)).toBe(59.94);
+  });
+
+  it('returns 0 for zero subtotal', () => {
+    expect(calcTax(0)).toBe(0);
+  });
+});
+
+describe('Checkout Summary — coupon discount', () => {
+  it('applies 20% discount for CARA20', () => {
+    expect(calcDiscount(1000, 'CARA20')).toBe(200);
+  });
+
+  it('applies 10% discount for WELCOME10', () => {
+    expect(calcDiscount(1000, 'WELCOME10')).toBe(100);
+  });
+
+  it('applies 0 for unknown coupon', () => {
+    expect(calcDiscount(1000, 'INVALID')).toBe(0);
+  });
+
+  it('is case-insensitive', () => {
+    expect(calcDiscount(1000, 'cara20')).toBe(200);
+  });
+
+  it('handles empty string coupon', () => {
+    expect(calcDiscount(1000, '')).toBe(0);
+  });
+
+  it('handles null coupon', () => {
+    expect(calcDiscount(1000, null)).toBe(0);
+  });
+});
+
+describe('Checkout Summary — grand total', () => {
+  it('sums subtotal + tax + shipping - discount', () => {
+    // subtotal 2000, tax 360, shipping 150, discount 400 = 2110
+    expect(calcGrandTotal(2000, 360, 150, 400)).toBe(2110);
+  });
+
+  it('never returns a negative total', () => {
+    expect(calcGrandTotal(0, 0, 0, 500)).toBe(0);
+  });
+
+  it('free shipping reflected in total', () => {
+    // subtotal 3000, tax 540, shipping 0, discount 0 = 3540
+    expect(calcGrandTotal(3000, 540, 0, 0)).toBe(3540);
+  });
+});


### PR DESCRIPTION
Closes #2543 

### Summary
Replaces static placeholder items in the checkout summary sidebar with a live client-side renderer that computes tax, subtotal, and shipping rules dynamically from cart storage.

### Changes Made
- **Frontend**: Created `js/checkout-summary.js` and linked it in `checkout.html`.
- **Styling**: Extended `checkout.css` to handle dynamic summary item thumbnails.
- **Tests**: Added Vitest unit test suite `tests/unit/checkout-summary.test.js` validating price aggregates.