### PR TITLE
feat: Add Recently Viewed Products Section with LocalStorage Persistence (#3008)

### DIFF
--- a/Cara-main/singleProduct.html
+++ b/Cara-main/singleProduct.html
@@ -40,6 +40,7 @@
 
     <!-- Stylesheets -->
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="recently-viewed.css">
     <link href="https://cdn.jsdelivr.net/npm/remixicon@4.5.0/fonts/remixicon.css" rel="stylesheet" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css"
         integrity="sha512-Kc323vGBEqzTmouAECnVceyQqyqdsSiqLQISBL29aUW4U/M7pSPA/gEUZQqv1cwx4OnYxTxve5UMg5GT6L4JJg=="
@@ -143,6 +144,12 @@
         <!-- Dynamic Js container  {csritik-max }-->
         <div class="pro-container" id="featured-container"></div>
         <!--   -->
+    </section>
+
+    <section id="recently-viewed-section" class="section-p1" style="display: none;">
+      <h2>Recently Viewed</h2>
+      <p>Pick up where you left off</p>
+      <div class="pro-container" id="recently-viewed-container"></div>
     </section>
 
     <!-- Footer -->
@@ -306,6 +313,7 @@
 <script>
     document.getElementById("Current-Year").textContent=new Date().getFullYear();
 </script>
+<script src="../js/recently-viewed.js"></script>
 </body>
 
 </html>

--- a/js/recently-viewed.js
+++ b/js/recently-viewed.js
@@ -19,6 +19,7 @@
 
   var STORAGE_KEY = 'recentlyViewed';
   var MAX_ITEMS = 6;
+  var memoryFallbackList = [];
 
   function safeParseList(raw) {
     if (!raw) return [];
@@ -32,22 +33,28 @@
 
   function getRecentlyViewed() {
     try {
-      return safeParseList(localStorage.getItem(STORAGE_KEY));
+      if (typeof localStorage !== 'undefined') {
+        return safeParseList(localStorage.getItem(STORAGE_KEY));
+      }
     } catch (e) {
-      return [];
+      /* ignore storage exception, return memory fallback */
     }
+    return memoryFallbackList;
   }
 
   function saveRecentlyViewed(list) {
     try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
-      return true;
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+        return true;
+      }
     } catch (e) {
       if (typeof root.logError === 'function') {
         root.logError('Failed to save recently viewed products:', e);
       }
-      return false;
     }
+    memoryFallbackList = list;
+    return false;
   }
 
   /**


### PR DESCRIPTION
# Pull Request

## Description

Implements a robust memory array fallback system for recently-viewed products when `localStorage` is unavailable or throws access exceptions. This prevents fatal JS runtime blockages on the product details and shop interfaces.

### Changes:

- `js/recently-viewed.js`: Added an internal list cache fallback (`memoryFallbackList`) that persists values in-memory if local storage calls fail.

Closes #3008

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my changes
- [x] New and existing unit tests pass locally with my changes
