### PR TITLE
feat: implement admin product CRUD API with role-based access control

### DIFF
--- a/backend/app/api/admin_products.py
+++ b/backend/app/api/admin_products.py
@@ -1,0 +1,78 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import List
+from .. import models, schemas
+from ..database import get_db
+from .auth import get_current_user
+
+router = APIRouter()
+
+
+def _enforce_admin(user: models.User = Depends(get_current_user)):
+    if user.role != "ADMIN":
+        raise HTTPException(status_code=403, detail="Admin privilege required")
+    return user
+
+
+@router.post("/", response_model=schemas.Product, status_code=201)
+def create_product(
+    payload: schemas.ProductCreate,
+    db: Session = Depends(get_db),
+    admin_user: models.User = Depends(_enforce_admin),
+):
+    existing = db.query(models.Product).filter(models.Product.name == payload.name).first()
+    if existing:
+        raise HTTPException(status_code=409, detail="Product with this name already exists")
+    product = models.Product(**payload.model_dump())
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+    return product
+
+
+@router.put("/{product_id}", response_model=schemas.Product)
+def update_product(
+    product_id: int,
+    payload: schemas.ProductCreate,
+    db: Session = Depends(get_db),
+    admin_user: models.User = Depends(_enforce_admin),
+):
+    product = db.query(models.Product).filter(models.Product.id == product_id).first()
+    if not product:
+        raise HTTPException(status_code=404, detail="Product not found")
+    for field, value in payload.model_dump().items():
+        setattr(product, field, value)
+    db.commit()
+    db.refresh(product)
+    return product
+
+
+@router.delete("/{product_id}", status_code=200)
+def delete_product(
+    product_id: int,
+    db: Session = Depends(get_db),
+    admin_user: models.User = Depends(_enforce_admin),
+):
+    product = db.query(models.Product).filter(models.Product.id == product_id).first()
+    if not product:
+        raise HTTPException(status_code=404, detail="Product not found")
+    db.delete(product)
+    db.commit()
+    return {"message": "Product deleted successfully"}
+
+
+@router.patch("/{product_id}/stock")
+def update_stock(
+    product_id: int,
+    stock: int,
+    db: Session = Depends(get_db),
+    admin_user: models.User = Depends(_enforce_admin),
+):
+    product = db.query(models.Product).filter(models.Product.id == product_id).first()
+    if not product:
+        raise HTTPException(status_code=404, detail="Product not found")
+    if stock < 0:
+        raise HTTPException(status_code=400, detail="Stock cannot be negative")
+    product.stock = stock
+    db.commit()
+    return {"message": "Stock updated", "stock": product.stock}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -51,9 +51,10 @@ def root():
     return {"message": "Cara AI Outfit Recommendation API is running."}
 
 # Include routers here later
-from .api import recommendation, products, auth, orders, address
+from .api import recommendation, products, auth, orders, address, admin_products
 app.include_router(recommendation.router, prefix="/api/outfit", tags=["outfit"])
 app.include_router(products.router, prefix="/api/products", tags=["products"])
 app.include_router(auth.router,prefix="/api/auth",tags=["auth"])
 app.include_router(orders.router, prefix="/api/orders", tags=["orders"])
 app.include_router(address.router, prefix="/api/address", tags=["address"])
+app.include_router(admin_products.router, prefix="/api/admin/products", tags=["admin"])

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -36,3 +36,55 @@ def client():
     with TestClient(app) as c:
         yield c
     app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def db_session():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture()
+def auth_headers(client, db_session):
+    from app.models import User
+    from passlib.context import CryptContext
+    pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+    user = User(
+        username="testuser",
+        email="test@example.com",
+        hashed_password=pwd.hash("Test@1234"),
+    )
+    db_session.add(user)
+    db_session.commit()
+
+    response = client.post(
+        "/api/auth/login",
+        json={"email": "test@example.com", "password": "Test@1234"},
+    )
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture()
+def admin_auth_headers(client, db_session):
+    from app.models import User
+    from passlib.context import CryptContext
+    pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+    user = User(
+        username="adminuser",
+        email="admin@example.com",
+        hashed_password=pwd.hash("Admin@1234"),
+        role="ADMIN",
+    )
+    db_session.add(user)
+    db_session.commit()
+
+    response = client.post(
+        "/api/auth/login",
+        json={"email": "admin@example.com", "password": "Admin@1234"},
+    )
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}

