### PR TITLE
feat: implement admin dashboard analytics with key performance indicators and category-wise sales splits

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -1,0 +1,92 @@
+"""
+Admin analytics API endpoints.
+
+Secure route for store managers/admins to fetch aggregates.
+"""
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+from typing import List
+
+from .. import models, schemas
+from ..database import get_db
+from .auth import get_current_user
+
+router = APIRouter()
+
+
+def _enforce_admin(user: models.User = Depends(get_current_user)):
+    """Only allow users with role == 'ADMIN' to proceed."""
+    if user.role != "ADMIN":
+        raise HTTPException(
+            status_code=403,
+            detail="Access forbidden: Admin privilege required."
+        )
+    return user
+
+
+@router.get("/analytics/summary", response_model=schemas.AdminSummaryResponse)
+def get_analytics_summary(
+    db: Session = Depends(get_db),
+    admin_user: models.User = Depends(_enforce_admin)
+) -> dict:
+    """Return lifetime dashboard indicators (total revenue, order volume, customers count)."""
+    total_revenue = db.query(func.sum(models.Order.total_amount)).scalar() or 0.0
+    total_orders = db.query(func.count(models.Order.id)).scalar() or 0
+    total_users = db.query(func.count(models.User.id)).scalar() or 0
+
+    return {
+        "total_revenue": float(total_revenue),
+        "total_orders": int(total_orders),
+        "total_customers": int(total_users),
+    }
+
+
+@router.get("/analytics/category-sales", response_model=List[schemas.CategorySalesOut])
+def get_sales_by_category(
+    db: Session = Depends(get_db),
+    admin_user: models.User = Depends(_enforce_admin)
+) -> list:
+    """Return sales aggregation by category."""
+    # Since OrderItem has product_name and product is linked, we can join to products table
+    # to group by category.
+    results = (
+        db.query(
+            models.Product.category,
+            func.sum(models.OrderItem.quantity).label("units_sold"),
+            func.sum(models.OrderItem.price * models.OrderItem.quantity).label("revenue")
+        )
+        .join(models.OrderItem, models.Product.name == models.OrderItem.product_name)
+        .group_by(models.Product.category)
+        .all()
+    )
+
+    return [
+        {
+            "category": r[0] or "Unknown",
+            "units_sold": int(r[1] or 0),
+            "revenue": float(r[2] or 0.0)
+        }
+        for r in results
+    ]
+
+
+@router.get("/analytics/order-status-distribution", response_model=List[schemas.StatusDistributionOut])
+def get_status_distribution(
+    db: Session = Depends(get_db),
+    admin_user: models.User = Depends(_enforce_admin)
+) -> list:
+    """Return volume distribution across statuses."""
+    results = (
+        db.query(models.Order.status, func.count(models.Order.id))
+        .group_by(models.Order.status)
+        .all()
+    )
+
+    return [
+        {
+            "status": r[0] or "Unknown",
+            "count": int(r[1] or 0)
+        }
+        for r in results
+    ]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -51,8 +51,9 @@ def root():
     return {"message": "Cara AI Outfit Recommendation API is running."}
 
 # Include routers here later
-from .api import recommendation, products, auth, orders
+from .api import recommendation, products, auth, orders, admin
 app.include_router(recommendation.router, prefix="/api/outfit", tags=["outfit"])
 app.include_router(products.router, prefix="/api/products", tags=["products"])
 app.include_router(auth.router,prefix="/api/auth",tags=["auth"])
 app.include_router(orders.router, prefix="/api/orders", tags=["orders"])
+app.include_router(admin.router, prefix="/api/admin", tags=["admin"])

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -113,3 +113,32 @@ class OrderCreate(BaseModel):
     zip: str
     items: list[OrderItemCreate]
     coupon: Optional[str] = None
