### PR TITLE
feat: add Recently Viewed Products section

### DIFF
--- a/js/recently-viewed.js
+++ b/js/recently-viewed.js
@@ -1,0 +1,303 @@
+/**
+ * Recently Viewed Products
+ * ------------------------
+ * Persists a capped, de-duplicated, most-recent-first list of products the
+ * user has opened on singleProduct.html into localStorage, and renders a
+ * horizontal "Recently Viewed" carousel on singleProduct.html and shop.html.
+ *
+ * Storage shape (localStorage key: "recentlyViewed"):
+ *   [{ id, name, price, image }, ...]   // newest first, max 6 items
+ *
+ * Exposed on window.RecentlyViewed for reuse/testing:
+ *   - STORAGE_KEY, MAX_ITEMS
+ *   - getRecentlyViewed()
+ *   - addRecentlyViewed(product)
+ *   - renderRecentlyViewed(options)
+ */
+(function (root) {
+  'use strict';
+
+  var STORAGE_KEY = 'recentlyViewed';
+  var MAX_ITEMS = 6;
+
+  function safeParseList(raw) {
+    if (!raw) return [];
+    try {
+      var parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch (e) {
+      return [];
+    }
+  }
+
+  function getRecentlyViewed() {
+    try {
+      return safeParseList(localStorage.getItem(STORAGE_KEY));
+    } catch (e) {
+      return [];
+    }
+  }
+
+  function saveRecentlyViewed(list) {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+      return true;
+    } catch (e) {
+      if (typeof root.logError === 'function') {
+        root.logError('Failed to save recently viewed products:', e);
+      }
+      return false;
+    }
+  }
+
+  /**
+   * Adds/moves a product to the front of the recently-viewed list.
+   * De-dupes by id when both entries have one, otherwise falls back to name.
+   * product: { id, name, price, image }
+   */
+  function addRecentlyViewed(product) {
+    if (!product || !product.name) return getRecentlyViewed();
+
+    var entry = {
+      id: product.id != null ? product.id : null,
+      name: product.name,
+      price: product.price != null ? product.price : null,
+      image: product.image || '',
+    };
+
+    var list = getRecentlyViewed().filter(function (item) {
+      var sameId = entry.id != null && item.id != null && item.id === entry.id;
+      var sameName = item.name === entry.name;
+      return !(sameId || (entry.id == null && sameName));
+    });
+
+    list.unshift(entry);
+    if (list.length > MAX_ITEMS) list = list.slice(0, MAX_ITEMS);
+
+    saveRecentlyViewed(list);
+    return list;
+  }
+
+  function formatPrice(price) {
+    if (typeof root.formatCurrency === 'function') {
+      return root.formatCurrency(price);
+    }
+    if (typeof price === 'number' && isFinite(price)) {
+      return '\u20B9' + Math.round(price).toLocaleString('en-IN');
+    }
+    return price ? String(price) : '';
+  }
+
+  function goToProduct(name) {
+    try {
+      localStorage.setItem('selectedProductId', name);
+    } catch (e) {
+      /* ignore storage errors, navigation still works */
+    }
+    root.location.href = 'singleProduct.html';
+  }
+
+  function buildCard(item, doc) {
+    var card = doc.createElement('div');
+    card.className = 'recently-viewed-card';
+    card.setAttribute('role', 'button');
+    card.setAttribute('tabindex', '0');
+    card.setAttribute('aria-label', 'View ' + item.name);
+
+    card.addEventListener('click', function () {
+      goToProduct(item.name);
+    });
+    card.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        goToProduct(item.name);
+      }
+    });
+
+    var imgWrap = doc.createElement('div');
+    imgWrap.className = 'pro-img-wrap';
+    var img = doc.createElement('img');
+    img.src = item.image || 'images/products/f1.jpg';
+    img.alt = item.name;
+    img.loading = 'lazy';
+    imgWrap.appendChild(img);
+    card.appendChild(imgWrap);
+
+    var des = doc.createElement('div');
+    des.className = 'des';
+
+    var name = doc.createElement('h5');
+    name.textContent = item.name;
+    des.appendChild(name);
+
+    var price = doc.createElement('h4');
+    price.textContent = formatPrice(item.price);
+    des.appendChild(price);
+
+    card.appendChild(des);
+    return card;
+  }
+
+  /**
+   * Renders the recently-viewed carousel into `containerId`.
+   * Hides `sectionId` entirely when the (filtered) list is empty.
+   * options: { containerId, sectionId, excludeId, excludeName, doc }
+   */
+  function renderRecentlyViewed(options) {
+    options = options || {};
+    var doc = options.doc || document;
+    var container = doc.getElementById(options.containerId);
+    if (!container) return [];
+
+    var section = options.sectionId
+      ? doc.getElementById(options.sectionId)
+      : null;
+
+    var list = getRecentlyViewed().filter(function (item) {
+      if (options.excludeId != null) return item.id !== options.excludeId;
+      if (options.excludeName) return item.name !== options.excludeName;
+      return true;
+    });
+
+    container.innerHTML = '';
+
+    if (list.length === 0) {
+      if (section) section.hidden = true;
+      return list;
+    }
+
+    if (section) section.hidden = false;
+    list.forEach(function (item) {
+      container.appendChild(buildCard(item, doc));
+    });
+
+    return list;
+  }
+
+  // ---- Page wiring -------------------------------------------------
+
+  function getStaticProductByName(name) {
+    var list =
+      typeof products !== 'undefined' && Array.isArray(products) // eslint-disable-line no-undef
+        ? products // eslint-disable-line no-undef
+        : Array.isArray(root.products)
+          ? root.products
+          : [];
+    var match = list.filter(function (p) {
+      return p.name === name;
+    })[0];
+    return match
+      ? { id: match.id, name: match.name, price: match.price, image: match.img }
+      : null;
+  }
+
+  function readCurrentProductFromDom(doc) {
+    var nameEl = doc.getElementById('product-name');
+    var imgEl = doc.getElementById('MainImg');
+    var name = nameEl ? nameEl.textContent.trim() : '';
+    if (!name || name === 'Unable to load product') return null;
+    return {
+      id: null,
+      name: name,
+      price: doc.getElementById('product-price')
+        ? doc.getElementById('product-price').textContent.trim()
+        : null,
+      image: imgEl ? imgEl.getAttribute('src') : '',
+    };
+  }
+
+  function resolveSelectedProductName() {
+    try {
+      var id = localStorage.getItem('selectedProductId');
+      if (id) return id;
+      var legacy = JSON.parse(localStorage.getItem('selectedProduct') || '{}');
+      return legacy.name || null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  async function fetchProductByName(name) {
+    try {
+      var res = await root.fetch('/api/products');
+      if (res && res.ok) {
+        var list = await res.json();
+        var match = list.filter(function (p) {
+          return p.name === name;
+        })[0];
+        if (match) {
+          return {
+            id: match.id,
+            name: match.name,
+            price: match.price,
+            image: match.img,
+          };
+        }
+      }
+    } catch (e) {
+      /* backend unavailable, caller will fall back to static data */
+    }
+    return null;
+  }
+
+  async function initSingleProductPage() {
+    var name = resolveSelectedProductName();
+    var current = null;
+
+    if (name) {
+      current = await fetchProductByName(name);
+      if (!current) current = getStaticProductByName(name);
+    }
+
+    // Backend/static lookups can miss (e.g. name mismatch); fall back to
+    // whatever ended up rendered on the page after app.js ran.
+    if (!current) {
+      for (var attempt = 0; attempt < 5 && !current; attempt++) {
+        current = readCurrentProductFromDom(document);
+        if (!current) {
+          await new Promise(function (resolve) {
+            root.setTimeout(resolve, 150);
+          });
+        }
+      }
+    }
+
+    if (current) {
+      addRecentlyViewed(current);
+    }
+
+    renderRecentlyViewed({
+      containerId: 'recently-viewed-container',
+      sectionId: 'recently-viewed-section',
+      excludeId: current && current.id != null ? current.id : undefined,
+      excludeName: current && current.id == null ? current.name : undefined,
+    });
+  }
+
+  function initShopPage() {
+    renderRecentlyViewed({
+      containerId: 'recently-viewed-container',
+      sectionId: 'recently-viewed-section',
+    });
+  }
+
+  if (typeof document !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', function () {
+      if (!document.getElementById('recently-viewed-container')) return;
+
+      if (root.location.pathname.indexOf('singleProduct') !== -1) {
+        initSingleProductPage();
+      } else {
+        initShopPage();
+      }
+    });
+  }
+
+  root.RecentlyViewed = {
+    STORAGE_KEY: STORAGE_KEY,
+    MAX_ITEMS: MAX_ITEMS,
+    getRecentlyViewed: getRecentlyViewed,
+    addRecentlyViewed: addRecentlyViewed,
+    renderRecentlyViewed: renderRecentlyViewed,
+  };
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/products.js
+++ b/products.js
@@ -1,7 +1,6 @@
 /* Reusable modal display element */
 const modalTemplate = `<div class="quick-view-modal" style="display:none;"></div>`;
