### PR TITLE
fix: use showToast instead of native alert for compare limit message

### DIFF
--- a/compare.js
+++ b/compare.js
@@ -28,8 +28,15 @@
   function addToCompare(product) {
     const list = getCompareList();
     if (list.length >= MAX_ITEMS) {
-      alert('You can compare up to ' + MAX_ITEMS + ' products at a time.');
-      return false;
+      if (typeof showToast === 'function') {
+        showToast(
+          `You can compare up to ${MAX_ITEMS} products at a time.`,
+          'warning',
+        );
+      } else {
+        alert('You can compare up to ' + MAX_ITEMS + ' products at a time.');
+      }
+      return;
     }
     if (list.find((p) => p.id === product.id)) return false;
     list.push(product);
@@ -281,9 +288,13 @@
     if (typeof window.CompareAnimationController === 'function') {
       const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
       const animController = new window.CompareAnimationController();
-      animController.applyMotionPreferences(animController.shouldDisableMotion(motionQuery.matches));
+      animController.applyMotionPreferences(
+        animController.shouldDisableMotion(motionQuery.matches),
+      );
       motionQuery.addEventListener('change', (e) => {
-        animController.applyMotionPreferences(animController.shouldDisableMotion(e.matches));
+        animController.applyMotionPreferences(
+          animController.shouldDisableMotion(e.matches),
+        );
       });
     }
 


### PR DESCRIPTION
## What changed
Replaced the native `alert()` call in `compare.js` (shown when a user tries to add a 4th product to compare) with `showToast()`, consistent with how every other limit/validation message is handled across the app.

## Why
`alert()` blocks the page and uses browser-default styling, breaking visual consistency with the rest of the site's non-blocking toast notifications (used for cart limits, coupon errors, wishlist actions, etc.).

## Testing
- Verified adding a 4th compare item now shows a toast instead of a native alert dialog
- Verified the toast message text is unchanged
- Verified fallback to alert() still works if showToast is somehow unavailable (defensive typeof check)
- npm run lint and npm test pass locally

Closes #3389 