### PR TITLE
fix: resolve false-positive no-undef lint errors and exclude archive/build files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,9 +3,47 @@ import globals from 'globals';
 import prettier from 'eslint-plugin-prettier';
 import configPrettier from 'eslint-config-prettier';
 
+const sharedAppGlobals = {
+  showToast: 'readonly',
+  loadNavbar: 'readonly',
+  loadCart: 'readonly',
+  saveCart: 'readonly',
+  cart: 'writable',
+  cartList: 'readonly',
+  subtotalEl: 'readonly',
+  updateCartTotal: 'readonly',
+  addToCart: 'readonly',
+  removeFromCart: 'readonly',
+  buyNow: 'readonly',
+  applyCoupon: 'readonly',
+  handleEmptyCartView: 'readonly',
+  products: 'writable',
+  renderProducts: 'readonly',
+  renderSearchSuggestions: 'readonly',
+  fetchWithTimeout: 'readonly',
+  formatPrice: 'readonly',
+  getWishlist: 'readonly',
+  isInWishlist: 'readonly',
+  toggleWishlistItem: 'readonly',
+  updateWishlistButtonState: 'readonly',
+  syncWishlistButtons: 'readonly',
+  hasPriceDropped: 'readonly',
+  getPriceDropAmount: 'readonly',
+  closeQuiz: 'readonly',
+  CaraToast: 'readonly',
+  CaraErrorBoundary: 'readonly',
+  Pose: 'readonly',
+};
+
 export default [
   {
-    ignores: ['node_modules/**', 'dist/**', 'build/**'],
+    ignores: [
+      'node_modules/**',
+      'dist/**',
+      'build/**',
+      'Cara-main/**',
+      '**/*.min.js',
+    ],
   },
   js.configs.recommended,
 
@@ -16,6 +54,7 @@ export default [
       globals: {
         ...globals.browser,
         ...globals.node,
+        ...sharedAppGlobals,
       },
     },
     plugins: {


### PR DESCRIPTION
## Summary

- Declares shared runtime globals (`showToast`, `getWishlist`, `loadNavbar`, `hasPriceDropped`, etc.) in `eslint.config.mjs` so cross-script symbols loaded via plain `<script>` tags no longer trigger false `no-undef` errors
- Excludes `Cara-main/**` (archived reference folder) and `**/*.min.js` (build artifacts) from lint scope

`npm run lint` previously reported 395 problems, with 171+ false-positive `no-undef` errors plus noise from archived and minified files. After this change, lint reports 274 problems with **zero** `no-undef` errors — remaining issues are legitimate (Prettier formatting, unused vars).

## Test plan

- [x] Run `npm install`
- [x] Run `npm run lint` and confirm zero `no-undef` errors
- [x] Confirm no lint output from `Cara-main/` or `*.min.js` files
- [x] Confirm remaining lint issues are Prettier/unused-vars only

This issue resolves #3249 
