### PR TITLE
fix(a11y): add ARIA labels to icon-only header buttons across all pages (#2828)

### DIFF
--- a/blog-aw20-menswear.html
+++ b/blog-aw20-menswear.html
@@ -194,12 +194,12 @@
                         <i class="ri-moon-line" id="themeIcon"></i>
                     </button>
                 </li>
-                <a href="javascript:void(0)" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="javascript:void(0)" id="close" aria-label="Close menu" aria-hidden="false"><i class="fa-solid fa-xmark"></i></a>
             </ul>
         </div>
         <div class="mobile">
             <a aria-label="Cart" href="cart.html"><i class="ri-shopping-bag-4-line"></i></a>
-            <i class="fas fa-outdent" id="bar"></i>
+            <i class="fas fa-outdent" id="bar" role="button" aria-label="Open menu" aria-expanded="false" tabindex="0"></i>
         </div>
     </section>
 

--- a/blog-cotton-jersey-hoodie.html
+++ b/blog-cotton-jersey-hoodie.html
@@ -209,12 +209,12 @@
                         <i class="ri-moon-line" id="themeIcon"></i>
                     </button>
                 </li>
-                <a href="javascript:void(0)" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="javascript:void(0)" id="close" aria-label="Close menu" aria-hidden="false"><i class="fa-solid fa-xmark"></i></a>
             </ul>
         </div>
         <div class="mobile">
             <a aria-label="Cart" href="cart.html"><i class="ri-shopping-bag-4-line"></i></a>
-            <i class="fas fa-outdent" id="bar"></i>
+            <i class="fas fa-outdent" id="bar" role="button" aria-label="Open menu" aria-expanded="false" tabindex="0"></i>
         </div>
     </section>
 

--- a/blog-quiff-styling.html
+++ b/blog-quiff-styling.html
@@ -194,12 +194,12 @@
                         <i class="ri-moon-line" id="themeIcon"></i>
                     </button>
                 </li>
-                <a href="javascript:void(0)" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="javascript:void(0)" id="close" aria-label="Close menu" aria-hidden="false"><i class="fa-solid fa-xmark"></i></a>
             </ul>
         </div>
         <div class="mobile">
             <a aria-label="Cart" href="cart.html"><i class="ri-shopping-bag-4-line"></i></a>
-            <i class="fas fa-outdent" id="bar"></i>
+            <i class="fas fa-outdent" id="bar" role="button" aria-label="Open menu" aria-expanded="false" tabindex="0"></i>
         </div>
     </section>
 

--- a/blog-runway-trends.html
+++ b/blog-runway-trends.html
@@ -193,12 +193,12 @@
                         <i class="ri-moon-line" id="themeIcon"></i>
                     </button>
                 </li>
-                <a href="javascript:void(0)" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="javascript:void(0)" id="close" aria-label="Close menu" aria-hidden="false"><i class="fa-solid fa-xmark"></i></a>
             </ul>
         </div>
         <div class="mobile">
             <a aria-label="Cart" href="cart.html"><i class="ri-shopping-bag-4-line"></i></a>
-            <i class="fas fa-outdent" id="bar"></i>
+            <i class="fas fa-outdent" id="bar" role="button" aria-label="Open menu" aria-expanded="false" tabindex="0"></i>
         </div>
     </section>
 

--- a/blog-skater-girls.html
+++ b/blog-skater-girls.html
@@ -193,12 +193,12 @@
                         <i class="ri-moon-line" id="themeIcon"></i>
                     </button>
                 </li>
-                <a href="javascript:void(0)" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="javascript:void(0)" id="close" aria-label="Close menu" aria-hidden="false"><i class="fa-solid fa-xmark"></i></a>
             </ul>
         </div>
         <div class="mobile">
             <a aria-label="Cart" href="cart.html"><i class="ri-shopping-bag-4-line"></i></a>
-            <i class="fas fa-outdent" id="bar"></i>
+            <i class="fas fa-outdent" id="bar" role="button" aria-label="Open menu" aria-expanded="false" tabindex="0"></i>
         </div>
     </section>
 

--- a/contributors.html
+++ b/contributors.html
@@ -51,7 +51,7 @@
 
     <div class="mobile">
       <a aria-label="Cart" href="cart.html"><i class="ri-shopping-bag-4-line"></i></a>
-      <i class="fas fa-outdent" id="bar"></i>
+      <i class="fas fa-outdent" id="bar" role="button" aria-label="Open menu" aria-expanded="false" tabindex="0"></i>
       <!-- Theme Toggle -->
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
         <i class="ri-moon-line" id="themeIconMobile"></i>

--- a/deals.html
+++ b/deals.html
@@ -222,7 +222,7 @@
     </div>
     <div class="mobile">
         <a aria-label="Cart" href="cart.html"><i class="ri-shopping-bag-4-line"></i></a>
-        <i class="fas fa-outdent" id="bar"></i>
+        <i class="fas fa-outdent" id="bar" role="button" aria-label="Open menu" aria-expanded="false" tabindex="0"></i>
       <!-- Theme Toggle -->
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
         <i class="ri-moon-line" id="themeIconMobile"></i>

--- a/footware-collection.html
+++ b/footware-collection.html
@@ -231,13 +231,13 @@
                     </button>
                 </li>
 
-                <a href="javascript:void(0)" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="javascript:void(0)" id="close" aria-label="Close menu" aria-hidden="false"><i class="fa-solid fa-xmark"></i></a>
             </ul>
         </div>
 
         <div class="mobile">
             <a aria-label="Cart" href="cart.html"><i class="ri-shopping-bag-4-line"></i></a>
-            <i class="fas fa-outdent" id="bar"></i>
+            <i class="fas fa-outdent" id="bar" role="button" aria-label="Open menu" aria-expanded="false" tabindex="0"></i>
         </div>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -184,7 +184,7 @@
         </li>
 
         <!-- Close Button -->
-        <a href="javascript:void(0)" id="close" aria-hidden="false">
+        <a href="javascript:void(0)" id="close" aria-label="Close menu" aria-hidden="false">
           <i class="fa-solid fa-xmark"></i>
         </a>
       </ul>

--- a/license.html
+++ b/license.html
@@ -144,7 +144,7 @@
                 <li><a href="contact.html">Contact</a></li>
                 <li><a aria-label="Cart" href="cart.html" id="lg-bag"><i class="ri-shopping-bag-4-line"></i></a></li>
                 <li>
-                <a href="javascript:void(0)" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="javascript:void(0)" id="close" aria-label="Close menu" aria-hidden="false"><i class="fa-solid fa-xmark"></i></a>
             </ul>
         </div>
       <div class="mobile">
@@ -152,7 +152,7 @@
     <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
         <i class="ri-moon-line" id="themeIconMobile"></i>
     </button>
-    <i class="fas fa-outdent" id="bar"></i>
+    <i class="fas fa-outdent" id="bar" role="button" aria-label="Open menu" aria-expanded="false" tabindex="0"></i>
 </div>
     </section>
 

--- a/privacy.html
+++ b/privacy.html
@@ -290,7 +290,7 @@
               <i class="ri-moon-line" id="themeIcon"></i>
             </button>
           </li>
-          <a href="javascript:void(0)" id="close"><i class="fa-solid fa-xmark"></i></a>
+          <a href="javascript:void(0)" id="close" aria-label="Close menu" aria-hidden="false"><i class="fa-solid fa-xmark"></i></a>
         </ul>
       </div>
       <div class="mobile">
@@ -298,7 +298,7 @@
           <i class="ri-shopping-bag-4-line"></i>
           <span class="cart-count" id="mobileCartCount">0</span>
         </a>
-        <i class="fas fa-outdent" id="bar"></i>
+        <i class="fas fa-outdent" id="bar" role="button" aria-label="Open menu" aria-expanded="false" tabindex="0"></i>
       </div>
     </section>
 

--- a/try-on.html
+++ b/try-on.html
@@ -626,7 +626,7 @@
                 <i class="ri-shopping-bag-4-line"></i>
                 <span class="cart-count" id="mobileCartCount">0</span>
             </a>
-            <i class="fas fa-outdent" id="bar"></i>
+            <i class="fas fa-outdent" id="bar" role="button" aria-label="Open menu" aria-expanded="false" tabindex="0"></i>
             </div> -->
         <!-- </section> -->
     <main>

--- a/tshirt.html
+++ b/tshirt.html
@@ -215,12 +215,12 @@
                         <i class="ri-moon-line" id="themeIcon"></i>
                     </button>
                 </li>
-                <a href="javascript:void(0)" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="javascript:void(0)" id="close" aria-label="Close menu" aria-hidden="false"><i class="fa-solid fa-xmark"></i></a>
             </ul>
         </div>
         <div class="mobile">
             <a aria-label="Cart" href="cart.html"><i class="ri-shopping-bag-4-line"></i></a>
-            <i class="fas fa-outdent" id="bar"></i>
+            <i class="fas fa-outdent" id="bar" role="button" aria-label="Open menu" aria-expanded="false" tabindex="0"></i>
       <!-- Theme Toggle -->
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
         <i class="ri-moon-line" id="themeIconMobile"></i>

--- a/winter-sale.html
+++ b/winter-sale.html
@@ -241,13 +241,13 @@
                 <li><a href="login.html">Login</a></li>
                 <li><a aria-label="Cart" href="cart.html" id="lg-bag"><i class="ri-shopping-bag-4-line"></i></a></li>
                 <li>
-                <a href="javascript:void(0)" id="close"><i class="fa-solid fa-xmark"></i></a>
+                <a href="javascript:void(0)" id="close" aria-label="Close menu" aria-hidden="false"><i class="fa-solid fa-xmark"></i></a>
             </ul>
         </div>
 
         <div class="mobile">
             <a aria-label="Cart" href="cart.html"><i class="ri-shopping-bag-4-line"></i></a>
-            <i class="fas fa-outdent" id="bar"></i>
+            <i class="fas fa-outdent" id="bar" role="button" aria-label="Open menu" aria-expanded="false" tabindex="0"></i>
       <!-- Theme Toggle -->
       <button class="theme-toggle" id="themeToggleMobile" aria-label="Toggle dark mode">
         <i class="ri-moon-line" id="themeIconMobile"></i>


### PR DESCRIPTION
## Summary
Fixes #2828 — icon-only header buttons announced as "Button" by screen readers.

This PR adds accessible names to the two icon-only controls that are duplicated in the header of nearly every page:
- `#close` — the mobile-menu close (X) anchor → `aria-label="Close menu"`
- `#bar` — the mobile-menu hamburger → `role="button" aria-label="Open menu" aria-expanded="false" tabindex="0"`

14 pages updated (24 insertions / 24 deletions); attributes are only added where missing, so pages already exposing a name are untouched.

## Why this supersedes #2865
#2865 is not safe to merge as-is:
- It only patched `index.html`, leaving ~20 other pages with the same unlabeled buttons, so #2828 is not actually resolved site-wide.
- Its diff (vs `main`) **accidentally removes** the live-sales toast feature — both `<link rel="stylesheet" href="live-sales-toast.css">` and `<script src="js/live-sales-toast.js">` — and **strips** `role="img" aria-label="…"` from the 3 hero slides and 3 banner boxes. Those are accessibility/functionality regressions.

This branch is based on clean `main`, so it only contains the additive a11y fix and introduces none of those regressions.

## Test plan
- [ ] `grep -rn 'id="close"\|id="bar"' --include=*.html .` shows every occurrence carrying an `aria-label`.
- [ ] `live-sales-toast.css` / `live-sales-toast.js` and hero/banner `role="img"` remain present in `index.html`.
- [ ] Optional: verify with VoiceOver/NVDA that the close and hamburger controls now announce "Close menu" / "Open menu".