### PR TITLE
Add subject/department validation and live error clearing (#3302)

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -808,12 +808,18 @@ form.addEventListener("submit", function (e) {
     isValid = false;
   }
 
+  
+const subject = document.getElementById("subject");
+  const department = document.getElementById("department");
+
   if (name.value.trim() === "") showError(name, "Name is required");
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   if (!emailRegex.test(email.value)) showError(email, "Valid email required");
+  if (subject.value.trim() === "") showError(subject, "Subject cannot be empty");
+  if (department.value === "") showError(department, "Please select a department");
   if (message.value.trim().length < 10) showError(message, "Message must be at least 10 characters");
 
-  if (isValid) {
+if (isValid) {
     const btn = form.querySelector("button");
     btn.classList.add("btn-loading");
 
@@ -825,7 +831,15 @@ form.addEventListener("submit", function (e) {
   }
 });
 
-
+[name, email, subject, department, message].forEach((field) => {
+  ["input", "change"].forEach((evt) => {
+    field.addEventListener(evt, () => {
+      field.classList.remove("input-error");
+      const next = field.nextElementSibling;
+      if (next && next.classList.contains("error-msg")) next.remove();
+    });
+  });
+});
 /* =========================
    NEWSLETTER FORM
 ========================= */


### PR DESCRIPTION
Closes #3302

## Summary
Completes the client-side validation and UX feedback system for the contact form on `contact.html`. Most of the core validation (name, email format, message min-length, loading spinner, success message) was already implemented in a previous pass — this PR closes the remaining gaps called out in #3302:

- Added validation for the **Subject** field (rejects empty submissions)
- Added validation for the **Department** select (rejects unselected default option)
- Added **live error clearing** — as the user types/selects a corrected value in any field, that field's error message and red border clear immediately, instead of only clearing on the next submit attempt

## Changes
- `contact.html`
  - Added `subject` and `department` to the validated fields on submit
  - Added an `input`/`change` listener loop across all validated fields to clear errors in real time
  - No changes to markup structure, IDs, or existing styling — reused existing `.error-msg` / `.input-error` classes already defined in the file's `<style>` block

## What was already in place (not touched)
- Live character counter on the message textarea (`0 / 500 characters`, with color warning near/at the limit)
- Email format validation via regex
- Message minimum-length check (10 chars)
- Submit loading state (`btn-loading` spinner)
- Success confirmation message with `aria-live="polite"` region

## Testing
- [x] Submitted empty form → all 5 fields (name, email, subject, department, message) show errors
- [x] Entered invalid email → only email error shown
- [x] Corrected a field → its error and red border cleared immediately without resubmitting
- [x] Valid submission → loading spinner shown, form resets, success message displayed, character counter resets to `0 / 500`
- [x] Verified no console errors on page load or interaction