### PR TITLE
docs: restore missing CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,181 @@
+# Contributing to Cara 🛍️
+
+First off, thank you for considering contributing to Cara!
+
+## 📋 Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Getting Started](#getting-started)
+- [How Can I Contribute?](#how-can-i-contribute)
+- [Development Setup](#development-setup)
+- [Pull Request Process](#pull-request-process)
+- [Style Guidelines](#style-guidelines)
+- [Issue Guidelines](#issue-guidelines)
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by our Code of Conduct. By participating, you are expected to uphold this code.
+
+### Our Pledge
+
+We pledge to make participation in our project a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Getting Started
+
+### First Time Setup
+
+1. **Fork the repository** on GitHub
+2. **Clone your fork** locally:
+
+```
+git clone https://github.com/YOUR_USERNAME/Cara.git
+cd Cara
+```
+
+## How Can I Contribute?
+
+### 🐛 Reporting Bugs
+
+Before creating bug reports, please check the existing issues to avoid duplicates. When you create a bug report, include as many details as possible:
+
+- **Use a clear and descriptive title**
+- **Describe the exact steps to reproduce the problem**
+- **Provide specific examples** to demonstrate the steps
+- **Describe the behavior you observed** after following the steps
+- **Explain which behavior you expected** to see instead and why
+- **Include screenshots and animated GIFs** if possible
+- **Include your environment details** (OS, browser, Node.js version)
+
+### ✨ Suggesting Enhancements
+
+Enhancement suggestions are tracked as GitHub issues. When creating an enhancement suggestion:
+
+- **Use a clear and descriptive title**
+- **Provide a step-by-step description** of the suggested enhancement
+- **Provide specific examples** to demonstrate the enhancement
+- **Describe the current behavior** and explain the improvement
+- **Explain why this enhancement would be useful**
+
+### 🔧 Code Contributions
+
+#### Good First Issues
+
+Look for issues labeled `good first issue` or `beginner-friendly`. These are specifically chosen to be approachable for newcomers.
+
+#### Areas We Need Help
+
+- **Frontend Components**: New UI components or improving existing ones
+- **Backend APIs**: New endpoints or optimizing existing ones
+- **Documentation**: Improving or adding documentation
+- **Testing**: Writing unit tests or integration tests
+- **Accessibility**: Making the app more accessible
+- **Performance**: Optimizing app performance
+- **Mobile Responsiveness**: Improving mobile experience
+
+## Development Setup
+
+### Development Workflow
+
+1. **Create a new branch** for your feature/fix:
+
+```
+git checkout -b feature/your-feature-name
+# or
+git checkout -b fix/your-bug-fix
+```
+
+2. **Make your changes** following our style guidelines
+
+3. **Test your changes** thoroughly
+
+4. **Commit your changes** using conventional commits:
+
+```
+git commit -m "feat: add feature"
+```
+
+5. **Push to your fork**:
+
+```
+git push origin feature/your-feature-name
+```
+
+6. **Create a Pull Request** on GitHub
+
+## Pull Request Process
+
+### Before Submitting
+
+- [ ] Check that your code follows our style guidelines
+- [ ] Run the linter and fix any issues: `npm run lint`
+- [ ] Test your changes manually
+- [ ] Link any related issue or feature request
+- [ ] Update documentation if needed
+- [ ] Add or update tests if applicable
+
+### PR Requirements
+
+1. **Title**: Use a clear and descriptive title
+
+2. **Description**: Include:
+   - What changes you made and why
+   - Link to any related issues
+   - Screenshots/GIFs for UI changes
+   - Testing instructions
+
+3. **Checklist**: Complete the PR checklist template
+
+### Review Process
+
+1. At least one maintainer will review your PR
+2. Address any requested changes
+3. Once approved, a maintainer will merge your PR
+
+## Style Guidelines
+
+### Code Style
+
+#### JavaScript/
+
+#### CSS/Styling
+
+## Issue Guidelines
+
+### Bug Reports
+
+Use the bug report template and include:
+
+- **Environment**: OS, browser, Node.js version
+- **Steps to reproduce**: Clear, numbered steps
+- **Expected behavior**: What should happen
+- **Actual behavior**: What actually happens
+- **Screenshots**: If applicable
+
+### Feature Requests
+
+Use the feature request template and include:
+
+- **Problem description**: What problem does this solve?
+- **Proposed solution**: How should it work?
+- **Alternatives considered**: Other approaches you've thought of
+- **Additional context**: Any other relevant information
+
+## Recognition
+
+Contributors will be recognized in:
+
+- README.md contributors section
+- GitHub contributors page
+- Release notes for significant contributions
+
+## Questions?
+
+Feel free to ask questions by:
+
+- Creating a discussion on GitHub
+- Joining our Discord community
+- Reaching out to maintainers
+
+---
+
+Thank you for contributing to Cara! Together.


### PR DESCRIPTION
## What changed
Restores `CONTRIBUTING.md` at the repository root. The file was missing from `main`, causing a 404 when accessed via the README's file tree link or GitHub's automatic "Contributing" prompt shown on new PRs.

## Why
Related to #3119  new contributors had no guidance on project setup, style guidelines, or the PR process since the file didn't exist. It's still referenced in the README's file listing and linked from GitHub's built-in contributing prompts.

## Testing
Verified the file renders correctly in GitHub's markdown preview and matches the structure previously present in the repo (table of contents, code of conduct, setup steps, PR process, style guidelines, issue guidelines).

Closes #3119 