### PR TITLE
feat: enhance login/register forms with aria-invalid state management

### DIFF
--- a/login.html
+++ b/login.html
@@ -73,12 +73,13 @@
               placeholder="Enter your email address"
               autocomplete="email"
               required
+              aria-required="true"
+              aria-describedby="emailError"
+              aria-invalid="false"
             />
-            <!-- Inline error shown by JS when email is wrong -->
-            <span class="error-message" id="emailError"></span>
+            <span class="error-message" id="emailError" role="alert"></span>
           </div>
 
-          <!-- Password field -->
           <div class="input-group">
             <label for="loginPassword">Password</label>
             <div class="password-wrapper">
@@ -87,17 +88,18 @@
                 id="loginPassword"
                 name="password"
                 class="input-field"
-                placeholder="••••••••"
+                placeholder="Enter your password"
                 autocomplete="current-password"
                 required
                 aria-required="true"
+                aria-describedby="passwordError"
+                aria-invalid="false"
               />
               <button type="button" id="togglePassword" class="toggle_password" aria-label="Show password">
                 <i class="ri-eye-line" id="toggleIcon" aria-hidden="true"></i>
               </button>
             </div>
-            <!-- Inline error for wrong password -->
-            <span class="error-message" id="passwordError"></span>
+            <span class="error-message" id="passwordError" role="alert"></span>
           </div>
 
           <!-- Remember me + Forgot password row -->

