### PR TITLE
fix: add issues:write permission to Issue Labeler workflow

### DIFF
--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -5,6 +5,8 @@ on:
 jobs:
   label:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - uses: actions/github-script@v7
         with:


### PR DESCRIPTION
## What changed
Added an explicit `permissions: issues: write` block to `.github/workflows/issue-labeler.yml`.

## Why
The workflow was failing on every new issue with:
Unhandled error: HttpError: Resource not accessible by integration


This happens because the workflow didn't declare any permissions, so it fell back to the repository's default `GITHUB_TOKEN` permissions which don't include write access to issues. Without this, `github.rest.issues.addLabels()` is rejected by the API.

## Testing
Confirmed the missing permissions block is the root cause per GitHub's own documentation on `GITHUB_TOKEN` default permissions. This is the standard fix for this exact error across issue-labeler-style workflows.

Closes #3121 