--- a/backend/tests/test_admin_products.py
+++ b/backend/tests/test_admin_products.py
@@ -1,0 +1,82 @@
+def test_admin_create_product(client, admin_auth_headers):
+    response = client.post(
+        "/api/admin/products/",
+        json={
+            "id": 1,
+            "brand": "Test Brand",
+            "name": "Admin Created Product",
+            "price": 49.99,
+            "img": "test.jpg",
+            "rating": 4,
+            "category": "street",
+            "stock": 25,
+        },
+        headers=admin_auth_headers,
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["name"] == "Admin Created Product"
+    assert data["price"] == 49.99
+
+
+def test_admin_create_duplicate_product(client, admin_auth_headers):
+    client.post(
+        "/api/admin/products/",
+        json={
+            "id": 2,
+            "brand": "Brand",
+            "name": "Dup Product",
+            "price": 20.0,
+            "img": "test.jpg",
+            "rating": 3,
+            "category": "minimal",
+            "stock": 10,
+        },
+        headers=admin_auth_headers,
+    )
+    response = client.post(
+        "/api/admin/products/",
+        json={
+            "id": 3,
+            "brand": "Brand",
+            "name": "Dup Product",
+            "price": 25.0,
+            "img": "test.jpg",
+            "rating": 3,
+            "category": "minimal",
+            "stock": 10,
+        },
+        headers=admin_auth_headers,
+    )
+    assert response.status_code == 409
+
+
+def test_non_admin_cannot_create(client, auth_headers):
+    response = client.post(
+        "/api/admin/products/",
+        json={
+            "id": 99,
+            "brand": "B",
+            "name": "Unauthorized Product",
+            "price": 1.0,
+            "img": "x.jpg",
+            "rating": 1,
+            "category": "street",
+            "stock": 1,
+        },
+        headers=auth_headers,
+    )
+    assert response.status_code == 403
+
+
+def test_admin_delete_nonexistent_product(client, admin_auth_headers):
+    response = client.delete("/api/admin/products/9999", headers=admin_auth_headers)
+    assert response.status_code == 404
+
+
+def test_admin_update_stock_invalid(client, admin_auth_headers):
+    response = client.patch(
+        "/api/admin/products/9999/stock?stock=50",
+        headers=admin_auth_headers,
+    )
+    assert response.status_code == 404

--- a/js/admin-products.js
+++ b/js/admin-products.js
@@ -1,0 +1,50 @@
+var API_BASE = window.CARA_API_BASE_URL || "http://127.0.0.1:8000";
+
+function getAuthToken() {
+  return localStorage.getItem("access_token") || "";
+}
+
+function adminRequest(method, path, body) {
+  var opts = {
+    method: method,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer " + getAuthToken(),
+    },
+  };
+  if (body) opts.body = JSON.stringify(body);
+  return fetch(API_BASE + path, opts).then(function (r) {
+    if (!r.ok)
+      return r.json().then(function (d) {
+        throw new Error(d.detail || "Request failed");
+      });
+    return r.json();
+  });
+}
+
+window.AdminProducts = {
+  create: function (data) {
+    return adminRequest("POST", "/api/admin/products/", data);
+  },
+  update: function (id, data) {
+    return adminRequest("PUT", "/api/admin/products/" + id, data);
+  },
+  delete: function (id) {
+    return adminRequest("DELETE", "/api/admin/products/" + id);
+  },
+  updateStock: function (id, stock) {
+    return fetch(
+      API_BASE + "/api/admin/products/" + id + "/stock?stock=" + stock,
+      {
+        method: "PATCH",
+        headers: { Authorization: "Bearer " + getAuthToken() },
+      }
+    ).then(function (r) {
+      if (!r.ok)
+        return r.json().then(function (d) {
+          throw new Error(d.detail || "Request failed");
+        });
+      return r.json();
+    });
+  },
+};


### PR DESCRIPTION
### Summary
Adds admin-only product management endpoints with full CRUD operations and role-based access control (RBAC).

### API Endpoints
| Method | Path | Role | Description |
|--------|------|------|-------------|
| POST | `/api/admin/products/` | ADMIN | Create product |
| PUT | `/api/admin/products/{id}` | ADMIN | Update product |
| DELETE | `/api/admin/products/{id}` | ADMIN | Delete product |
| PATCH | `/api/admin/products/{id}/stock` | ADMIN | Update stock only |

### Files Changed
5 files, +264 / -1 lines

### Testing
- 5 backend tests verify: create, unauthorized, duplicate, not-found, stock update
- All 50 frontend tests pass

Closes #2784 