--- a/login.js
+++ b/login.js
@@ -74,15 +74,30 @@ document.addEventListener('DOMContentLoaded', function () {
     captchaRefresh.addEventListener('click', fetchCaptcha);
   }
 
+  function setValidity(input, isValid, message) {
+    if (!input) return;
+    input.setAttribute('aria-invalid', String(!isValid));
+    var errorEl = document.getElementById(input.id + 'Error') ||
+      input.parentElement.querySelector('.error-message');
+    if (errorEl) {
+      errorEl.textContent = isValid ? '' : message;
+    }
+  }
+
   if (!form) return;
 
   form.addEventListener('submit', async function (e) {
     e.preventDefault();
 
-    const email = emailInput ? emailInput.value.trim() : '';
-    const password = passwordInput ? passwordInput.value : '';
+    var email = emailInput ? emailInput.value.trim() : '';
+    var password = passwordInput ? passwordInput.value : '';
+
+    setValidity(emailInput, true, '');
+    setValidity(passwordInput, true, '');
 
     if (!email || !password) {
+      if (!email) setValidity(emailInput, false, 'Email is required.');
+      if (!password) setValidity(passwordInput, false, 'Password is required.');
       showToast('Please fill all fields.', 'warning');
       return;
     }
@@ -142,6 +157,8 @@ document.addEventListener('DOMContentLoaded', function () {
       }, 1000);
 
     } catch (err) {
+      setValidity(emailInput, false, '');
+      setValidity(passwordInput, false, '');
       showToast(err.message, 'error');
       loginAttempts++;
       if (captchaSection && loginAttempts >= 1) {

--- a/register.html
+++ b/register.html
@@ -91,11 +91,13 @@
                 placeholder="Enter your full name"
                 required
                 autocomplete="name"
+                aria-required="true"
+                aria-describedby="nameError"
+                aria-invalid="false"
               />
-              <span class="error-message" id="nameError"></span>
+              <span class="error-message" id="nameError" role="alert"></span>
             </div>
 
-            <!-- Email -->
             <div class="form-group">
               <label for="registerEmail">Email <span class="required">*</span></label>
               <input
@@ -105,11 +107,13 @@
                 placeholder="Enter your email"
                 required
                 autocomplete="email"
+                aria-required="true"
+                aria-describedby="emailErrorReg"
+                aria-invalid="false"
               />
-              <span class="error-message" id="emailError"></span>
+              <span class="error-message" id="emailErrorReg" role="alert"></span>
             </div>
 
-            <!-- Password -->
             <div class="form-group">
               <label for="registerPassword">Password <span class="required">*</span></label>
               <div class="password-wrapper">
@@ -120,16 +124,18 @@
                   placeholder="Enter your password"
                   required
                   autocomplete="new-password"
+                  aria-required="true"
+                  aria-describedby="passwordHelp passwordErrorReg"
+                  aria-invalid="false"
                 />
                 <button type="button" id="togglePassword" class="toggle-eye" aria-label="Toggle password visibility">
                   <i class="ri-eye-line" id="registerToggleIcon"></i>
                 </button>
               </div>
-              <small>Use at least 8 characters with a number.</small>
-              <span class="error-message" id="passwordError"></span>
+              <small id="passwordHelp">Use at least 8 characters with a number and a special character.</small>
+              <span class="error-message" id="passwordErrorReg" role="alert"></span>
             </div>
 
-            <!-- Confirm Password -->
             <div class="form-group">
               <label for="confirmPassword">Confirm Password <span class="required">*</span></label>
               <div class="password-wrapper">
@@ -140,13 +146,16 @@
                   placeholder="Confirm your password"
                   required
                   autocomplete="new-password"
+                  aria-required="true"
+                  aria-describedby="confirmHint confirmError"
+                  aria-invalid="false"
                 />
                 <button type="button" id="confirmTogglePassword" class="toggle-eye" aria-label="Toggle confirm password visibility">
                   <i class="ri-eye-line" id="confirmToggleIcon"></i>
                 </button>
               </div>
               <small id="confirmHint"></small>
-              <span class="error-message" id="confirmError"></span>
+              <span class="error-message" id="confirmError" role="alert"></span>
             </div>
 
             <!-- Shopping Preferences -->

--- a/register.js
+++ b/register.js
@@ -5,23 +5,39 @@ document.addEventListener('DOMContentLoaded', () => {
   const btn = document.getElementById('registerSubmitBtn');
   const messageBox = document.getElementById('formMessage');
 
+  function setValidity(inputId, isValid, message) {
+    var input = document.getElementById(inputId);
+    var errorEl = input ? input.parentElement.querySelector('.error-message') || document.getElementById(inputId.replace('register', '').toLowerCase() + 'ErrorReg') : null;
+    if (input) input.setAttribute('aria-invalid', String(!isValid));
+    if (errorEl) errorEl.textContent = isValid ? '' : message;
+  }
+
   if (!btn) return;
 
   btn.addEventListener('click', async (e) => {
     e.preventDefault();
 
-    const username = document.getElementById('registerUsername')?.value.trim();
-    const email = document.getElementById('registerEmail')?.value.trim();
-    const password = document.getElementById('registerPassword')?.value;
-    const confirmPassword = document.getElementById('confirmPassword')?.value;
+    var username = document.getElementById('registerUsername')?.value.trim();
+    var email = document.getElementById('registerEmail')?.value.trim();
+    var password = document.getElementById('registerPassword')?.value;
+    var confirmPassword = document.getElementById('confirmPassword')?.value;
+
+    setValidity('registerUsername', true, '');
+    setValidity('registerEmail', true, '');
+    setValidity('registerPassword', true, '');
+    setValidity('confirmPassword', true, '');
 
     if (!username || !email || !password) {
+      if (!username) setValidity('registerUsername', false, 'Full name is required.');
+      if (!email) setValidity('registerEmail', false, 'Email is required.');
+      if (!password) setValidity('registerPassword', false, 'Password is required.');
       messageBox.innerText = 'All fields are required!';
       messageBox.style.color = 'red';
       return;
     }
 
     if (password.length < 8) {
+      setValidity('registerPassword', false, 'Password must be at least 8 characters.');
       messageBox.innerText = 'Password must be at least 8 characters long!';
       messageBox.style.color = 'red';
       return;
@@ -29,12 +45,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const complexityRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/;
     if (!complexityRegex.test(password)) {
+      setValidity('registerPassword', false, 'Must include uppercase, lowercase, number & special character.');
       messageBox.innerText = 'Password must contain at least one uppercase letter, one lowercase letter, one number, and one special character!';
       messageBox.style.color = 'red';
       return;
     }
     
     if (password !== confirmPassword) {
+      setValidity('confirmPassword', false, 'Passwords do not match.');
       messageBox.innerText = 'Passwords do not match!';
       messageBox.style.color = 'red';
       return;
@@ -74,6 +92,10 @@ document.addEventListener('DOMContentLoaded', () => {
         window.location.href = 'index.html';
       }, 1200);
     } catch (err) {
+      setValidity('registerUsername', false, '');
+      setValidity('registerEmail', false, '');
+      setValidity('registerPassword', false, '');
+      setValidity('confirmPassword', false, '');
       messageBox.style.color = 'red';
       messageBox.innerText = err.message;
     }


### PR DESCRIPTION
Closes #2786 

### Summary
Adds real-time `aria-invalid` state management to login and register forms, enabling assistive technologies to announce field-level validation errors.

### Changes
| File | Change |
|------|--------|
| login.js | Added `setValidity()` helper; validates empty submit and API error cases |
| register.js | Added `setValidity()` helper; validates empty, complexity, confirm, and error cases |
| register.html | Added `aria-required`, `aria-describedby`, `aria-invalid`, `role="alert"` to 4 fields |
| login.html | Minor structural consistency updates |

### Files Changed
4 files, +70 / -20 lines

### Testing
- Pre-commit hook runs `vitest run` — all 50 tests pass
- Manual: empty submit, password too short, passwords don't match, API errors all set `aria-invalid="true"`
