### PR TITLE
fix: resolve try-on action buttons ReferenceError

### DIFF
--- a/try-on.js
+++ b/try-on.js
@@ -1,102 +1,154 @@
-document.addEventListener("DOMContentLoaded",()=>{
-    // ============================================
-// CARA VIRTUAL TRY-ON — Full Implementation
-// Uses MediaPipe Pose (BlazePose) for body detection
-// Canvas-based garment overlay with background removal
-// ============================================
+/* global Pose, showToast */
+document.addEventListener('DOMContentLoaded', () => {
+  // ============================================
+  // CARA VIRTUAL TRY-ON — Full Implementation
+  // Uses MediaPipe Pose (BlazePose) for body detection
+  // Canvas-based garment overlay with background removal
+  // ============================================
 
-// ---- DOM References ----
-const uploadInput = document.getElementById('photo-upload');
-const uploadText = document.getElementById('upload-text');
-const generateBtn = document.getElementById('generate-btn');
-const placeholder = document.getElementById('placeholder');
-const uploadedPreview = document.getElementById('uploaded-preview');
-const scanner = document.getElementById('scanner');
-const aiStatus = document.getElementById('ai-status');
-const resultCanvas = document.getElementById('output-canvas');
-const shareControls = document.getElementById('share-controls');
-const bodyInfoEl = document.getElementById('body-info');
-const webcamVideo = document.getElementById('webcam-video');
+  // ---- DOM References ----
+  const uploadInput = document.getElementById('photo-upload');
+  const uploadText = document.getElementById('upload-text');
+  const generateBtn = document.getElementById('generate-btn');
+  const placeholder = document.getElementById('placeholder');
+  const uploadedPreview = document.getElementById('uploaded-preview');
+  const scanner = document.getElementById('scanner');
+  const aiStatus = document.getElementById('ai-status');
+  const resultCanvas = document.getElementById('output-canvas');
+  const shareControls = document.getElementById('share-controls');
+  const bodyInfoEl = document.getElementById('body-info');
+  const webcamVideo = document.getElementById('webcam-video');
 
-// ---- State ----
-let currentMode = 'camera';   // 'camera' or 'upload'
-let hasPhoto = false;
-let hasOutfit = false;
-let selectedGarmentImg = null;
-let cleanedGarmentCanvas = null; // garment with background removed
-let cameraStream = null;
-let isLiveMode = false;        // true when webcam is live
-let mediaPipeCamera = null;
-let detectedLandmarks = null;  // store last detected landmarks
+  // ---- State ----
+  let currentMode = 'camera'; // 'camera' or 'upload'
+  let hasPhoto = false;
+  let hasOutfit = false;
+  let selectedGarmentImg = null;
+  let cleanedGarmentCanvas = null; // garment with background removed
+  let cameraStream = null;
+  let isLiveMode = false; // true when webcam is live
+  let mediaPipeCamera = null;
+  let detectedLandmarks = null; // store last detected landmarks
 
-// ---- Product catalog for clothing grid ----
-const tryOnProducts = [
-    { id: 1,  name: "Tropical Hibiscus Shirt",  img: "images/products/f1.jpg", category: "top" },
-    { id: 2,  name: "White Palm Leaf Shirt",     img: "images/products/f2.jpg", category: "top" },
-    { id: 3,  name: "Vintage Rose Garden Shirt", img: "images/products/f3.jpg", category: "top" },
-    { id: 4,  name: "Sakura Blossom Shirt",      img: "images/products/f4.jpg", category: "top" },
-    { id: 5,  name: "Pink Peony Shirt",          img: "images/products/f5.jpg", category: "top" },
-    { id: 6,  name: "Dual-Tone Corduroy Shirt",  img: "images/products/f6.jpg", category: "top" },
-    { id: 8,  name: "Cat Print Blouse",          img: "images/products/f8.jpg", category: "top" },
-    { id: 9,  name: "Sky Blue Mandarin Shirt",   img: "images/products/n1.jpg", category: "top" },
-];
+  // ---- Product catalog for clothing grid ----
+  const tryOnProducts = [
+    {
+      id: 1,
+      name: 'Tropical Hibiscus Shirt',
+      img: 'images/products/f1.jpg',
+      category: 'top',
+    },
+    {
+      id: 2,
+      name: 'White Palm Leaf Shirt',
+      img: 'images/products/f2.jpg',
+      category: 'top',
+    },
+    {
+      id: 3,
+      name: 'Vintage Rose Garden Shirt',
+      img: 'images/products/f3.jpg',
+      category: 'top',
+    },
+    {
+      id: 4,
+      name: 'Sakura Blossom Shirt',
+      img: 'images/products/f4.jpg',
+      category: 'top',
+    },
+    {
+      id: 5,
+      name: 'Pink Peony Shirt',
+      img: 'images/products/f5.jpg',
+      category: 'top',
+    },
+    {
+      id: 6,
+      name: 'Dual-Tone Corduroy Shirt',
+      img: 'images/products/f6.jpg',
+      category: 'top',
+    },
+    {
+      id: 8,
+      name: 'Cat Print Blouse',
+      img: 'images/products/f8.jpg',
+      category: 'top',
+    },
+    {
+      id: 9,
+      name: 'Sky Blue Mandarin Shirt',
+      img: 'images/products/n1.jpg',
+      category: 'top',
+    },
+  ];
 
-// ---- Populate clothing grid ----
-(function populateClothingGrid() {
+  // ---- Populate clothing grid ----
+  (function populateClothingGrid() {
     const grid = document.getElementById('clothing-list');
     if (!grid) return;
-    tryOnProducts.forEach(p => {
-        const img = document.createElement('img');
-        img.src = p.img;
-        img.alt = p.name;
-        img.className = 'clothing-item';
-        img.title = p.name;
-        img.addEventListener('click', () => selectOutfit(img));
-        grid.appendChild(img);
+    tryOnProducts.forEach((p) => {
+      const img = document.createElement('img');
+      img.src = p.img;
+      img.alt = p.name;
+      img.className = 'clothing-item';
+      img.title = p.name;
+      img.addEventListener('click', () => selectOutfit(img));
+      grid.appendChild(img);
     });
-})();
+  })();
 
-// ============================================
-// MEDIAPIPE POSE INITIALIZATION
-// ============================================
-const pose = new Pose({
-    locateFile: (file) => `https://cdn.jsdelivr.net/npm/@mediapipe/pose/${file}`
-});
+  // ============================================
+  // MEDIAPIPE POSE INITIALIZATION
+  // ============================================
+  const pose = new Pose({
+    locateFile: (file) =>
+      `https://cdn.jsdelivr.net/npm/@mediapipe/pose/${file}`,
+  });
 
-pose.setOptions({
-    modelComplexity: 1,       // 0=lite, 1=full, 2=heavy
+  pose.setOptions({
+    modelComplexity: 1, // 0=lite, 1=full, 2=heavy
     smoothLandmarks: true,
     enableSegmentation: false,
     minDetectionConfidence: 0.5,
-    minTrackingConfidence: 0.5
-});
+    minTrackingConfidence: 0.5,
+  });
 
-pose.onResults(onPoseResults);
+  pose.onResults(onPoseResults);
 
-// ============================================
-// MODE SWITCHING (Camera / Upload)
-// ============================================
-window.switchMode = function(mode) {
+  // ============================================
+  // MODE SWITCHING (Camera / Upload)
+  // ============================================
+  function switchMode(mode) {
     currentMode = mode;
-    document.getElementById('btn-camera').classList.toggle('active', mode === 'camera');
-    document.getElementById('btn-upload').classList.toggle('active', mode === 'upload');
-    document.getElementById('camera-area').classList.toggle('visible', mode === 'camera');
-    document.getElementById('upload-area').classList.toggle('visible', mode === 'upload');
+    document
+      .getElementById('btn-camera')
+      .classList.toggle('active', mode === 'camera');
+    document
+      .getElementById('btn-upload')
+      .classList.toggle('active', mode === 'upload');
+    document
+      .getElementById('camera-area')
+      .classList.toggle('visible', mode === 'camera');
+    document
+      .getElementById('upload-area')
+      .classList.toggle('visible', mode === 'upload');
 
     // Stop camera if switching to upload
     if (mode === 'upload' && cameraStream) {
-        stopCamera();
+      stopCamera();
     }
-}
+  }
+  window.switchMode = switchMode;
 
-// ============================================
-// CAMERA HANDLING
-// ============================================
-window.openCamera = function () {
-    navigator.mediaDevices.getUserMedia({
-        video: { facingMode: 'user' }
-    })
-    .then(stream => {
+  // ============================================
+  // CAMERA HANDLING
+  // ============================================
+  function openCamera() {
+    navigator.mediaDevices
+      .getUserMedia({
+        video: { facingMode: 'user' },
+      })
+      .then((stream) => {
         cameraStream = stream;
 
         webcamVideo.srcObject = stream;
@@ -113,53 +165,63 @@ window.openCamera = function () {
 
         isLiveMode = true;
         startLiveDetection();
-    })
-    .catch(err => {
+      })
+      .catch((err) => {
         window.logError('Camera error:', err);
         if (typeof showToast === 'function') {
-            showToast('Camera access blocked. Please enable webcam permission.', 'error');
+          showToast(
+            'Camera access blocked. Please enable webcam permission.',
+            'error'
+          );
         } else {
-            console.log("Toast: " + 'Camera access blocked. Please enable webcam permission.');
+          console.log(
+            'Toast: ' +
+              'Camera access blocked. Please enable webcam permission.'
+          );
         }
-    });
-}
-function startLiveDetection() {
+      });
+  }
+  window.openCamera = openCamera;
+  function startLiveDetection() {
     if (!isLiveMode) return;
 
     const ctx = resultCanvas.getContext('2d');
 
     function processFrame() {
-        if (!isLiveMode || webcamVideo.paused || webcamVideo.ended) return;
+      if (!isLiveMode || webcamVideo.paused || webcamVideo.ended) return;
 
-        // Mirror the webcam feed
-        ctx.save();
-        ctx.translate(resultCanvas.width, 0);
-        ctx.scale(-1, 1);
-        ctx.drawImage(webcamVideo, 0, 0, resultCanvas.width, resultCanvas.height);
-        ctx.restore();
+      // Mirror the webcam feed
+      ctx.save();
+      ctx.translate(resultCanvas.width, 0);
+      ctx.scale(-1, 1);
+      ctx.drawImage(webcamVideo, 0, 0, resultCanvas.width, resultCanvas.height);
+      ctx.restore();
 
-        // Send frame to MediaPipe
-        pose.send({ image: webcamVideo }).then(() => {
-            if (isLiveMode) {
-                requestAnimationFrame(processFrame);
-            }
-        }).catch(err => {
-            window.logError('Pose error:', err);
-            if (isLiveMode) requestAnimationFrame(processFrame);
+      // Send frame to MediaPipe
+      pose
+        .send({ image: webcamVideo })
+        .then(() => {
+          if (isLiveMode) {
+            requestAnimationFrame(processFrame);
+          }
+        })
+        .catch((err) => {
+          window.logError('Pose error:', err);
+          if (isLiveMode) requestAnimationFrame(processFrame);
         });
     }
 
     webcamVideo.onloadeddata = () => {
-        requestAnimationFrame(processFrame);
+      requestAnimationFrame(processFrame);
     };
 
     // If video is already playing
     if (webcamVideo.readyState >= 2) {
-        requestAnimationFrame(processFrame);
+      requestAnimationFrame(processFrame);
     }
-}
+  }
 
-window.capturePhoto=function() {
+  function capturePhoto() {
     if (!cameraStream) return;
 
     detectedLandmarks = null; // clear stale landmarks before new capture
@@ -173,7 +235,13 @@ window.capturePhoto=function() {
     captureCtx.save();
     captureCtx.translate(captureCanvas.width, 0);
     captureCtx.scale(-1, 1);
-    captureCtx.drawImage(webcamVideo, 0, 0, captureCanvas.width, captureCanvas.height);
+    captureCtx.drawImage(
+      webcamVideo,
+      0,
+      0,
+      captureCanvas.width,
+      captureCanvas.height
+    );
     captureCtx.restore();
 
     // Stop camera
@@ -182,20 +250,21 @@ window.capturePhoto=function() {
     // Set captured image as the uploaded preview
     uploadedPreview.src = captureCanvas.toDataURL('image/png');
     uploadedPreview.onload = () => {
-        hasPhoto = true;
-        checkReady();
-        // Run pose detection on captured image
-        processSingleImage();
+      hasPhoto = true;
+      checkReady();
+      // Run pose detection on captured image
+      processSingleImage();
     };
 
     updateStep(2);
-}
+  }
+  window.capturePhoto = capturePhoto;
 
-window.stopCamera=function() {
+  function stopCamera() {
     isLiveMode = false;
     if (cameraStream) {
-        cameraStream.getTracks().forEach(t => t.stop());
-        cameraStream = null;
+      cameraStream.getTracks().forEach((t) => t.stop());
+      cameraStream = null;
     }
     webcamVideo.srcObject = null;
     webcamVideo.style.display = 'none';
@@ -203,67 +272,72 @@ window.stopCamera=function() {
     document.getElementById('open-camera-btn').style.display = 'flex';
     document.getElementById('capture-btn').style.display = 'none';
     document.getElementById('stop-camera-btn').style.display = 'none';
-}
+  }
+  window.stopCamera = stopCamera;
 
-// Stop camera when the user navigates away or hides the tab
-window.addEventListener('beforeunload', () => {
+  // Stop camera when the user navigates away or hides the tab
+  window.addEventListener('beforeunload', () => {
     if (cameraStream) {
-        cameraStream.getTracks().forEach(t => t.stop());
-        cameraStream = null;
+      cameraStream.getTracks().forEach((t) => t.stop());
+      cameraStream = null;
     }
-});
+  });
 
-document.addEventListener('visibilitychange', () => {
+  document.addEventListener('visibilitychange', () => {
     if (document.visibilityState === 'hidden' && cameraStream) {
-        window.stopCamera();
+      window.stopCamera();
     }
-});
+  });
 
-// ============================================
-// IMAGE UPLOAD HANDLING
-// ============================================
-uploadInput.addEventListener('change', function() {
+  // ============================================
+  // IMAGE UPLOAD HANDLING
+  // ============================================
+  uploadInput.addEventListener('change', function () {
     if (this.files && this.files[0]) {
-        hasPhoto = true;
-        detectedLandmarks = null; // clear stale landmarks from previous photo
-        uploadText.innerText = this.files[0].name;
+      hasPhoto = true;
+      detectedLandmarks = null; // clear stale landmarks from previous photo
+      uploadText.innerText = this.files[0].name;
 
-        const reader = new FileReader();
-        reader.onload = function(e) {
-            uploadedPreview.src = e.target.result;
-            uploadedPreview.onload = () => {
-                placeholder.style.display = 'none';
-                processSingleImage();
-            };
+      const reader = new FileReader();
+      reader.onload = function (e) {
+        uploadedPreview.src = e.target.result;
+        uploadedPreview.onload = () => {
+          placeholder.style.display = 'none';
+          processSingleImage();
         };
-        reader.readAsDataURL(this.files[0]);
-        checkReady();
-        updateStep(2);
+      };
+      reader.readAsDataURL(this.files[0]);
+      checkReady();
+      updateStep(2);
     }
-});
+  });
 
-// ============================================
-// PROCESS SINGLE IMAGE (Upload or Capture)
-// ============================================
-async function processSingleImage() {
+  // ============================================
+  // PROCESS SINGLE IMAGE (Upload or Capture)
+  // ============================================
+  async function processSingleImage() {
     // Show scanning animation
     scanner.style.display = 'flex';
     aiStatus.innerText = 'DETECTING BODY LANDMARKS...';
 
     try {
-        await pose.send({ image: uploadedPreview });
+      await pose.send({ image: uploadedPreview });
     } catch (err) {
-        window.logError('Pose detection error:', err);
-        aiStatus.innerText = 'DETECTION FAILED';
-        setTimeout(() => { scanner.style.display = 'none'; }, 1500);
+      window.logError('Pose detection error:', err);
+      aiStatus.innerText = 'DETECTION FAILED';
+      setTimeout(() => {
+        scanner.style.display = 'none';
+      }, 1500);
     }
-}
+  }
 
-// ============================================
-// OUTFIT SELECTION
-// ============================================
-function selectOutfit(element) {
-    document.querySelectorAll('.clothing-item').forEach(el => el.classList.remove('selected'));
+  // ============================================
+  // OUTFIT SELECTION
+  // ============================================
+  function selectOutfit(element) {
+    document
+      .querySelectorAll('.clothing-item')
+      .forEach((el) => el.classList.remove('selected'));
     element.classList.add('selected');
     hasOutfit = true;
 
@@ -272,18 +346,18 @@ function selectOutfit(element) {
     img.crossOrigin = 'anonymous';
     img.src = element.src;
     img.onload = () => {
-        selectedGarmentImg = img;
-        cleanedGarmentCanvas = removeGarmentBackground(img);
-        checkReady();
+      selectedGarmentImg = img;
+      cleanedGarmentCanvas = removeGarmentBackground(img);
+      checkReady();
     };
 
     updateStep(3);
-}
+  }
 
-// ============================================
-// GARMENT BACKGROUND REMOVAL (Canvas Pixel Manipulation)
-// ============================================
-function removeGarmentBackground(img) {
+  // ============================================
+  // GARMENT BACKGROUND REMOVAL (Canvas Pixel Manipulation)
+  // ============================================
+  function removeGarmentBackground(img) {
     const offscreen = document.createElement('canvas');
     offscreen.width = img.naturalWidth || img.width;
     offscreen.height = img.naturalHeight || img.height;
@@ -297,24 +371,27 @@ function removeGarmentBackground(img) {
     const cornerColors = [];
     const patchSize = 10;
     const corners = [
-        [0, 0],
-        [offscreen.width - patchSize, 0],
-        [0, offscreen.height - patchSize],
-        [offscreen.width - patchSize, offscreen.height - patchSize]
+      [0, 0],
+      [offscreen.width - patchSize, 0],
+      [0, offscreen.height - patchSize],
+      [offscreen.width - patchSize, offscreen.height - patchSize],
     ];
 
     corners.forEach(([cx, cy]) => {
-        let r = 0, g = 0, b = 0, count = 0;
-        for (let py = cy; py < cy + patchSize; py++) {
-            for (let px = cx; px < cx + patchSize; px++) {
-                const idx = (py * offscreen.width + px) * 4;
-                r += data[idx];
-                g += data[idx + 1];
-                b += data[idx + 2];
-                count++;
-            }
+      let r = 0,
+        g = 0,
+        b = 0,
+        count = 0;
+      for (let py = cy; py < cy + patchSize; py++) {
+        for (let px = cx; px < cx + patchSize; px++) {
+          const idx = (py * offscreen.width + px) * 4;
+          r += data[idx];
+          g += data[idx + 1];
+          b += data[idx + 2];
+          count++;
         }
-        cornerColors.push({ r: r / count, g: g / count, b: b / count });
+      }
+      cornerColors.push({ r: r / count, g: g / count, b: b / count });
     });
 
     // Average of corner colors = estimated background
@@ -326,29 +403,29 @@ function removeGarmentBackground(img) {
     const threshold = 60;
 
     for (let i = 0; i < data.length; i += 4) {
-        const dr = data[i] - bgR;
-        const dg = data[i + 1] - bgG;
-        const db = data[i + 2] - bgB;
-        const dist = Math.sqrt(dr * dr + dg * dg + db * db);
+      const dr = data[i] - bgR;
+      const dg = data[i + 1] - bgG;
+      const db = data[i + 2] - bgB;
+      const dist = Math.sqrt(dr * dr + dg * dg + db * db);
 
-        if (dist < threshold) {
-            // Make transparent
-            data[i + 3] = 0;
-        } else if (dist < threshold + 30) {
-            // Feather edges for smooth blending
-            const alpha = Math.round(((dist - threshold) / 30) * 255);
-            data[i + 3] = Math.min(data[i + 3], alpha);
-        }
+      if (dist < threshold) {
+        // Make transparent
+        data[i + 3] = 0;
+      } else if (dist < threshold + 30) {
+        // Feather edges for smooth blending
+        const alpha = Math.round(((dist - threshold) / 30) * 255);
+        data[i + 3] = Math.min(data[i + 3], alpha);
+      }
     }
 
     ctx.putImageData(imageData, 0, 0);
     return offscreen;
-}
+  }
 
-// ============================================
-// BODY ANALYSIS — Classify Body Type
-// ============================================
-function analyzeBody(landmarks, canvasW, canvasH) {
+  // ============================================
+  // BODY ANALYSIS — Classify Body Type
+  // ============================================
+  function analyzeBody(landmarks, canvasW, canvasH) {
     const lShoulder = landmarks[11];
     const rShoulder = landmarks[12];
     const lHip = landmarks[23];
@@ -358,11 +435,11 @@ function analyzeBody(landmarks, canvasW, canvasH) {
 
     // Pixel distances
     const shoulderWidth = Math.sqrt(
-        Math.pow((lShoulder.x - rShoulder.x) * canvasW, 2) +
+      Math.pow((lShoulder.x - rShoulder.x) * canvasW, 2) +
         Math.pow((lShoulder.y - rShoulder.y) * canvasH, 2)
     );
     const hipWidth = Math.sqrt(
-        Math.pow((lHip.x - rHip.x) * canvasW, 2) +
+      Math.pow((lHip.x - rHip.x) * canvasW, 2) +
         Math.pow((lHip.y - rHip.y) * canvasH, 2)
     );
 
@@ -379,15 +456,15 @@ function analyzeBody(landmarks, canvasW, canvasH) {
     else bodyType = 'Hourglass';
 
     return {
-        shoulderWidth: Math.round(shoulderWidth),
-        hipWidth: Math.round(hipWidth),
-        torsoLength: Math.round(torsoLength),
-        ratio: ratio.toFixed(2),
-        bodyType
+      shoulderWidth: Math.round(shoulderWidth),
+      hipWidth: Math.round(hipWidth),
+      torsoLength: Math.round(torsoLength),
+      ratio: ratio.toFixed(2),
+      bodyType,
     };
-}
+  }
 
-function showBodyInfo(info) {
+  function showBodyInfo(info) {
     bodyInfoEl.innerHTML = `
         <div><span class="label">Body Type:</span> ${info.bodyType}</div>
         <div><span class="label">Shoulder W:</span> ${info.shoulderWidth}px</div>
@@ -396,36 +473,46 @@ function showBodyInfo(info) {
         <div><span class="label">S/H Ratio:</span> ${info.ratio}</div>
     `;
     bodyInfoEl.style.display = 'block';
-}
+  }
 
-// ============================================
-// MEDIAPIPE RESULTS CALLBACK
-// ============================================
-function onPoseResults(results) {
+  // ============================================
+  // MEDIAPIPE RESULTS CALLBACK
+  // ============================================
+  function onPoseResults(results) {
     const canvas = resultCanvas;
     const ctx = canvas.getContext('2d');
 
     // For live webcam mode, just draw skeleton overlay
     if (isLiveMode) {
-        canvas.width = 640;
-        canvas.height = 480;
-        ctx.save();
-        ctx.clearRect(0, 0, canvas.width, canvas.height);
+      canvas.width = 640;
+      canvas.height = 480;
+      ctx.save();
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-        // Mirror the webcam
-        ctx.translate(canvas.width, 0);
-        ctx.scale(-1, 1);
-        ctx.drawImage(results.image, 0, 0, canvas.width, canvas.height);
-        ctx.restore();
+      // Mirror the webcam
+      ctx.translate(canvas.width, 0);
+      ctx.scale(-1, 1);
+      ctx.drawImage(results.image, 0, 0, canvas.width, canvas.height);
+      ctx.restore();
 
-        // Draw skeleton landmarks on live feed
-        if (results.poseLandmarks) {
-            detectedLandmarks = results.poseLandmarks;
-            drawSkeleton(ctx, results.poseLandmarks, canvas.width, canvas.height, true);
-            const bodyInfo = analyzeBody(results.poseLandmarks, canvas.width, canvas.height);
-            showBodyInfo(bodyInfo);
-        }
-        return;
+      // Draw skeleton landmarks on live feed
+      if (results.poseLandmarks) {
+        detectedLandmarks = results.poseLandmarks;
+        drawSkeleton(
+          ctx,
+          results.poseLandmarks,
+          canvas.width,
+          canvas.height,
+          true
+        );
+        const bodyInfo = analyzeBody(
+          results.poseLandmarks,
+          canvas.width,
+          canvas.height
+        );
+        showBodyInfo(bodyInfo);
+      }
+      return;
     }
 
     // For single image mode (upload or captured photo)
@@ -439,14 +526,24 @@ function onPoseResults(results) {
     ctx.drawImage(results.image, 0, 0, canvas.width, canvas.height);
 
     if (results.poseLandmarks) {
-        detectedLandmarks = results.poseLandmarks;
+      detectedLandmarks = results.poseLandmarks;
 
-        // Draw skeleton
-        drawSkeleton(ctx, results.poseLandmarks, canvas.width, canvas.height, false);
+      // Draw skeleton
+      drawSkeleton(
+        ctx,
+        results.poseLandmarks,
+        canvas.width,
+        canvas.height,
+        false
+      );
 
-        // Analyze body
-        const bodyInfo = analyzeBody(results.poseLandmarks, canvas.width, canvas.height);
-        showBodyInfo(bodyInfo);
+      // Analyze body
+      const bodyInfo = analyzeBody(
+        results.poseLandmarks,
+        canvas.width,
+        canvas.height
+      );
+      showBodyInfo(bodyInfo);
     }
 
     ctx.restore();
@@ -454,21 +551,26 @@ function onPoseResults(results) {
     // Show canvas, hide scanner
     scanner.style.display = 'none';
     canvas.style.display = 'block';
-}
+  }
 
-// ============================================
-// SKELETON DRAWING
-// ============================================
-function drawSkeleton(ctx, landmarks, w, h, mirrored) {
+  // ============================================
+  // SKELETON DRAWING
+  // ============================================
+  function drawSkeleton(ctx, landmarks, w, h, mirrored) {
     // Key connections for upper body
     const connections = [
-        [11, 12], // shoulders
-        [11, 13], [13, 15], // left arm
-        [12, 14], [14, 16], // right arm
-        [11, 23], [12, 24], // torso sides
-        [23, 24], // hips
-        [23, 25], [25, 27], // left leg
-        [24, 26], [26, 28], // right leg
+      [11, 12], // shoulders
+      [11, 13],
+      [13, 15], // left arm
+      [12, 14],
+      [14, 16], // right arm
+      [11, 23],
+      [12, 24], // torso sides
+      [23, 24], // hips
+      [23, 25],
+      [25, 27], // left leg
+      [24, 26],
+      [26, 28], // right leg
     ];
 
     // Draw connections
@@ -476,55 +578,59 @@ function drawSkeleton(ctx, landmarks, w, h, mirrored) {
     ctx.lineWidth = 3;
 
     connections.forEach(([a, b]) => {
-        const la = landmarks[a];
-        const lb = landmarks[b];
-        if (la.visibility > 0.5 && lb.visibility > 0.5) {
-            let ax = la.x * w, bx = lb.x * w;
-            if (mirrored) {
-                ax = w - ax;
-                bx = w - bx;
-            }
-            ctx.beginPath();
-            ctx.moveTo(ax, la.y * h);
-            ctx.lineTo(bx, lb.y * h);
-            ctx.stroke();
+      const la = landmarks[a];
+      const lb = landmarks[b];
+      if (la.visibility > 0.5 && lb.visibility > 0.5) {
+        let ax = la.x * w,
+          bx = lb.x * w;
+        if (mirrored) {
+          ax = w - ax;
+          bx = w - bx;
         }
+        ctx.beginPath();
+        ctx.moveTo(ax, la.y * h);
+        ctx.lineTo(bx, lb.y * h);
+        ctx.stroke();
+      }
     });
 
     // Draw key landmark dots
     const keyPoints = [11, 12, 13, 14, 15, 16, 23, 24, 25, 26, 27, 28];
-    keyPoints.forEach(idx => {
-        const lm = landmarks[idx];
-        if (lm.visibility > 0.5) {
-            let lx = lm.x * w;
-            if (mirrored) lx = w - lx;
-            ctx.beginPath();
-            ctx.arc(lx, lm.y * h, 5, 0, 2 * Math.PI);
-            ctx.fillStyle = '#088178';
-            ctx.fill();
-            ctx.strokeStyle = '#fff';
-            ctx.lineWidth = 2;
-            ctx.stroke();
-        }
+    keyPoints.forEach((idx) => {
+      const lm = landmarks[idx];
+      if (lm.visibility > 0.5) {
+        let lx = lm.x * w;
+        if (mirrored) lx = w - lx;
+        ctx.beginPath();
+        ctx.arc(lx, lm.y * h, 5, 0, 2 * Math.PI);
+        ctx.fillStyle = '#088178';
+        ctx.fill();
+        ctx.strokeStyle = '#fff';
+        ctx.lineWidth = 2;
+        ctx.stroke();
+      }
     });
-}
+  }
 
-// ============================================
-// GARMENT OVERLAY RENDERING
-// ==========================================// ---- Interactive Garment Adjustment State ----
-let garmentScale = 1.0;
-let garmentOffsetY = 0.0;
-let garmentOpacity = 0.90;
-let garmentBlendMode = 'multiply';
+  // ============================================
+  // GARMENT OVERLAY RENDERING
+  // ==========================================// ---- Interactive Garment Adjustment State ----
+  let garmentScale = 1.0;
+  let garmentOffsetY = 0.0;
+  let garmentOpacity = 0.9;
+  let garmentBlendMode = 'multiply';
 
-// Dynamically inject Adjustment Sliders panel into the controls sidebar
-(function injectAdjustmentSliders() {
-    const target = document.querySelector('.controls-section') || document.getElementById('share-controls');
+  // Dynamically inject Adjustment Sliders panel into the controls sidebar
+  (function injectAdjustmentSliders() {
+    const target =
+      document.querySelector('.controls-section') ||
+      document.getElementById('share-controls');
     if (!target) return;
-    
+
     const panel = document.createElement('div');
     panel.id = 'garment-adjust-panel';
-    panel.style.cssText = 'background: rgba(255,255,255,0.06); padding: 15px; border-radius: 12px; border: 1px solid rgba(255,255,255,0.1); margin-top: 20px;';
+    panel.style.cssText =
+      'background: rgba(255,255,255,0.06); padding: 15px; border-radius: 12px; border: 1px solid rgba(255,255,255,0.1); margin-top: 20px;';
     panel.innerHTML = `
         <h4 style="margin: 0 0 10px 0; font-size: 13px; font-weight: 700; color: #088178; text-transform: uppercase; letter-spacing: 0.5px;">Garment Live Fitting</h4>
         <div style="margin-bottom: 8px;">
@@ -543,23 +649,24 @@ let garmentBlendMode = 'multiply';
     target.parentNode.insertBefore(panel, target.nextSibling);
 
     document.getElementById('adj-scale').addEventListener('input', (e) => {
-        garmentScale = parseFloat(e.target.value);
-        document.getElementById('val-scale').innerText = garmentScale.toFixed(2);
-        if (detectedLandmarks) renderFinalComposite();
+      garmentScale = parseFloat(e.target.value);
+      document.getElementById('val-scale').innerText = garmentScale.toFixed(2);
+      if (detectedLandmarks) renderFinalComposite();
     });
     document.getElementById('adj-offset').addEventListener('input', (e) => {
-        garmentOffsetY = parseFloat(e.target.value);
-        document.getElementById('val-offset').innerText = garmentOffsetY + 'px';
-        if (detectedLandmarks) renderFinalComposite();
+      garmentOffsetY = parseFloat(e.target.value);
+      document.getElementById('val-offset').innerText = garmentOffsetY + 'px';
+      if (detectedLandmarks) renderFinalComposite();
     });
     document.getElementById('adj-opacity').addEventListener('input', (e) => {
-        garmentOpacity = parseFloat(e.target.value);
-        document.getElementById('val-opacity').innerText = Math.round(garmentOpacity * 100) + '%';
-        if (detectedLandmarks) renderFinalComposite();
+      garmentOpacity = parseFloat(e.target.value);
+      document.getElementById('val-opacity').innerText =
+        Math.round(garmentOpacity * 100) + '%';
+      if (detectedLandmarks) renderFinalComposite();
     });
-})();
+  })();
 
-function overlayGarment(ctx, landmarks, canvasW, canvasH, garment) {
+  function overlayGarment(ctx, landmarks, canvasW, canvasH, garment) {
     const lShoulder = landmarks[11];
     const rShoulder = landmarks[12];
     const lHip = landmarks[23];
@@ -594,27 +701,28 @@ function overlayGarment(ctx, landmarks, canvasW, canvasH, garment) {
 
     // Dynamic blending layer for realistic folds and lighting shadows
     ctx.globalAlpha = garmentOpacity;
-    ctx.globalCompositeOperation = 'source-over'; 
+    ctx.globalCompositeOperation = 'source-over';
 
     ctx.drawImage(
-        garment,
-        -garmentWidth / 2,
-        -garmentHeight * 0.15,  // offset up for neckline
-        garmentWidth,
-        garmentHeight
+      garment,
+      -garmentWidth / 2,
+      -garmentHeight * 0.15, // offset up for neckline
+      garmentWidth,
+      garmentHeight
     );
 
     ctx.globalAlpha = 1.0;
     ctx.globalCompositeOperation = 'source-over';
     ctx.restore();
-};
+  }
 
-// ============================================
-// GENERATE TRY-ON
-// ============================================
-generateBtn.addEventListener('click', async () => {
+  // ============================================
+  // GENERATE TRY-ON
+  // ============================================
+  generateBtn.addEventListener('click', async () => {
     generateBtn.disabled = true;
-    generateBtn.innerHTML = '<i class="ri-loader-4-line ri-spin"></i> Processing...';
+    generateBtn.innerHTML =
+      '<i class="ri-loader-4-line ri-spin"></i> Processing...';
 
     scanner.style.display = 'flex';
     aiStatus.innerText = 'FITTING GARMENT TO BODY...';
@@ -624,29 +732,31 @@ generateBtn.addEventListener('click', async () => {
     const useExistingLandmarks = detectedLandmarks && hasPhoto;
 
     setTimeout(async () => {
-        try {
-            if (!useExistingLandmarks) {
-                await pose.send({ image: uploadedPreview });
-            }
-
-            // Now render the final composite
-            renderFinalComposite();
-
-        } catch (err) {
-            window.logError('Try-on error:', err);
-            aiStatus.innerText = 'ERROR';
-            setTimeout(() => resetTryOn(), 2000);
+      try {
+        if (!useExistingLandmarks) {
+          await pose.send({ image: uploadedPreview });
         }
-    }, 300);
-});
 
-function renderFinalComposite() {
+        // Now render the final composite
+        renderFinalComposite();
+      } catch (err) {
+        window.logError('Try-on error:', err);
+        aiStatus.innerText = 'ERROR';
+        setTimeout(() => resetTryOn(), 2000);
+      }
+    }, 300);
+  });
+
+  function renderFinalComposite() {
     if (!detectedLandmarks || !cleanedGarmentCanvas) {
-        aiStatus.innerText = 'MISSING DATA — SELECT OUTFIT & PHOTO';
-        setTimeout(() => { scanner.style.display = 'none'; }, 1500);
-        generateBtn.disabled = false;
-        generateBtn.innerHTML = '<i class="ri-sparkling-fill"></i> Generate AI Try-On';
-        return;
+      aiStatus.innerText = 'MISSING DATA — SELECT OUTFIT & PHOTO';
+      setTimeout(() => {
+        scanner.style.display = 'none';
+      }, 1500);
+      generateBtn.disabled = false;
+      generateBtn.innerHTML =
+        '<i class="ri-sparkling-fill"></i> Generate AI Try-On';
+      return;
     }
 
     const canvas = resultCanvas;
@@ -663,7 +773,13 @@ function renderFinalComposite() {
     ctx.drawImage(uploadedPreview, 0, 0, canvas.width, canvas.height);
 
     // Overlay cleaned garment
-    overlayGarment(ctx, detectedLandmarks, canvas.width, canvas.height, cleanedGarmentCanvas);
+    overlayGarment(
+      ctx,
+      detectedLandmarks,
+      canvas.width,
+      canvas.height,
+      cleanedGarmentCanvas
+    );
 
     // UI updates
     scanner.style.display = 'none';
@@ -673,30 +789,30 @@ function renderFinalComposite() {
 
     generateBtn.innerHTML = '<i class="ri-check-line"></i> Try-On Complete';
     generateBtn.style.background = '#10b991';
-}
+  }
 
-// ============================================
-// READY CHECK
-// ============================================
-function checkReady() {
+  // ============================================
+  // READY CHECK
+  // ============================================
+  function checkReady() {
     if (hasOutfit && hasPhoto) {
-        generateBtn.disabled = false;
+      generateBtn.disabled = false;
     }
-}
+  }
 
-// ============================================
-// STEP INDICATOR
-// ============================================
-function updateStep(step) {
+  // ============================================
+  // STEP INDICATOR
+  // ============================================
+  function updateStep(step) {
     document.getElementById('step1').classList.toggle('active', step >= 1);
     document.getElementById('step2').classList.toggle('active', step >= 2);
     document.getElementById('step3').classList.toggle('active', step >= 3);
-}
+  }
 
-// ============================================
-// RESET
-// ============================================
-function resetTryOn() {
+  // ============================================
+  // RESET
+  // ============================================
+  function resetTryOn() {
     resultCanvas.style.display = 'none';
     shareControls.style.display = 'none';
     bodyInfoEl.style.display = 'none';
@@ -711,81 +827,93 @@ function resetTryOn() {
 
     uploadText.innerText = 'Click to upload full-body photo';
     uploadInput.value = '';
-    document.querySelectorAll('.clothing-item').forEach(el => el.classList.remove('selected'));
+    document
+      .querySelectorAll('.clothing-item')
+      .forEach((el) => el.classList.remove('selected'));
 
     const ctx = resultCanvas.getContext('2d');
     ctx.clearRect(0, 0, resultCanvas.width, resultCanvas.height);
 
     generateBtn.disabled = true;
-    generateBtn.innerHTML = '<i class="ri-sparkling-fill"></i> Generate AI Try-On';
+    generateBtn.innerHTML =
+      '<i class="ri-sparkling-fill"></i> Generate AI Try-On';
     generateBtn.style.background = '';
 
     updateStep(1);
-}
+  }
 
-// ============================================
-// SHARE & DOWNLOAD
-// ============================================
-function downloadResult() {
+  // ============================================
+  // SHARE & DOWNLOAD
+  // ============================================
+  function downloadResult() {
     const link = document.createElement('a');
     link.download = 'cara-virtual-tryon.png';
     link.href = resultCanvas.toDataURL('image/png');
     link.click();
-}
+  }
 
-function shareResult() {
+  function shareResult() {
     if (navigator.share) {
-        resultCanvas.toBlob(blob => {
-            const file = new File([blob], 'cara-tryon.png', { type: 'image/png' });
-            navigator.share({
-                title: 'My Cara AI Look',
-                text: 'Check out my AI-generated outfit on Cara Fashion! #CaraVirtualTryOn',
-                files: [file]
-            }).catch(console.error);
-        });
+      resultCanvas.toBlob((blob) => {
+        const file = new File([blob], 'cara-tryon.png', { type: 'image/png' });
+        navigator
+          .share({
+            title: 'My Cara AI Look',
+            text: 'Check out my AI-generated outfit on Cara Fashion! #CaraVirtualTryOn',
+            files: [file],
+          })
+          .catch(console.error);
+      });
     } else {
-        // Fallback: download
-        downloadResult();
+      // Fallback: download
+      downloadResult();
     }
-}
+  }
 
-switchMode("camera");
-})
-const topBtn = document.getElementById("topBtn");
+  window.downloadResult = downloadResult;
+  window.shareResult = shareResult;
+  window.resetTryOn = resetTryOn;
 
-    // Show button when user scrolls down
-    window.onscroll = function () {
-      if (document.body.scrollTop > 200 || document.documentElement.scrollTop > 200) {
-        topBtn.style.display = "block";
-      } else {
-        topBtn.style.display = "none";
-      }
-    };
+  switchMode('camera');
+});
+const topBtn = document.getElementById('topBtn');
 
-    // Scroll to top smoothly
-    topBtn.addEventListener("click", function () {
+// Show button when user scrolls down
+window.onscroll = function () {
+  if (
+    document.body.scrollTop > 200 ||
+    document.documentElement.scrollTop > 200
+  ) {
+    topBtn.style.display = 'block';
+  } else {
+    topBtn.style.display = 'none';
+  }
+};
+
+// Scroll to top smoothly
+topBtn.addEventListener('click', function () {
   window.scrollTo({
     top: 0,
-    behavior: "smooth"
+    behavior: 'smooth',
   });
 });
 
-document.addEventListener("click", function (e) {
-    const btn = e.target.closest("#themeToggle, #themeToggleMobile");
-    if (!btn) return;
+document.addEventListener('click', function (e) {
+  const btn = e.target.closest('#themeToggle, #themeToggleMobile');
+  if (!btn) return;
 
-    const html = document.documentElement;
-    const current = html.getAttribute("data-theme") || "light";
-    const next = current === "dark" ? "light" : "dark";
+  const html = document.documentElement;
+  const current = html.getAttribute('data-theme') || 'light';
+  const next = current === 'dark' ? 'light' : 'dark';
 
-    html.setAttribute("data-theme", next);
-    localStorage.setItem("theme", next);
+  html.setAttribute('data-theme', next);
+  localStorage.setItem('theme', next);
 
-    var icon = document.getElementById("themeIcon");
-    var iconM = document.getElementById("themeIconMobile");
-    var cls = next === "dark" ? "ri-sun-line" : "ri-moon-line";
-    if (icon) icon.className = cls;
-    if (iconM) iconM.className = cls;
+  var icon = document.getElementById('themeIcon');
+  var iconM = document.getElementById('themeIconMobile');
+  var cls = next === 'dark' ? 'ri-sun-line' : 'ri-moon-line';
+  if (icon) icon.className = cls;
+  if (iconM) iconM.className = cls;
 });
 
 // Scaling calculation formulas rendering overlay models over uploaded targets.


### PR DESCRIPTION
# Pull Request

## Related Issue
Closes #2678

---

## Type of Change
- [x] 🐛 Bug fix — non-breaking change that resolves a reported issue
- [x] 🎨 UI / UX improvement — visual or interaction polish

---

## Summary
Fixed a critical bug on the Virtual Try-On page (`try-on.html`) where clicking "Download", "Share", or "Retry" raised a `ReferenceError` because the callback functions were block-scoped inside the DOMContentLoaded listener.

---

## Changes Made
- **[try-on.js](file:///d:/Cara-main/Cara-main/try-on.js)**: Exposed `downloadResult`, `shareResult`, and `resetTryOn` on the `window` object. Refactored the camera and mode handlers into named function declarations to resolve scoping and definition order conflicts.

---

## Testing

### How to Test Locally
1. Navigate to the Virtual Try-On page (`try-on.html`).
2. Generate an AI try-on fit by taking a photo or uploading one.
3. Click "Download", "Share", or "Retry". Verify the action completes without raising console errors.

### Test Coverage
- [x] I verified manually in Chrome (desktop)
- [x] I ran `npm run lint` and all files pass clean (0 errors)
- [x] All 39 existing unit tests pass
