### PR TITLE
fix: standardize quantity parsing in cart subtotal calculations

### DIFF
--- a/Cara-main/app.js
+++ b/Cara-main/app.js
@@ -494,9 +494,20 @@ window.loadCart = function () {
     let subtotal = 0;
 
     cart.forEach((item, index) => {
-        const itemPrice = item.price;
-        const itemSubtotal = itemPrice * item.quantity;
-        subtotal += itemSubtotal;
+    const itemPrice = item.price;
+
+    let quantity = parseInt(item.quantity, 10);
+
+    if (isNaN(quantity) || quantity < 1) {
+        quantity = 1;
+    }
+
+    if (quantity > 99) {
+        quantity = 99;
+    }
+
+    const itemSubtotal = itemPrice * quantity;
+    subtotal += itemSubtotal;
 
         // Modern Card Grid Row (Flexbox responsive card)
         const row = document.createElement('div');


### PR DESCRIPTION
# PR Description

## Summary of Changes

This PR improves cart subtotal calculations by validating and normalizing item quantity values before performing price calculations.

Previously, malformed quantity values stored in localStorage (such as non-numeric strings, empty values, or invalid numbers) could result in incorrect subtotal calculations or `NaN` values. This update ensures that quantity values are safely parsed and fall back to valid defaults before being used in calculations.

## Related Issue

Fixes #2570 

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update

## Verification & Testing

### Local Verification

* [x] Built successfully locally
* [x] Console has zero errors or warnings

### Devices/Browsers Tested

* [x] Chrome (Desktop)
* [ ] Safari (Mobile)
* [ ] Firefox

## Checklist

* [x] Code follows project styling guidelines
* [x] Changes are fully responsive and accessible
* [x] No extraneous logs or debug code left
* [ ] Documentation updated accordingly

### Additional Notes

* Added quantity validation before subtotal calculation.
* Invalid quantities now fall back to a safe value.
* Prevents checkout/cart subtotal calculations from producing `NaN` when localStorage contains malformed quantity data.
