### PR TITLE
feat: implement social proof live sales notifications toast on index.…

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,7 @@
     integrity="sha512-Kc323vGBEqzTmouAECnVceyQqyqdsSiqLQISBL29aUW4U/M7pSPA/gEUZQqv1cwx4OnYxTxve5UMg5GT6L4JJg=="
     crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="global.css">
+  <link rel="stylesheet" href="live-sales-toast.css">
 
   <!-- Inline Critical CSS -->
   <style>
@@ -834,6 +835,7 @@ if (btn) {
 </script>
 <button id="backToTop">â†‘</button>
 <script src="js/session-lock.js" defer></script>
+<script src="js/live-sales-toast.js" defer></script>
 </body>
 
 </html>

--- a/js/live-sales-toast.js
+++ b/js/live-sales-toast.js
@@ -1,0 +1,162 @@
+// live-sales-toast.js
+// Dynamically renders social proof live sales notifications toasts periodically.
+
+(function () {
+  'use strict';
+
+  const BUYERS = [
+    'Amit',
+    'Priya',
+    'Ramesh',
+    'Sneha',
+    'Rahul',
+    'Ananya',
+    'Arjun',
+    'Kavya',
+    'Vivek',
+    'Meera',
+    'Aditya',
+    'Neha',
+    'Siddharth',
+    'Riya',
+    'Karan',
+  ];
+
+  const CITIES = [
+    'Mumbai',
+    'Delhi',
+    'Bangalore',
+    'Pune',
+    'Chennai',
+    'Kolkata',
+    'Hyderabad',
+    'Ahmedabad',
+    'Jaipur',
+    'Lucknow',
+    'Chandigarh',
+    'Kochi',
+  ];
+
+  const TIMES = [
+    '1 minute ago',
+    '2 minutes ago',
+    '3 minutes ago',
+    '5 minutes ago',
+    '10 minutes ago',
+    'just now',
+  ];
+
+  const POPUP_INTERVAL = 25000; // 25 seconds
+  const DISPLAY_DURATION = 6000; // 6 seconds
+  let dismissTimer = null;
+
+  function getRandomElement(arr) {
+    return arr[Math.floor(Math.random() * arr.length)];
+  }
+
+  function getProducts() {
+    return window.products || [];
+  }
+
+  function createContainer() {
+    let container = document.getElementById('live-sales-container');
+    if (!container) {
+      container = document.createElement('div');
+      container.id = 'live-sales-container';
+      document.body.appendChild(container);
+    }
+    return container;
+  }
+
+  function showLiveToast() {
+    const products = getProducts();
+    if (products.length === 0) return;
+
+    const container = createContainer();
+    const product = getRandomElement(products);
+    const buyer = getRandomElement(BUYERS);
+    const city = getRandomElement(CITIES);
+    const time = getRandomElement(TIMES);
+
+    // Create toast element
+    const toast = document.createElement('div');
+    toast.className = 'live-sales-toast';
+    toast.innerHTML = `
+      <button class="live-sales-close" aria-label="Dismiss">&times;</button>
+      <div class="live-sales-img-wrapper">
+        <img src="${product.img}" alt="${product.name}">
+      </div>
+      <div class="live-sales-details">
+        <p class="live-sales-title">Recent Purchase</p>
+        <p class="live-sales-message">
+          <span class="buyer">${buyer}</span> from ${city} bought a 
+          <span class="product">${product.name}</span>
+        </p>
+        <span class="live-sales-time">${time}</span>
+      </div>
+    `;
+
+    container.innerHTML = '';
+    container.appendChild(toast);
+
+    // Slide-in after a tick
+    requestAnimationFrame(() => {
+      toast.classList.add('show');
+    });
+
+    // Close button click listener
+    toast.querySelector('.live-sales-close').addEventListener('click', (e) => {
+      e.stopPropagation();
+      dismissToast(toast);
+    });
+
+    // Hover pause logic
+    let isHovered = false;
+    let timeRemaining = DISPLAY_DURATION;
+    let startTime = Date.now();
+
+    function startDismissTimer() {
+      dismissTimer = setTimeout(() => {
+        if (!isHovered) {
+          dismissToast(toast);
+        }
+      }, timeRemaining);
+    }
+
+    toast.addEventListener('mouseenter', () => {
+      isHovered = true;
+      clearTimeout(dismissTimer);
+      timeRemaining -= Date.now() - startTime;
+    });
+
+    toast.addEventListener('mouseleave', () => {
+      isHovered = false;
+      startTime = Date.now();
+      startDismissTimer();
+    });
+
+    startDismissTimer();
+  }
+
+  function dismissToast(toast) {
+    clearTimeout(dismissTimer);
+    toast.classList.add('hide');
+    toast.addEventListener('transitionend', () => {
+      toast.remove();
+    });
+  }
+
+  function startToastCycle() {
+    // Show first toast after 6 seconds of landing
+    setTimeout(() => {
+      showLiveToast();
+      // Setup recurring timer afterwards
+      setInterval(showLiveToast, POPUP_INTERVAL);
+    }, 6000);
+  }
+
+  // Auto-init on DOMContentLoaded
+  document.addEventListener('DOMContentLoaded', () => {
+    startToastCycle();
+  });
+})();

--- a/live-sales-toast.css
+++ b/live-sales-toast.css
@@ -1,0 +1,135 @@
+/* live-sales-toast.css */
+/* Styles for the dynamic social proof live purchase notifications */
+
+#live-sales-container {
+  position: fixed;
+  bottom: 24px;
+  left: 24px;
+  z-index: 9999;
+  pointer-events: none; /* let clicks pass through when empty */
+}
+
+.live-sales-toast {
+  pointer-events: auto; /* re-enable interactions on the toast itself */
+  width: 320px;
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: 12px;
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.12);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  position: relative;
+  overflow: hidden;
+  box-sizing: border-box;
+  font-family: 'Poppins', sans-serif;
+  opacity: 0;
+  transform: translateY(30px) scale(0.95);
+  transition: all 0.4s cubic-bezier(0.165, 0.84, 0.44, 1);
+}
+
+.live-sales-toast.show {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.live-sales-toast.hide {
+  opacity: 0;
+  transform: translateX(-40px) scale(0.9);
+}
+
+/* Close/Dismiss Button */
+.live-sales-close {
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  background: none;
+  border: none;
+  color: #888;
+  font-size: 16px;
+  font-weight: 700;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+  transition: color 0.2s ease;
+}
+
+.live-sales-close:hover {
+  color: #ef4444;
+}
+
+/* Image section */
+.live-sales-img-wrapper {
+  flex-shrink: 0;
+  width: 50px;
+  height: 50px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.live-sales-img-wrapper img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* Details Section */
+.live-sales-details {
+  flex-grow: 1;
+  padding-right: 10px;
+}
+
+.live-sales-title {
+  font-size: 11px;
+  color: var(--text-secondary, #777);
+  margin: 0 0 2px 0;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.live-sales-message {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--text-primary, #222);
+  margin: 0;
+  line-height: 1.4;
+}
+
+.live-sales-message span.buyer {
+  font-weight: 700;
+}
+
+.live-sales-message span.product {
+  color: var(--accent, #088178);
+  font-weight: 600;
+}
+
+.live-sales-time {
+  font-size: 10px;
+  color: #999;
+  display: block;
+  margin-top: 3px;
+}
+
+/* Dark mode theme overrides */
+[data-theme="dark"] .live-sales-toast {
+  background: rgba(28, 36, 49, 0.9);
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.4);
+}
+
+[data-theme="dark"] .live-sales-message {
+  color: #f3f4f6;
+}
+
+[data-theme="dark"] .live-sales-close {
+  color: #aaa;
+}
+
+[data-theme="dark"] .live-sales-close:hover {
+  color: #f87171;
+}


### PR DESCRIPTION

## Related Issue
Closes #2895

---

## Type of Change
- [x] ✨ New feature — non-breaking change that adds functionality
- [x] 🎨 UI / UX improvement — visual or interaction polish

---

## Summary
Added an animated social proof notification toast popup to the homepage. The popup displays simulated purchase activity periodically to make the landing page feel live, active, and trusted.

---

## Changes Made
- **[NEW] [live-sales-toast.css](file:///d:/Cara-main/Cara-main/live-sales-toast.css)**: Styled the glassmorphic card container, hover transitions, and dark theme support.
- **[NEW] [js/live-sales-toast.js](file:///d:/Cara-main/Cara-main/js/live-sales-toast.js)**: Interval timing loop rendering notifications from the product catalog.
- **[MODIFY] [index.html](file:///d:/Cara-main/Cara-main/index.html)**: Linked script and stylesheet resources.

---

## Testing

### How to Test Locally
1. Land on the homepage (`index.html`) and wait 6 seconds.
2. Verify that a purchase toast slides up smoothly.
3. Test hovering to pause the dismiss timer, and clicking the close button to dismiss it immediately.

### Test Coverage
- [x] I ran `npm run lint` and all files pass clean (0 errors)
- [x] All 50 existing unit tests pass