+
+
+# -- Admin Analytics Response Schemas --
+
+class AdminSummaryResponse(BaseModel):
+    total_revenue: float
+    total_orders: int
+    total_customers: int
+
+    class Config:
+        from_attributes = True
+
+
+class CategorySalesOut(BaseModel):
+    category: str
+    units_sold: int
+    revenue: float
+
+    class Config:
+        from_attributes = True
+
+
+class StatusDistributionOut(BaseModel):
+    status: str
+    count: int
+
+    class Config:
+        from_attributes = True
+

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -1,0 +1,95 @@
+"""
+Tests for Admin Analytics API endpoints.
+
+Covers:
+  - Role enforcement (regular user gets 403, admin gets 200)
+  - GET /api/admin/analytics/summary returns total_revenue, total_orders, total_customers
+  - GET /api/admin/analytics/category-sales returns list of CategorySalesOut
+  - GET /api/admin/analytics/order-status-distribution returns list of StatusDistributionOut
+"""
+import pytest
+from fastapi.testclient import TestClient
+from app import models
+
+
+def _register_and_login(client: TestClient, role: str, suffix: str) -> None:
+    # Register
+    client.post(
+        "/api/auth/register",
+        json={
+            "username": f"admin_t_{suffix}",
+            "email": f"admin_t_{suffix}@test.com",
+            "password": "Password1@",
+        },
+    )
+    # Perform login to establish credentials cookie
+    client.post(
+        "/api/auth/login",
+        json={
+            "email": f"admin_t_{suffix}@test.com",
+            "password": "Password1@",
+        },
+    )
+
+
+@pytest.fixture
+def make_admin(db_session):
+    """Mutate a user's role to ADMIN in the DB."""
+    def _mutate(email: str):
+        user = db_session.query(models.User).filter(models.User.email == email).first()
+        if user:
+            user.role = "ADMIN"
+            db_session.commit()
+    return _mutate
+
+
+class TestAdminSecurity:
+    def test_regular_user_access_forbidden(self, client: TestClient):
+        """A user with role 'USER' should be denied access (403)."""
+        _register_and_login(client, "USER", "regular")
+        resp = client.get("/api/admin/analytics/summary")
+        assert resp.status_code == 403
+
+    def test_unauthenticated_access_unauthorized(self, client: TestClient):
+        """Unauthenticated requests must get 401."""
+        client.cookies.clear()
+        resp = client.get("/api/admin/analytics/summary")
+        assert resp.status_code == 401
+
+
+class TestAdminAnalytics:
+    @pytest.mark.usefixtures("setup_database")
+    def test_admin_analytics_summary(self, client: TestClient, db_session, make_admin):
+        """Admin user can successfully fetch summary statistics."""
+        email = "admin_t_super@test.com"
+        _register_and_login(client, "USER", "super")
+        make_admin(email)
+
+        resp = client.get("/api/admin/analytics/summary")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "total_revenue" in body
+        assert "total_orders" in body
+        assert "total_customers" in body
+
+    def test_admin_category_sales(self, client: TestClient, db_session, make_admin):
+        """Admin can fetch sales grouped by product category."""
+        email = "admin_t_sales@test.com"
+        _register_and_login(client, "USER", "sales")
+        make_admin(email)
+
+        resp = client.get("/api/admin/analytics/category-sales")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert isinstance(body, list)
+
+    def test_admin_status_distribution(self, client: TestClient, db_session, make_admin):
+        """Admin can fetch status distribution stats."""
+        email = "admin_t_dist@test.com"
+        _register_and_login(client, "USER", "dist")
+        make_admin(email)
+
+        resp = client.get("/api/admin/analytics/order-status-distribution")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert isinstance(body, list)

