### PR TITLE
Add color filtering to product listing page (#3039)

### DIFF
--- a/Cara-main/products.js
+++ b/Cara-main/products.js
@@ -10,6 +10,7 @@ const products = [
     img: 'images/products/f1.jpg',
     rating: 5,
     category: 'street',
+    color: 'red',
   },
   {
     id: 2,
@@ -19,6 +20,7 @@ const products = [
     img: 'images/products/f2.jpg',
     rating: 5,
     category: 'minimal',
+    color: 'white',
   },
   {
     id: 3,
@@ -28,6 +30,7 @@ const products = [
     img: 'images/products/f3.jpg',
     rating: 5,
     category: 'minimal',
+    color: 'pink',
   },
   {
     id: 4,
@@ -37,6 +40,7 @@ const products = [
     img: 'images/products/f4.jpg',
     rating: 5,
     category: 'minimal',
+    color: 'pink',
   },
   {
     id: 5,
@@ -46,6 +50,7 @@ const products = [
     img: 'images/products/f5.jpg',
     rating: 5,
     category: 'street',
+    color: 'pink',
   },
   {
     id: 6,
@@ -55,6 +60,7 @@ const products = [
     img: 'images/products/f6.jpg',
     rating: 5,
     category: 'street',
+    color: 'brown',
   },
   {
     id: 7,
@@ -64,6 +70,7 @@ const products = [
     img: 'images/products/f7.jpg',
     rating: 5,
     category: 'street',
+    color: 'beige',
   },
   {
     id: 8,
@@ -73,6 +80,7 @@ const products = [
     img: 'images/products/f8.jpg',
     rating: 5,
     category: 'minimal',
+    color: 'white',
   },
   {
     id: 9,
@@ -82,6 +90,7 @@ const products = [
     img: 'images/products/n1.jpg',
     rating: 5,
     category: 'formal',
+    color: 'blue',
   },
   {
     id: 10,
@@ -91,6 +100,7 @@ const products = [
     img: 'images/products/n2.jpg',
     rating: 5,
     category: 'formal',
+    color: 'blue',
   },
   {
     id: 11,
@@ -100,6 +110,7 @@ const products = [
     img: 'images/products/n3.jpg',
     rating: 5,
     category: 'formal',
+    color: 'white',
   },
   {
     id: 12,
@@ -109,6 +120,7 @@ const products = [
     img: 'images/products/n4.jpg',
     rating: 5,
     category: 'formal',
+    color: 'beige',
   },
   {
     id: 13,
@@ -118,6 +130,7 @@ const products = [
     img: 'images/products/n5.jpg',
     rating: 5,
     category: 'minimal',
+    color: 'blue',
   },
   {
     id: 14,
@@ -127,6 +140,7 @@ const products = [
     img: 'images/products/n6.jpg',
     rating: 5,
     category: 'minimal',
+    color: 'beige',
   },
   {
     id: 15,
@@ -136,6 +150,7 @@ const products = [
     img: 'images/products/n7.jpg',
     rating: 5,
     category: 'minimal',
+    color: 'green',
   },
   {
     id: 16,
@@ -145,6 +160,7 @@ const products = [
     img: 'images/products/n8.jpg',
     rating: 5,
     category: 'minimal',
+    color: 'black',
   },
 ];
 

--- a/Cara-main/shop-filters.js
+++ b/Cara-main/shop-filters.js
@@ -18,6 +18,9 @@ const categoryRadios = Array.from(
 const brandCheckboxes = Array.from(
   document.querySelectorAll('input[name="afb-brand"]'),
 );
+const colorCheckboxes = Array.from(
+  document.querySelectorAll('input[name="afb-color"]'),
+);
 const availCheckboxes = Array.from(
   document.querySelectorAll('input[name="afb-avail"]'),
 );
@@ -73,7 +76,7 @@ const refreshPillStates = () =>
   );
 
 const refreshCheckStates = () =>
-  [...brandCheckboxes, ...availCheckboxes].forEach((c) =>
+  [...brandCheckboxes, ...availCheckboxes, ...colorCheckboxes].forEach((c) =>
     c.closest('.afb-check')?.classList.toggle('active', c.checked),
   );
 
@@ -102,6 +105,9 @@ const updateChips = () => {
   brandCheckboxes
     .filter((c) => c.checked)
     .forEach((c) => chips.push(`Brand: ${c.value}`));
+  colorCheckboxes
+    .filter((c) => c.checked)
+    .forEach((c) => chips.push(`Color: ${c.value}`));
   const rating = getActiveRating();
   if (rating > 0) chips.push(`Rating: ${rating}+`);
   availCheckboxes
@@ -141,6 +147,9 @@ const applyFilters = () => {
   const selBrands = brandCheckboxes
     .filter((c) => c.checked)
     .map((c) => c.value.toLowerCase());
+  const selColors = colorCheckboxes
+    .filter((c) => c.checked)
+    .map((c) => c.value.toLowerCase());
   const selAvail = availCheckboxes
     .filter((c) => c.checked)
     .map((c) => c.value.toLowerCase());
@@ -157,6 +166,10 @@ const applyFilters = () => {
 
     // Brand (only when at least one brand box is checked)
     if (selBrands.length && !selBrands.includes(p.brand.toLowerCase()))
+      return false;
+
+    // Color (only when at least one color box is checked)
+    if (selColors.length && !selColors.includes((p.color || '').toLowerCase()))
       return false;
 
     // Availability — products.js has no avail field; treat all as instock
@@ -233,6 +246,12 @@ brandCheckboxes.forEach((c) =>
     applyFilters();
   }),
 );
+colorCheckboxes.forEach((c) =>
+  c.addEventListener('change', () => {
+    refreshCheckStates();
+    applyFilters();
+  }),
+);
 availCheckboxes.forEach((c) =>
   c.addEventListener('change', () => {
     refreshCheckStates();
@@ -259,6 +278,9 @@ clearBtn?.addEventListener('click', () => {
     r.checked = r.value === 'all';
   });
   brandCheckboxes.forEach((c) => {
+    c.checked = false;
+  });
+  colorCheckboxes.forEach((c) => {
     c.checked = false;
   });
   availCheckboxes.forEach((c) => {

--- a/Cara-main/shop.html
+++ b/Cara-main/shop.html
@@ -223,6 +223,20 @@
           </fieldset>
 
           <fieldset class="afb-group">
+            <legend class="afb-group-title"><i class="ri-palette-line"></i> Color</legend>
+            <div class="afb-check-group">
+              <label class="afb-check"><input type="checkbox" name="afb-color" value="black"> <span>Black</span></label>
+              <label class="afb-check"><input type="checkbox" name="afb-color" value="white"> <span>White</span></label>
+              <label class="afb-check"><input type="checkbox" name="afb-color" value="blue"> <span>Blue</span></label>
+              <label class="afb-check"><input type="checkbox" name="afb-color" value="red"> <span>Red</span></label>
+              <label class="afb-check"><input type="checkbox" name="afb-color" value="pink"> <span>Pink</span></label>
+              <label class="afb-check"><input type="checkbox" name="afb-color" value="green"> <span>Green</span></label>
+              <label class="afb-check"><input type="checkbox" name="afb-color" value="beige"> <span>Beige</span></label>
+              <label class="afb-check"><input type="checkbox" name="afb-color" value="brown"> <span>Brown</span></label>
+            </div>
+          </fieldset>
+
+          <fieldset class="afb-group">
             <legend class="afb-group-title"><i class="ri-checkbox-circle-line"></i> Availability</legend>
             <div class="afb-check-group">
               <label class="afb-check"><input type="checkbox" name="afb-avail" value="instock" checked> <span>In Stock</span></label>


### PR DESCRIPTION
Description:

Closes #3039

What this does

Adds a "Color" filter to the shop page's existing filter panel, alongside Category, Brand, Availability, and Rating.

Changes
products.js: added a color field to each of the 16 products
shop.html: added a new "Color" fieldset (checkboxes) inside the existing filter panel, between Brand and Availability
shop-filters.js: wired up color checkboxes into the existing applyFilters() pipeline — reads selected colors, filters the products array, updates chips/count, and resets correctly via "Reset Filters"
Notes
Products can only match one color each right now (single color field, not an array) — multi-color variants can be added later by changing it to colors: [...] if needed.
No backend/API involved — this repo is a static site, so filtering happens client-side against the local products array, same pattern as the existing Brand/Category filters.
Reused the existing .afb-check-group / .afb-check markup and styling, so no new CSS was needed.
Testing done
Verified selecting one or more colors filters the grid correctly
Verified combining Color with Category, Brand, Price, and Rating filters all work together
Verified "Reset Filters" clears color selections
Verified result count and filter chips update correctly
No console errors on load or interaction