### PR TITLE
fix: add rate limiting to forgot-password and reset-password endpoints

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -248,6 +248,7 @@ def refresh_token(request: Request, response: Response, db: Session = Depends(ge
     return {"message": "Token refreshed successfully"}
 
 @router.post("/forgot-password")
+@limiter.limit("5/minute")
 def forgot_password(
     request: Request,
     payload: ForgotPasswordRequest,
@@ -272,6 +273,7 @@ def forgot_password(
 
 
 @router.post("/reset-password")
+@limiter.limit("5/minute")
 def reset_password(
     request: Request,
     payload: ResetPasswordRequest,


### PR DESCRIPTION
## What changed
Added `@limiter.limit("5/minute")` to `/forgot-password` and `/reset-password`, matching the existing rate-limiting pattern already applied to `/login` and `/register`.

## Why
These two endpoints had no rate limiting, unlike the rest of the auth surface. Without it, `/forgot-password` can be called an unlimited number of times against the same email address, allowing an attacker to email-bomb a victim's inbox with repeated password reset links — a known real-world abuse/harassment vector.

## Testing
- Verified sending more than 5 requests/minute to /forgot-password now returns 429 Too Many Requests
- Verified the same for /reset-password
- Verified normal single-request flow (forgot password → receive email → reset) is unaffected

Closes #3391 