--- a/js/admin-analytics.js
+++ b/js/admin-analytics.js
@@ -1,0 +1,133 @@
+/**
+ * admin-analytics.js
+ * Client-side script for the store manager dashboard.
+ *
+ * Fetches shop KPI analytics (lifetime revenue, order volumes, category splits)
+ * from /api/admin/analytics/* and dynamically renders progress bars, metrics,
+ * and data tables.
+ */
+
+(function () {
+  'use strict';
+
+  const SUMMARY_API = '/api/admin/analytics/summary';
+  const CATEGORY_API = '/api/admin/analytics/category-sales';
+  const STATUS_API = '/api/admin/analytics/order-status-distribution';
+
+  // ── DOM References ─────────────────────────────────────────────────────────
+  const revEl       = document.getElementById('analyticsRevenue');
+  const volumeEl    = document.getElementById('analyticsOrders');
+  const customersEl = document.getElementById('analyticsCustomers');
+  const catTable    = document.getElementById('analyticsCategoryTable');
+  const statusWrap  = document.getElementById('analyticsStatusWrap');
+  const errorAlert  = document.getElementById('analyticsError');
+
+  // ── Format helpers ─────────────────────────────────────────────────────────
+  function _fmtRev(val) {
+    return '₹' + parseFloat(val).toFixed(2).replace(/\d(?=(\d{3})+\.)/g, '$&,');
+  }
+
+  function _escape(str) {
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  // ── Render functions ───────────────────────────────────────────────────────
+  function renderSummary(data) {
+    if (revEl) revEl.textContent = _fmtRev(data.total_revenue || 0);
+    if (volumeEl) volumeEl.textContent = (data.total_orders || 0).toLocaleString();
+    if (customersEl) customersEl.textContent = (data.total_customers || 0).toLocaleString();
+  }
+
+  function renderCategorySales(list) {
+    if (!catTable) return;
+    if (list.length === 0) {
+      catTable.innerHTML = '<tr><td colspan="3" class="text-muted text-center">No sales recorded yet.</td></tr>';
+      return;
+    }
+    catTable.innerHTML = list
+      .map(
+        (r) => `
+      <tr>
+        <td><strong>${_escape(r.category.toUpperCase())}</strong></td>
+        <td class="text-right">${r.units_sold.toLocaleString()} units</td>
+        <td class="text-right font-weight-bold text-teal">${_fmtRev(r.revenue)}</td>
+      </tr>`,
+      )
+      .join('');
+  }
+
+  function renderStatusDistribution(list) {
+    if (!statusWrap) return;
+    if (list.length === 0) {
+      statusWrap.innerHTML = '<p class="text-muted text-center">No orders to categorize.</p>';
+      return;
+    }
+    const maxVal = Math.max(...list.map((r) => r.count), 1);
+
+    statusWrap.innerHTML = list
+      .map((r) => {
+        const pct = Math.round((r.count / maxVal) * 100);
+        return `
+        <div class="status-dist-bar-wrap" role="group" aria-label="${r.status}: ${r.count} orders">
+          <div class="status-dist-header">
+            <span class="status-label">${_escape(r.status)}</span>
+            <span class="status-count">${r.count.toLocaleString()}</span>
+          </div>
+          <div class="status-progress-track" role="progressbar" aria-valuenow="${r.count}" aria-valuemin="0" aria-valuemax="${maxVal}">
+            <div class="status-progress-fill" style="width: ${pct}%"></div>
+          </div>
+        </div>`;
+      })
+      .join('');
+  }
+
+  // ── Load all data ──────────────────────────────────────────────────────────
+  async function loadDashboard() {
+    try {
+      const [sumRes, catRes, statRes] = await Promise.all([
+        fetch(SUMMARY_API, { credentials: 'include' }),
+        fetch(CATEGORY_API, { credentials: 'include' }),
+        fetch(STATUS_API, { credentials: 'include' }),
+      ]);
+
+      if (sumRes.status === 403 || catRes.status === 403) {
+        throw new Error('Admin privilege required.');
+      }
+      if (!sumRes.ok || !catRes.ok || !statRes.ok) {
+        throw new Error('Failed to retrieve dashboard analytics.');
+      }
+
+      const sumData = await sumRes.json();
+      const catData = await catRes.json();
+      const statData = await statRes.json();
+
+      renderSummary(sumData);
+      renderCategorySales(catData);
+      renderStatusDistribution(statData);
+
+      if (errorAlert) errorAlert.style.display = 'none';
+    } catch (err) {
+      console.error('[AdminAnalytics] Load failed:', err);
+      if (errorAlert) {
+        errorAlert.textContent = err.message || 'Error loading dashboard.';
+        errorAlert.style.display = 'block';
+        errorAlert.setAttribute('role', 'alert');
+      }
+    }
+  }
+
+  // ── Initialise ─────────────────────────────────────────────────────────────
+  document.addEventListener('DOMContentLoaded', () => {
+    // Only load if dashboard components exist on page
+    if (revEl || catTable || statusWrap) {
+      loadDashboard();
+    }
+  });
+
+  window.AdminDashboard = { refresh: loadDashboard };
+})();


### PR DESCRIPTION
Closes #2553 

### Summary
Adds admin-only dashboard API endpoints to query revenue, total customer counts, and product category sales metrics. Includes a frontend helper to populate charts.

### Changes Made
- **APIs**: Created `api/admin.py` with `role == 'ADMIN'` access guards, and registered it in `main.py`.
- **Schemas**: Defined response schemas in `schemas.py`.
- **JS**: Created `js/admin-analytics.js` for rendering dashboards.
- **Tests**: Added `tests/test_admin.py` verifying security role restrictions.

### Verification Plan
#### Automated Tests
- Run: `pytest backend/tests/test_admin.py`