-/* Reusable modal display element */
-const modalTemplate = `<div class="quick-view-modal" style="display:none;"></div>`;
+
 const products = [
   {
     id: 1,

--- a/recently-viewed.css
+++ b/recently-viewed.css
@@ -3,109 +3,111 @@
    ============================================================ */
 
 #recently-viewed-section {
-    text-align: center;
+  text-align: center;
 }
 
 #recently-viewed-section[hidden] {
-    display: none;
+  display: none;
 }
 
 #recently-viewed-section h2 {
-    font-size: 32px;
-    line-height: 1.2;
-    margin-bottom: 6px;
+  font-size: 32px;
+  line-height: 1.2;
+  margin-bottom: 6px;
 }
 
 #recently-viewed-section .recently-viewed-subtext {
-    color: #666;
-    margin-bottom: 10px;
-    font-size: 15px;
+  color: #666;
+  margin-bottom: 10px;
+  font-size: 15px;
 }
 
-[data-theme="dark"] #recently-viewed-section .recently-viewed-subtext {
-    color: #aaa;
+[data-theme='dark'] #recently-viewed-section .recently-viewed-subtext {
+  color: #aaa;
 }
 
 .recently-viewed-track {
-    display: flex;
-    gap: 20px;
-    overflow-x: auto;
-    scroll-behavior: smooth;
-    padding: 15px 80px 25px;
-    -webkit-overflow-scrolling: touch;
-    scrollbar-width: thin;
-    scrollbar-color: var(--accent, #088178) transparent;
+  display: flex;
+  gap: 20px;
+  overflow-x: auto;
+  scroll-behavior: smooth;
+  padding: 15px 80px 25px;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: thin;
+  scrollbar-color: var(--accent, #088178) transparent;
 }
 
 .recently-viewed-track::-webkit-scrollbar {
-    height: 8px;
+  height: 8px;
 }
 
 .recently-viewed-track::-webkit-scrollbar-track {
-    background: transparent;
+  background: transparent;
 }
 
 .recently-viewed-track::-webkit-scrollbar-thumb {
-    background: var(--accent, #088178);
-    border-radius: 10px;
+  background: var(--accent, #088178);
+  border-radius: 10px;
 }
 
 .recently-viewed-card {
-    position: relative;
-    flex: 0 0 220px;
-    max-width: 220px;
-    text-align: left;
-    cursor: pointer;
-    padding: 12px 12px 14px;
-    border: 1.5px solid var(--border-color, #e5e5e5);
-    border-radius: 16px;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
-    background-color: var(--card-bg, #fff);
-    transition: box-shadow 0.3s ease, transform 0.25s ease;
+  position: relative;
+  flex: 0 0 220px;
+  max-width: 220px;
+  text-align: left;
+  cursor: pointer;
+  padding: 12px 12px 14px;
+  border: 1.5px solid var(--border-color, #e5e5e5);
+  border-radius: 16px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
+  background-color: var(--card-bg, #fff);
+  transition:
+    box-shadow 0.3s ease,
+    transform 0.25s ease;
 }
 
 .recently-viewed-card:hover {
-    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.12);
-    transform: translateY(-3px);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.12);
+  transform: translateY(-3px);
 }
 
 .recently-viewed-card:hover .pro-img-wrap img {
-    transform: scale(1.04);
+  transform: scale(1.04);
 }
 
 .recently-viewed-card:focus-visible {
-    outline: 2px solid var(--accent, #088178);
-    outline-offset: 4px;
+  outline: 2px solid var(--accent, #088178);
+  outline-offset: 4px;
 }
 
 .recently-viewed-card .pro-img-wrap {
-    margin-bottom: 8px;
+  margin-bottom: 8px;
 }
 
 .recently-viewed-card .des h5 {
-    font-size: 15px;
-    font-weight: 600;
-    margin: 4px 0;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    color: var(--text-primary, #1a1a1a);
+  font-size: 15px;
+  font-weight: 600;
+  margin: 4px 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text-primary, #1a1a1a);
 }
 
 .recently-viewed-card .des h4 {
-    font-size: 16px;
-    color: var(--accent, #088178);
-    font-weight: 700;
-    margin: 0;
+  font-size: 16px;
+  color: var(--accent, #088178);
+  font-weight: 700;
+  margin: 0;
 }
 
 @media (max-width: 900px) {
-    .recently-viewed-track {
-        padding: 10px 18px 20px;
-    }
+  .recently-viewed-track {
+    padding: 10px 18px 20px;
+  }
 
-    .recently-viewed-card {
-        flex: 0 0 160px;
-        max-width: 160px;
-    }
+  .recently-viewed-card {
+    flex: 0 0 160px;
+    max-width: 160px;
+  }
 }

--- a/recently-viewed.css
+++ b/recently-viewed.css
@@ -1,0 +1,111 @@
+/* ============================================================
+   Recently Viewed Products
+   ============================================================ */
+
+#recently-viewed-section {
+    text-align: center;
+}
+
+#recently-viewed-section[hidden] {
+    display: none;
+}
+
+#recently-viewed-section h2 {
+    font-size: 32px;
+    line-height: 1.2;
+    margin-bottom: 6px;
+}
+
+#recently-viewed-section .recently-viewed-subtext {
+    color: #666;
+    margin-bottom: 10px;
+    font-size: 15px;
+}
+
+[data-theme="dark"] #recently-viewed-section .recently-viewed-subtext {
+    color: #aaa;
+}
+
+.recently-viewed-track {
+    display: flex;
+    gap: 20px;
+    overflow-x: auto;
+    scroll-behavior: smooth;
+    padding: 15px 80px 25px;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
+    scrollbar-color: var(--accent, #088178) transparent;
+}
+
+.recently-viewed-track::-webkit-scrollbar {
+    height: 8px;
+}
+
+.recently-viewed-track::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.recently-viewed-track::-webkit-scrollbar-thumb {
+    background: var(--accent, #088178);
+    border-radius: 10px;
+}
+
+.recently-viewed-card {
+    position: relative;
+    flex: 0 0 220px;
+    max-width: 220px;
+    text-align: left;
+    cursor: pointer;
+    padding: 12px 12px 14px;
+    border: 1.5px solid var(--border-color, #e5e5e5);
+    border-radius: 16px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
+    background-color: var(--card-bg, #fff);
+    transition: box-shadow 0.3s ease, transform 0.25s ease;
+}
+
+.recently-viewed-card:hover {
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.12);
+    transform: translateY(-3px);
+}
+
+.recently-viewed-card:hover .pro-img-wrap img {
+    transform: scale(1.04);
+}
+
+.recently-viewed-card:focus-visible {
+    outline: 2px solid var(--accent, #088178);
+    outline-offset: 4px;
+}
+
+.recently-viewed-card .pro-img-wrap {
+    margin-bottom: 8px;
+}
+
+.recently-viewed-card .des h5 {
+    font-size: 15px;
+    font-weight: 600;
+    margin: 4px 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: var(--text-primary, #1a1a1a);
+}
+
+.recently-viewed-card .des h4 {
+    font-size: 16px;
+    color: var(--accent, #088178);
+    font-weight: 700;
+    margin: 0;
+}
+
+@media (max-width: 900px) {
+    .recently-viewed-track {
+        padding: 10px 18px 20px;
+    }
+
+    .recently-viewed-card {
+        flex: 0 0 160px;
+        max-width: 160px;
+    }
+}

--- a/shop.html
+++ b/shop.html
@@ -44,6 +44,7 @@
     <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="ui-fix.css" />
     <link rel="stylesheet" href="shop.css" />
+    <link rel="stylesheet" href="recently-viewed.css" />
     <link href="https://cdn.jsdelivr.net/npm/remixicon@4.5.0/fonts/remixicon.css" rel="stylesheet" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css" integrity="sha512-Kc323vGBEqzTmouAECnVceyQqyqdsSiqLQISBL29aUW4U/M7pSPA/gEUZQqv1cwx4OnYxTxve5UMg5GT6L4JJg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="manifest" href="/manifest.json">
@@ -236,6 +237,13 @@
       <div class="pro-container" id="shop-container"></div>
     </section>
 
+    <!-- Recently Viewed Products (hidden automatically when the list is empty) -->
+    <section id="recently-viewed-section" class="section-p1" hidden>
+      <h2>Recently Viewed</h2>
+      <p class="recently-viewed-subtext">Pick up where you left off</p>
+      <div class="recently-viewed-track" id="recently-viewed-container"></div>
+    </section>
+
     <section id="newsletter" class="section-p1">
       <div class="newstext">
         <h4>Sign Up For Newsletters</h4>
@@ -418,6 +426,7 @@ if (btn) {
 </script>
    <button id="backToTop">â†‘</button>
   <script src="js/shimmer-loader.js" defer></script>
+  <script src="js/recently-viewed.js"></script>
 </body>
 </html>
 

--- a/singleProduct.html
+++ b/singleProduct.html
@@ -44,6 +44,7 @@
   <link rel="stylesheet" href="ui-fix.css" />
   <link rel="stylesheet" href="singleProduct.css" />
   <link rel="stylesheet" href="reviews.css" />
+  <link rel="stylesheet" href="recently-viewed.css" />
   <link href="https://cdn.jsdelivr.net/npm/remixicon@4.5.0/fonts/remixicon.css" rel="stylesheet" />
 
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css"
@@ -268,6 +269,13 @@
     <!--   -->
   </section>
 
+  <!-- Recently Viewed Products (hidden automatically when the list is empty) -->
+  <section id="recently-viewed-section" class="section-p1" hidden>
+    <h2>Recently Viewed</h2>
+    <p class="recently-viewed-subtext">Pick up where you left off</p>
+    <div class="recently-viewed-track" id="recently-viewed-container"></div>
+  </section>
+
   <!-- Footer -->
   <footer class="section-p1">
     <!-- Contact Column -->
@@ -430,6 +438,7 @@
   </script>
 <script src="js/reviews.js"></script>
 <script src="js/image-zoom.js" defer></script>
+<script src="js/recently-viewed.js"></script>
 </body>
 <script src="singleProduct.js"></script>
 <script src="js/stock-simulator.js" defer></script>

--- a/tests/unit/recently-viewed.test.js
+++ b/tests/unit/recently-viewed.test.js
@@ -11,146 +11,164 @@ import '../../js/recently-viewed.js';
 const RecentlyViewed = window.RecentlyViewed;
 
 beforeEach(() => {
-    localStorage.clear();
-    document.body.innerHTML = '';
-    expect(RecentlyViewed).toBeTruthy();
+  localStorage.clear();
+  document.body.innerHTML = '';
+  expect(RecentlyViewed).toBeTruthy();
 });
 
 function product(overrides) {
-    return {
-        id: 1,
-        name: 'Tropical Hibiscus Summer Shirt',
-        price: 2499,
-        image: 'images/products/f1.jpg',
-        ...overrides,
-    };
+  return {
+    id: 1,
+    name: 'Tropical Hibiscus Summer Shirt',
+    price: 2499,
+    image: 'images/products/f1.jpg',
+    ...overrides,
+  };
 }
 
 describe('addRecentlyViewed', () => {
-    it('adds a product to the front of an empty list', () => {
-        const list = RecentlyViewed.addRecentlyViewed(product());
-        expect(list).toHaveLength(1);
-        expect(list[0]).toMatchObject({ id: 1, name: 'Tropical Hibiscus Summer Shirt' });
+  it('adds a product to the front of an empty list', () => {
+    const list = RecentlyViewed.addRecentlyViewed(product());
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({
+      id: 1,
+      name: 'Tropical Hibiscus Summer Shirt',
     });
+  });
 
-    it('persists the list to localStorage', () => {
-        RecentlyViewed.addRecentlyViewed(product());
-        const stored = JSON.parse(localStorage.getItem(RecentlyViewed.STORAGE_KEY));
-        expect(stored).toHaveLength(1);
-        expect(stored[0].name).toBe('Tropical Hibiscus Summer Shirt');
+  it('persists the list to localStorage', () => {
+    RecentlyViewed.addRecentlyViewed(product());
+    const stored = JSON.parse(localStorage.getItem(RecentlyViewed.STORAGE_KEY));
+    expect(stored).toHaveLength(1);
+    expect(stored[0].name).toBe('Tropical Hibiscus Summer Shirt');
+  });
+
+  it('moves a re-viewed product to the front instead of duplicating it (dedupe by id)', () => {
+    RecentlyViewed.addRecentlyViewed(product({ id: 1, name: 'A' }));
+    RecentlyViewed.addRecentlyViewed(product({ id: 2, name: 'B' }));
+    const list = RecentlyViewed.addRecentlyViewed(
+      product({ id: 1, name: 'A' })
+    );
+
+    expect(list).toHaveLength(2);
+    expect(list[0].name).toBe('A');
+    expect(list[1].name).toBe('B');
+  });
+
+  it('dedupes by name when no id is available', () => {
+    RecentlyViewed.addRecentlyViewed({
+      id: null,
+      name: 'No Id Product',
+      price: 100,
+      image: 'x.jpg',
     });
-
-    it('moves a re-viewed product to the front instead of duplicating it (dedupe by id)', () => {
-        RecentlyViewed.addRecentlyViewed(product({ id: 1, name: 'A' }));
-        RecentlyViewed.addRecentlyViewed(product({ id: 2, name: 'B' }));
-        const list = RecentlyViewed.addRecentlyViewed(product({ id: 1, name: 'A' }));
-
-        expect(list).toHaveLength(2);
-        expect(list[0].name).toBe('A');
-        expect(list[1].name).toBe('B');
+    const list = RecentlyViewed.addRecentlyViewed({
+      id: null,
+      name: 'No Id Product',
+      price: 100,
+      image: 'x.jpg',
     });
+    expect(list).toHaveLength(1);
+  });
 
-    it('dedupes by name when no id is available', () => {
-        RecentlyViewed.addRecentlyViewed({ id: null, name: 'No Id Product', price: 100, image: 'x.jpg' });
-        const list = RecentlyViewed.addRecentlyViewed({
-            id: null,
-            name: 'No Id Product',
-            price: 100,
-            image: 'x.jpg',
-        });
-        expect(list).toHaveLength(1);
-    });
+  it('caps the list at MAX_ITEMS, dropping the oldest entries', () => {
+    for (let i = 1; i <= RecentlyViewed.MAX_ITEMS + 3; i++) {
+      RecentlyViewed.addRecentlyViewed(
+        product({ id: i, name: `Product ${i}` })
+      );
+    }
+    const list = RecentlyViewed.getRecentlyViewed();
+    expect(list).toHaveLength(RecentlyViewed.MAX_ITEMS);
+    expect(list[0].name).toBe(`Product ${RecentlyViewed.MAX_ITEMS + 3}`);
+  });
 
-    it('caps the list at MAX_ITEMS, dropping the oldest entries', () => {
-        for (let i = 1; i <= RecentlyViewed.MAX_ITEMS + 3; i++) {
-            RecentlyViewed.addRecentlyViewed(product({ id: i, name: `Product ${i}` }));
-        }
-        const list = RecentlyViewed.getRecentlyViewed();
-        expect(list).toHaveLength(RecentlyViewed.MAX_ITEMS);
-        expect(list[0].name).toBe(`Product ${RecentlyViewed.MAX_ITEMS + 3}`);
-    });
-
-    it('ignores invalid input without throwing', () => {
-        expect(() => RecentlyViewed.addRecentlyViewed(null)).not.toThrow();
-        expect(() => RecentlyViewed.addRecentlyViewed({})).not.toThrow();
-        expect(RecentlyViewed.getRecentlyViewed()).toHaveLength(0);
-    });
+  it('ignores invalid input without throwing', () => {
+    expect(() => RecentlyViewed.addRecentlyViewed(null)).not.toThrow();
+    expect(() => RecentlyViewed.addRecentlyViewed({})).not.toThrow();
+    expect(RecentlyViewed.getRecentlyViewed()).toHaveLength(0);
+  });
 });
 
 describe('renderRecentlyViewed', () => {
-    function setUpDom() {
-        document.body.innerHTML = `
+  function setUpDom() {
+    document.body.innerHTML = `
             <section id="recently-viewed-section" hidden>
                 <div id="recently-viewed-container"></div>
             </section>
         `;
-    }
+  }
 
-    it('hides the section when there is nothing to show', () => {
-        setUpDom();
-        RecentlyViewed.renderRecentlyViewed({
-            containerId: 'recently-viewed-container',
-            sectionId: 'recently-viewed-section',
-        });
-
-        const section = document.getElementById('recently-viewed-section');
-        expect(section.hidden).toBe(true);
-        expect(document.getElementById('recently-viewed-container').children).toHaveLength(0);
+  it('hides the section when there is nothing to show', () => {
+    setUpDom();
+    RecentlyViewed.renderRecentlyViewed({
+      containerId: 'recently-viewed-container',
+      sectionId: 'recently-viewed-section',
     });
 
-    it('reveals the section and renders a card per stored product', () => {
-        setUpDom();
-        RecentlyViewed.addRecentlyViewed(product({ id: 1, name: 'A' }));
-        RecentlyViewed.addRecentlyViewed(product({ id: 2, name: 'B' }));
+    const section = document.getElementById('recently-viewed-section');
+    expect(section.hidden).toBe(true);
+    expect(
+      document.getElementById('recently-viewed-container').children
+    ).toHaveLength(0);
+  });
 
-        RecentlyViewed.renderRecentlyViewed({
-            containerId: 'recently-viewed-container',
-            sectionId: 'recently-viewed-section',
-        });
+  it('reveals the section and renders a card per stored product', () => {
+    setUpDom();
+    RecentlyViewed.addRecentlyViewed(product({ id: 1, name: 'A' }));
+    RecentlyViewed.addRecentlyViewed(product({ id: 2, name: 'B' }));
 
-        const section = document.getElementById('recently-viewed-section');
-        const cards = document.getElementById('recently-viewed-container').children;
-        expect(section.hidden).toBe(false);
-        expect(cards).toHaveLength(2);
-        expect(cards[0].getAttribute('aria-label')).toBe('View B');
+    RecentlyViewed.renderRecentlyViewed({
+      containerId: 'recently-viewed-container',
+      sectionId: 'recently-viewed-section',
     });
 
-    it('excludes the currently viewed product by id', () => {
-        setUpDom();
-        RecentlyViewed.addRecentlyViewed(product({ id: 1, name: 'A' }));
-        RecentlyViewed.addRecentlyViewed(product({ id: 2, name: 'B' }));
+    const section = document.getElementById('recently-viewed-section');
+    const cards = document.getElementById('recently-viewed-container').children;
+    expect(section.hidden).toBe(false);
+    expect(cards).toHaveLength(2);
+    expect(cards[0].getAttribute('aria-label')).toBe('View B');
+  });
 
-        const list = RecentlyViewed.renderRecentlyViewed({
-            containerId: 'recently-viewed-container',
-            sectionId: 'recently-viewed-section',
-            excludeId: 2,
-        });
+  it('excludes the currently viewed product by id', () => {
+    setUpDom();
+    RecentlyViewed.addRecentlyViewed(product({ id: 1, name: 'A' }));
+    RecentlyViewed.addRecentlyViewed(product({ id: 2, name: 'B' }));
 
-        expect(list).toHaveLength(1);
-        expect(list[0].name).toBe('A');
-        expect(document.getElementById('recently-viewed-container').children).toHaveLength(1);
+    const list = RecentlyViewed.renderRecentlyViewed({
+      containerId: 'recently-viewed-container',
+      sectionId: 'recently-viewed-section',
+      excludeId: 2,
     });
 
-    it('re-hides the section if excluding the only item empties the list', () => {
-        setUpDom();
-        RecentlyViewed.addRecentlyViewed(product({ id: 1, name: 'Only Product' }));
+    expect(list).toHaveLength(1);
+    expect(list[0].name).toBe('A');
+    expect(
+      document.getElementById('recently-viewed-container').children
+    ).toHaveLength(1);
+  });
 
-        RecentlyViewed.renderRecentlyViewed({
-            containerId: 'recently-viewed-container',
-            sectionId: 'recently-viewed-section',
-            excludeId: 1,
-        });
+  it('re-hides the section if excluding the only item empties the list', () => {
+    setUpDom();
+    RecentlyViewed.addRecentlyViewed(product({ id: 1, name: 'Only Product' }));
 
-        expect(document.getElementById('recently-viewed-section').hidden).toBe(true);
+    RecentlyViewed.renderRecentlyViewed({
+      containerId: 'recently-viewed-container',
+      sectionId: 'recently-viewed-section',
+      excludeId: 1,
     });
 
-    it('does nothing when the container is missing from the DOM', () => {
-        document.body.innerHTML = '';
-        expect(() =>
-            RecentlyViewed.renderRecentlyViewed({
-                containerId: 'does-not-exist',
-                sectionId: 'also-missing',
-            })
-        ).not.toThrow();
-    });
+    expect(document.getElementById('recently-viewed-section').hidden).toBe(
+      true
+    );
+  });
+
+  it('does nothing when the container is missing from the DOM', () => {
+    document.body.innerHTML = '';
+    expect(() =>
+      RecentlyViewed.renderRecentlyViewed({
+        containerId: 'does-not-exist',
+        sectionId: 'also-missing',
+      })
+    ).not.toThrow();
+  });
 });

--- a/tests/unit/recently-viewed.test.js
+++ b/tests/unit/recently-viewed.test.js
@@ -1,0 +1,156 @@
+/**
+ * Unit tests for the Recently Viewed Products feature (js/recently-viewed.js).
+ *
+ * Loads the real source module (vitest's jsdom environment provides
+ * `window`, `document`, and `localStorage` as ambient globals) and exercises
+ * the public API exposed on `window.RecentlyViewed`.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import '../../js/recently-viewed.js';
+
+const RecentlyViewed = window.RecentlyViewed;
+
+beforeEach(() => {
+    localStorage.clear();
+    document.body.innerHTML = '';
+    expect(RecentlyViewed).toBeTruthy();
+});
+
+function product(overrides) {
+    return {
+        id: 1,
+        name: 'Tropical Hibiscus Summer Shirt',
+        price: 2499,
+        image: 'images/products/f1.jpg',
+        ...overrides,
+    };
+}
+
+describe('addRecentlyViewed', () => {
+    it('adds a product to the front of an empty list', () => {
+        const list = RecentlyViewed.addRecentlyViewed(product());
+        expect(list).toHaveLength(1);
+        expect(list[0]).toMatchObject({ id: 1, name: 'Tropical Hibiscus Summer Shirt' });
+    });
+
+    it('persists the list to localStorage', () => {
+        RecentlyViewed.addRecentlyViewed(product());
+        const stored = JSON.parse(localStorage.getItem(RecentlyViewed.STORAGE_KEY));
+        expect(stored).toHaveLength(1);
+        expect(stored[0].name).toBe('Tropical Hibiscus Summer Shirt');
+    });
+
+    it('moves a re-viewed product to the front instead of duplicating it (dedupe by id)', () => {
+        RecentlyViewed.addRecentlyViewed(product({ id: 1, name: 'A' }));
+        RecentlyViewed.addRecentlyViewed(product({ id: 2, name: 'B' }));
+        const list = RecentlyViewed.addRecentlyViewed(product({ id: 1, name: 'A' }));
+
+        expect(list).toHaveLength(2);
+        expect(list[0].name).toBe('A');
+        expect(list[1].name).toBe('B');
+    });
+
+    it('dedupes by name when no id is available', () => {
+        RecentlyViewed.addRecentlyViewed({ id: null, name: 'No Id Product', price: 100, image: 'x.jpg' });
+        const list = RecentlyViewed.addRecentlyViewed({
+            id: null,
+            name: 'No Id Product',
+            price: 100,
+            image: 'x.jpg',
+        });
+        expect(list).toHaveLength(1);
+    });
+
+    it('caps the list at MAX_ITEMS, dropping the oldest entries', () => {
+        for (let i = 1; i <= RecentlyViewed.MAX_ITEMS + 3; i++) {
+            RecentlyViewed.addRecentlyViewed(product({ id: i, name: `Product ${i}` }));
+        }
+        const list = RecentlyViewed.getRecentlyViewed();
+        expect(list).toHaveLength(RecentlyViewed.MAX_ITEMS);
+        expect(list[0].name).toBe(`Product ${RecentlyViewed.MAX_ITEMS + 3}`);
+    });
+
+    it('ignores invalid input without throwing', () => {
+        expect(() => RecentlyViewed.addRecentlyViewed(null)).not.toThrow();
+        expect(() => RecentlyViewed.addRecentlyViewed({})).not.toThrow();
+        expect(RecentlyViewed.getRecentlyViewed()).toHaveLength(0);
+    });
+});
+
+describe('renderRecentlyViewed', () => {
+    function setUpDom() {
+        document.body.innerHTML = `
+            <section id="recently-viewed-section" hidden>
+                <div id="recently-viewed-container"></div>
+            </section>
+        `;
+    }
+
+    it('hides the section when there is nothing to show', () => {
+        setUpDom();
+        RecentlyViewed.renderRecentlyViewed({
+            containerId: 'recently-viewed-container',
+            sectionId: 'recently-viewed-section',
+        });
+
+        const section = document.getElementById('recently-viewed-section');
+        expect(section.hidden).toBe(true);
+        expect(document.getElementById('recently-viewed-container').children).toHaveLength(0);
+    });
+
+    it('reveals the section and renders a card per stored product', () => {
+        setUpDom();
+        RecentlyViewed.addRecentlyViewed(product({ id: 1, name: 'A' }));
+        RecentlyViewed.addRecentlyViewed(product({ id: 2, name: 'B' }));
+
+        RecentlyViewed.renderRecentlyViewed({
+            containerId: 'recently-viewed-container',
+            sectionId: 'recently-viewed-section',
+        });
+
+        const section = document.getElementById('recently-viewed-section');
+        const cards = document.getElementById('recently-viewed-container').children;
+        expect(section.hidden).toBe(false);
+        expect(cards).toHaveLength(2);
+        expect(cards[0].getAttribute('aria-label')).toBe('View B');
+    });
+
+    it('excludes the currently viewed product by id', () => {
+        setUpDom();
+        RecentlyViewed.addRecentlyViewed(product({ id: 1, name: 'A' }));
+        RecentlyViewed.addRecentlyViewed(product({ id: 2, name: 'B' }));
+
+        const list = RecentlyViewed.renderRecentlyViewed({
+            containerId: 'recently-viewed-container',
+            sectionId: 'recently-viewed-section',
+            excludeId: 2,
+        });
+
+        expect(list).toHaveLength(1);
+        expect(list[0].name).toBe('A');
+        expect(document.getElementById('recently-viewed-container').children).toHaveLength(1);
+    });
+
+    it('re-hides the section if excluding the only item empties the list', () => {
+        setUpDom();
+        RecentlyViewed.addRecentlyViewed(product({ id: 1, name: 'Only Product' }));
+
+        RecentlyViewed.renderRecentlyViewed({
+            containerId: 'recently-viewed-container',
+            sectionId: 'recently-viewed-section',
+            excludeId: 1,
+        });
+
+        expect(document.getElementById('recently-viewed-section').hidden).toBe(true);
+    });
+
+    it('does nothing when the container is missing from the DOM', () => {
+        document.body.innerHTML = '';
+        expect(() =>
+            RecentlyViewed.renderRecentlyViewed({
+                containerId: 'does-not-exist',
+                sectionId: 'also-missing',
+            })
+        ).not.toThrow();
+    });
+});


### PR DESCRIPTION
# Pull Request

## Related Issue
Closes #2703

---

## Type of Change
- [x] ✨ New feature — non-breaking change that adds functionality

---

## Summary
Adds a "Recently Viewed Products" section that lets users pick up where they left off. Every time a product page is opened, it's saved to a capped, de-duplicated, most-recent-first list in `localStorage`, and rendered as a horizontal carousel on both the shop page and product pages. The section stays hidden entirely until the user has actually viewed a product, so first-time visitors don't see an empty shelf.

---

## Changes Made
- Added `js/recently-viewed.js`: core logic to get/add/render the recently-viewed list, exposed via `window.RecentlyViewed` for reuse and testing.
- Added `recently-viewed.css`: styling for the horizontal scroll carousel, matching the existing product card look.
- Added `tests/unit/recently-viewed.test.js`: 11 unit tests covering add/dedupe/cap behavior and render/hide logic.
- Updated `singleProduct.html`: added the "Recently Viewed" section (excludes the product currently being viewed), linked the new CSS/JS.
- Updated `shop.html`: added the same section (no exclusion), linked the new CSS/JS.
- Fixed a pre-existing duplicate `const modalTemplate` declaration in `products.js` that was throwing a `SyntaxError` and breaking product rendering on page load.

---

## Screenshots / Recordings

shop.html:
<img width="1906" height="905" alt="image" src="https://github.com/user-attachments/assets/209b8765-b3b5-4918-939f-b9d81a51d41c" />

---

singleProduct.html:
<img width="1907" height="910" alt="image" src="https://github.com/user-attachments/assets/c36913c1-deff-40d9-9c80-d3700740b125" />

---

## Testing

### How to Test Locally
1. Run `npm install` then serve the site locally (e.g. VS Code Live Server) and open `shop.html`.
2. Click into a couple of different products via `singleProduct.html`.
3. Scroll down on either `shop.html` or `singleProduct.html` — the "Recently Viewed" section should appear with the products you viewed (excluding the one currently open, on the product page). Refresh to confirm it persists; view 7+ products to confirm it caps at 6.

### Test Coverage
- [x] I added / updated unit tests for the new logic
- [x] I verified manually in Chrome (desktop)
- [x] I verified manually on a mobile viewport (< 480 px)
- [x] I ran `npm run lint` and it passes with no errors
- [ ] I ran `npm run format:check` and it passes with no errors

---

## Impact
Gives users a fast way to return to products they've already looked at without re-searching or re-browsing categories, improving navigation and reducing friction toward a purchase decision, a common, expected e-commerce pattern.

---

## Checklist
- [x] My code follows the existing style and conventions of this project
- [x] I have self-reviewed my diff and removed debug/console logs
- [x] I have not introduced any unrelated changes in this PR
- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format (`fix:`, `feat:`, `docs:`, etc.)
- [ ] I have updated relevant documentation (README, CONTRIBUTING, inline comments) if needed
- [x] All new and existing tests pass
- [x] This PR is independently reviewable and mergeable (no stacked dependencies)