### PR TITLE
chore: overhaul GitHub issue templates and PR template with structured forms and acceptance criteria

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,35 +1,119 @@
-name: Bug Report Form
-description: File a structured bug report to help us improve Cara
-title: "[BUG]: "
-labels: ["bug"]
+---
+name: 🐛 Bug Report
+description: Report a bug or unexpected behavior in Cara
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+assignees: []
 body:
   - type: markdown
     attributes:
       value: |
-        Thank you for reporting a bug! Please fill out the form below.
+        ## Before You File
+        - Search [existing issues](https://github.com/janavipandole/Cara/issues) to avoid duplicates.
+        - For security vulnerabilities, please read [SECURITY.md](../SECURITY.md) instead.
+
+  - type: input
+    id: affected-page
+    attributes:
+      label: Affected Page / Feature
+      description: Which page or feature does this bug occur on?
+      placeholder: e.g. checkout.html – order summary sidebar
+    validations:
+      required: true
+
   - type: textarea
     id: description
     attributes:
       label: Bug Description
       description: A clear and concise description of what the bug is.
-      placeholder: Describe your issue here...
+      placeholder: When I ... the page shows / does ...
     validations:
       required: true
+
   - type: textarea
     id: steps
     attributes:
       label: Steps to Reproduce
-      description: Describe how to reproduce the bug.
+      description: Ordered steps to reliably reproduce the bug.
       placeholder: |
-        1. Go to '...'
-        2. Click on '....'
-        3. Scroll down to '....'
+        1. Open `shop.html`
+        2. Add a product to the cart
+        3. Navigate to `checkout.html`
+        4. Observe the order summary shows ₹0.00
     validations:
       required: true
-  - type: input
-    id: environment
+
+  - type: textarea
+    id: expected
     attributes:
-      label: Browser/OS Environment
-      placeholder: e.g., Chrome 120 on macOS Sonoma
+      label: Expected Behavior
+      description: What should happen instead?
     validations:
-      required: false
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happens? Include screenshots or console errors where possible.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: browser
+    attributes:
+      label: Browser(s)
+      description: Which browser(s) are affected?
+      multiple: true
+      options:
+        - Chrome (latest)
+        - Firefox (latest)
+        - Safari (latest)
+        - Edge (latest)
+        - Mobile Chrome
+        - Mobile Safari
+        - Other (describe in additional context)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: device
+    attributes:
+      label: Device Type
+      options:
+        - Desktop
+        - Tablet
+        - Mobile
+    validations:
+      required: true
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js Version (if applicable)
+      placeholder: e.g. v20.11.0
+
+  - type: textarea
+    id: console-errors
+    attributes:
+      label: Console Errors
+      description: Paste any browser console errors here.
+      render: shell
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or screen recordings that help explain the problem.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I searched existing issues and this is not a duplicate
+          required: true
+        - label: I have provided clear reproduction steps
+          required: true
+        - label: I am using the latest version of the codebase
+          required: false

--- a/.github/ISSUE_TEMPLATE/documentation_update.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_update.yml
@@ -1,0 +1,66 @@
+---
+name: 📚 Documentation Update
+description: Report missing, incorrect, or outdated documentation
+title: "[Docs]: "
+labels: ["documentation", "needs-triage"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Documentation Issues
+        Use this template to report gaps, inaccuracies, or improvement opportunities in any project documentation.
+
+  - type: input
+    id: doc-location
+    attributes:
+      label: Documentation Location
+      description: Which file or section needs updating?
+      placeholder: e.g. README.md — Getting Started section, CONTRIBUTING.md — Branch naming
+    validations:
+      required: true
+
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Type of Documentation Issue
+      options:
+        - Missing documentation
+        - Incorrect / outdated information
+        - Unclear or confusing wording
+        - Broken links
+        - Missing code examples
+        - Typo / grammar
+    validations:
+      required: true
+
+  - type: textarea
+    id: current-content
+    attributes:
+      label: Current Content (if applicable)
+      description: Quote the existing text that needs to be changed.
+      render: markdown
+
+  - type: textarea
+    id: suggested-change
+    attributes:
+      label: Suggested Change
+      description: What should the documentation say instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Why Is This Change Needed?
+      description: Explain the impact of the current documentation issue on contributors or users.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I searched existing issues and this is not a duplicate
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,100 @@
+---
+name: ✨ Feature Request
+description: Propose a new feature or significant enhancement for Cara
+title: "[Feature]: "
+labels: ["enhancement", "needs-triage"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Before You Request
+        - Check the [Roadmap](https://github.com/janavipandole/Cara#%EF%B8%8F-roadmap) — your idea may already be planned.
+        - Search [existing issues](https://github.com/janavipandole/Cara/issues) to avoid duplicates.
+
+  - type: input
+    id: feature-area
+    attributes:
+      label: Feature Area
+      description: Which part of the project does this relate to?
+      placeholder: e.g. checkout flow, product search, wishlist, backend API
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: |
+        What problem does this feature solve? Who is affected?
+        A clear problem statement helps maintainers evaluate the feature quickly.
+      placeholder: As a shopper, I cannot find products by colour, so I have to scroll through hundreds of items manually.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the feature you'd like and how it would work from the user's perspective.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Have you considered any alternative solutions or workarounds?
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Impact / Priority
+      description: How impactful do you believe this feature is?
+      options:
+        - Critical — blocks key user journeys
+        - High — significantly improves UX
+        - Medium — nice to have
+        - Low — minor quality-of-life improvement
+    validations:
+      required: true
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Estimated Scope
+      options:
+        - Frontend only
+        - Backend only
+        - Full-stack (frontend + backend)
+        - Developer tooling / CI
+        - Documentation
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: How will we know this feature is done? List specific, testable criteria.
+      placeholder: |
+        - [ ] Users can filter products by colour using a dropdown
+        - [ ] Filter state is preserved in the URL query string
+        - [ ] Filters work on mobile viewports
+        - [ ] No existing tests are broken
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Mockups, references to similar features in other sites, links, or any other helpful context.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I searched existing issues and this is not a duplicate
+          required: true
+        - label: I am willing to work on this feature myself (optional)
+          required: false

--- a/.github/ISSUE_TEMPLATE/performance_issue.yml
+++ b/.github/ISSUE_TEMPLATE/performance_issue.yml
@@ -1,0 +1,77 @@
+---
+name: ⚡ Performance Issue
+description: Report a performance degradation, slow page load, or memory leak in Cara
+title: "[Performance]: "
+labels: ["performance", "needs-triage"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Performance Issues
+        Use this template to report pages that load slowly, animations that stutter, or memory leaks.
+
+  - type: input
+    id: affected-page
+    attributes:
+      label: Affected Page / Feature
+      placeholder: e.g. shop.html product grid — loads slowly on mobile
+    validations:
+      required: true
+
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Type of Performance Issue
+      options:
+        - Slow initial page load (LCP / FCP)
+        - Janky scroll / animation
+        - Memory leak
+        - Excessive network requests
+        - Large asset / bundle size
+        - Layout shift (CLS)
+        - Long input latency (INP)
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the performance issue and when it occurs.
+    validations:
+      required: true
+
+  - type: textarea
+    id: metrics
+    attributes:
+      label: Measured Metrics
+      description: |
+        If you have profiling data, Lighthouse scores, or network timings — paste them here.
+        Even rough numbers (e.g. "3s to first paint on a mid-range phone") are helpful.
+
+  - type: dropdown
+    id: device
+    attributes:
+      label: Device Type
+      options:
+        - Desktop (fast internet)
+        - Desktop (throttled — Fast 3G)
+        - Mobile (mid-range)
+        - Mobile (low-end)
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested-fix
+    attributes:
+      label: Suggested Fix (optional)
+      description: Do you have ideas on how to address this? (lazy loading, memoisation, image optimisation, etc.)
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I searched existing issues and this is not a duplicate
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,29 +1,91 @@
-# PR Description
-
-## Summary of Changes
-Provide a brief summary of the changes made and the problem being solved.
+# Pull Request
 
 ## Related Issue
-Fixes # (issue number)
+<!--
+Every PR MUST link to an existing issue.
+Use "Closes #ISSUE_NUMBER" so GitHub auto-closes the issue on merge.
+-->
+Closes #
+
+---
 
 ## Type of Change
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Documentation update
+<!-- Mark the boxes that apply. Remove lines that are not relevant. -->
+- [ ] 🐛 Bug fix — non-breaking change that resolves a reported issue
+- [ ] ✨ New feature — non-breaking change that adds functionality
+- [ ] 💥 Breaking change — fix or feature that changes existing behavior
+- [ ] 🎨 UI / UX improvement — visual or interaction polish
+- [ ] ♻️ Refactor — code improvement with no functional change
+- [ ] 📚 Documentation update
+- [ ] ⚙️ CI / tooling / workflow change
+- [ ] 🔒 Security fix
 
-## Verification & Testing
-### Local Verification
-- [ ] Built successfully locally
-- [ ] Console has zero errors or warnings
+---
 
-### Devices/Browsers Tested
-- [ ] Chrome (Desktop)
-- [ ] Safari (Mobile)
-- [ ] Firefox
+## Summary
+<!--
+2–5 sentence description of WHAT changed and WHY.
+Focus on the decision, not just the diff.
+-->
+
+---
+
+## Changes Made
+<!--
+Bullet list of the concrete changes in this PR.
+Keep each item focused and scannable.
+-->
+- 
+- 
+- 
+
+---
+
+## Screenshots / Recordings
+<!--
+Required for UI changes. Add before/after screenshots or a short screen recording.
+Drag and drop images directly into this text area.
+-->
+
+| Before | After |
+|--------|-------|
+|        |       |
+
+---
+
+## Testing
+<!--
+Describe how you tested these changes so reviewers can verify them quickly.
+-->
+
+### How to Test Locally
+1. 
+2. 
+3. 
+
+### Test Coverage
+- [ ] I added / updated unit tests for the new logic
+- [ ] I verified manually in Chrome (desktop)
+- [ ] I verified manually on a mobile viewport (< 480 px)
+- [ ] I ran `npm run lint` and it passes with no errors
+- [ ] I ran `npm run format:check` and it passes with no errors
+- [ ] Backend: I ran `pytest` and all tests pass (if backend changed)
+- [ ] Backend: Alembic migration applies cleanly with `alembic upgrade head` (if DB schema changed)
+
+---
+
+## Impact
+<!--
+Explain the user-facing or developer-facing benefit of this change.
+-->
+
+---
 
 ## Checklist
-- [ ] Code follows project styling guidelines
-- [ ] Changes are fully responsive and accessible
-- [ ] No extraneous logs or debug code left
-- [ ] Documentation updated accordingly
+- [ ] My code follows the existing style and conventions of this project
+- [ ] I have self-reviewed my diff and removed debug/console logs
+- [ ] I have not introduced any unrelated changes in this PR
+- [ ] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format (`fix:`, `feat:`, `docs:`, etc.)
+- [ ] I have updated relevant documentation (README, CONTRIBUTING, inline comments) if needed
+- [ ] All new and existing tests pass
+- [ ] This PR is independently reviewable and mergeable (no stacked dependencies)


### PR DESCRIPTION
Closes #2545

### Summary
Replaces old unstructured Markdown issues with interactive YAML forms (Bug, Feature, Performance, Documentation) and updates the PR checklist template.

### Changes Made
- **Issue Templates**: Added YAML files in `.github/ISSUE_TEMPLATE/` (bug, feature, documentation, performance).
- **PR Template**: Overhauled `.github/pull_request_template.md` with conventional commit reminders and testing tables.
