### PR TITLE
fix: Fix Mismatched HTML Tags in Blog Cards Causing Broken Grid Layout (#2632)

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -252,7 +252,7 @@
           </div>
         </div>
         <h1>13/01</h1>
-      </div>
+      </article>
       <article class="blog-box">
         <div class="blog-img">
           <img src="images/blog/b2.jpg" alt="A professional styling a Quiff haircut" width="600" height="400" loading="lazy" />
@@ -275,7 +275,7 @@
           </div>
         </div>
         <h1>13/04</h1>
-      </div>
+      </article>
       <article class="blog-box">
         <div class="blog-img">
           <img src="images/blog/b3.jpg" alt="A variety of Must-Have Skater Girls Items laid out" width="600" height="400" loading="lazy" />
@@ -299,7 +299,7 @@
           </div>
         </div>
         <h1>12/01</h1>
-      </div>
+      </article>
       <article class="blog-box">
         <div class="blog-img">
           <img src="images/blog/b4.jpg" alt="Models showcasing Runway-Inspired Trends" width="600" height="400" loading="lazy" />
@@ -322,7 +322,7 @@
           </div>
         </div>
         <h1>16/01</h1>
-      </div>
+      </article>
       <article class="blog-box">
         <div class="blog-img">
           <img src="images/blog/b6.jpg" alt="Menswear autumn winter collection presentation" width="600" height="400" loading="lazy" />
@@ -345,7 +345,7 @@
           </div>
         </div>
         <h1>10/01</h1>
-      </div>
+      </article>
     </section>
 
     <!-- Back to Top and Scroll to Bottom Buttons -->


### PR DESCRIPTION
Closes #2632

## Type of Change
- [x] 🐛 Bug fix — non-breaking change that resolves a reported issue

## Summary
All 5 blog card sections in `blog.html` were opened with `<article class="blog-box">` but closed with `</div>`, creating mismatched HTML tags. This caused the blog grid layout to break completely, with cards rendering at inconsistent heights and positions. Fixed by replacing all incorrect closing `</div>` tags with `</article>`.

## Changes Made
- Fixed 5 mismatched closing tags in `blog.html` — changed `</div>` to `</article>` for each `.blog-box` element

## Screenshots / Recordings

<img width="1328" height="612" alt="image" src="https://github.com/user-attachments/assets/c7e6ae2a-df4e-4aa1-8ee3-a0ab37a93aba" />
    

## Testing
### How to Test Locally
1. Open `blog.html` in Live Preview
2. Scroll to the blog cards section
3. Verify all cards are aligned in a consistent grid layout

### Test Coverage
- [x] I verified manually in Chrome (desktop)
- [x] I ran `npm run lint` and it passes with no errors

## Impact
Blog post cards now render in a proper aligned grid as intended, fixing the broken layout visible on the blog page.

## Checklist
- [x] My code follows the existing style and conventions of this project
- [x] I have self-reviewed my diff and removed debug/console logs
- [x] I have not introduced any unrelated changes in this PR
- [x] The PR title follows Conventional Commits format
- [x] All new and existing tests pass
- [x] This PR is independently reviewable and mergeable