### PR TITLE
fix: escape user-supplied order fields to prevent stored XSS in order…

### DIFF
--- a/order-history.js
+++ b/order-history.js
@@ -36,7 +36,18 @@ function setStateVisibility({ loading = false, error = false, empty = false, ord
 function statusClass(status) {
   return `status-pill status-${String(status || 'pending').toLowerCase()}`;
 }
-
+// Escapes HTML-significant characters so user-supplied order data
+// (full_name, address, city, product_name, etc.) can never be
+// interpreted as markup when interpolated into innerHTML.
+function escapeHtml(value) {
+  return String(value ?? '').replace(/[&<>"']/g, (ch) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  }[ch]));
+}
 function renderOrders(orders) {
   const tbody = document.getElementById('ordersTableBody');
   tbody.innerHTML = '';
@@ -46,11 +57,11 @@ function renderOrders(orders) {
     const createdAt = order.created_at ? new Date(order.created_at).toLocaleDateString() : 'N/A';
 
     row.innerHTML = `
-      <td>#${order.id}</td>
-      <td>${createdAt}</td>
-      <td>${formatCurrency(order.total_amount)}</td>
-      <td><span class="${statusClass(order.status)}">${order.status}</span></td>
-      <td><button class="details-btn" type="button" data-order-id="${order.id}">View</button></td>
+      <td>#${escapeHtml(order.id)}</td>
+      <td>${escapeHtml(createdAt)}</td>
+      <td>${escapeHtml(formatCurrency(order.total_amount))}</td>
+      <td><span class="${escapeHtml(statusClass(order.status))}">${escapeHtml(order.status)}</span></td>
+      <td><button class="details-btn" type="button" data-order-id="${escapeHtml(order.id)}">View</button></td>
     `;
 
     tbody.appendChild(row);
@@ -66,16 +77,16 @@ function renderOrderDetails(order) {
 
   modalContent.innerHTML = `
     <div class="order-detail-head">
-      <p class="eyebrow">Order #${order.id}</p>
-      <h2 style="margin: 0 0 8px;">${order.status}</h2>
-      <p style="margin: 0; color: #55606f;">Placed on ${order.created_at ? new Date(order.created_at).toLocaleString() : 'N/A'}</p>
+      <p class="eyebrow">Order #${escapeHtml(order.id)}</p>
+      <h2 style="margin: 0 0 8px;">${escapeHtml(order.status)}</h2>
+      <p style="margin: 0; color: #55606f;">Placed on ${escapeHtml(order.created_at ? new Date(order.created_at).toLocaleString() : 'N/A')}</p>
     </div>
 
     <div class="order-meta-grid">
-      <div class="meta-card"><span class="meta-label">Customer</span><strong>${order.full_name}</strong></div>
-      <div class="meta-card"><span class="meta-label">Email</span><strong>${order.email}</strong></div>
-      <div class="meta-card"><span class="meta-label">Shipping</span><strong>${order.address}, ${order.city} ${order.zip_code}</strong></div>
-      <div class="meta-card"><span class="meta-label">Total</span><strong>${formatCurrency(order.total_amount)}</strong></div>
+      <div class="meta-card"><span class="meta-label">Customer</span><strong>${escapeHtml(order.full_name)}</strong></div>
+      <div class="meta-card"><span class="meta-label">Email</span><strong>${escapeHtml(order.email)}</strong></div>
+      <div class="meta-card"><span class="meta-label">Shipping</span><strong>${escapeHtml(order.address)}, ${escapeHtml(order.city)} ${escapeHtml(order.zip_code)}</strong></div>
+      <div class="meta-card"><span class="meta-label">Total</span><strong>${escapeHtml(formatCurrency(order.total_amount))}</strong></div>
     </div>
 
     <h3 style="margin: 0 0 12px;">Items</h3>
@@ -83,10 +94,10 @@ function renderOrderDetails(order) {
       ${items.map((item) => `
         <div class="item-card">
           <div>
-            <p class="item-name">${item.product_name}</p>
-            <p style="margin: 4px 0 0; color: #64748b;">Quantity: ${item.quantity}</p>
+            <p class="item-name">${escapeHtml(item.product_name)}</p>
+            <p style="margin: 4px 0 0; color: #64748b;">Quantity: ${escapeHtml(item.quantity)}</p>
           </div>
-          <strong>${formatCurrency(item.price)}</strong>
+          <strong>${escapeHtml(formatCurrency(item.price))}</strong>
         </div>
       `).join('') || '<p>No item details available.</p>'}
     </div>


### PR DESCRIPTION
# Pull Request

## Related Issue
Closes #2886

---

## Type of Change
- [x] 🐛 Bug fix — non-breaking change that resolves a reported issue
- [x] 🔒 Security fix

---

## Summary
`order-history.js` was rendering user-controlled order data directly into `innerHTML` without escaping. Since checkout fields were only validated as non-empty, malicious HTML/JavaScript could be stored and later executed when viewing Order History, resulting in stored XSS.

This PR adds an `escapeHtml()` helper and escapes user-controlled values before interpolating them into `innerHTML`.

---

## Changes Made
- Added `escapeHtml()` utility to encode `& < > " '`
- Escaped interpolated values in `renderOrders()`
- Escaped user-controlled fields in `renderOrderDetails()`
- Prevented stored HTML/JavaScript payloads from executing in Order History
- No backend, database, API, or styling changes

---

## Screenshots / Recordings

| Before | After |
|--------|-------|
| Stored XSS payload executes when viewing order details | Payload renders as escaped plain text and does not execute |

---

## Testing

### How to Test Locally
1. Go to checkout and enter `<img src=x onerror="alert(document.cookie)">` in the Full Name, address, or city field.
2. Complete the order.
3. Open `order-history.html`.
4. Click **View** on the created order.
5. Confirm the payload is displayed as plain text and no alert executes.

### Test Coverage
- [x] Verified manually in Chrome (desktop)
- [ ] Verified manually on a mobile viewport (< 480 px)
- [ ] Ran `npm run lint`
- [ ] Ran `npm run format:check`
- [ ] Backend tests (not applicable — frontend-only change)
- [ ] Database migration (not applicable — no schema changes)

---

## Impact
Fixes the stored XSS vulnerability reported in #2886. User-controlled order fields are now safely escaped before being rendered through `innerHTML`.

No API contract, markup structure, or styling behavior has been changed.

---

## Checklist
- [x] My code follows the existing style and conventions of this project
- [x] I have self-reviewed my diff and removed debug/console logs
- [x] I have not introduced unrelated changes
- [x] The PR title follows Conventional Commits format
- [ ] I have updated relevant documentation if needed
- [ ] All new and existing tests pass
- [x] This PR is independently reviewable and mergeable

---

**Note for maintainer:** This PR directly resolves #2886.