### PR TITLE
fix: add warning log to empty catch block for legacy product data parsing

### DIFF
--- a/app.js
+++ b/app.js
@@ -183,7 +183,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         productName = JSON.parse(
           localStorage.getItem('selectedProduct') || '{}',
         ).name;
-      } catch (e) {}
+      } catch (e) {
+        console.warn('Failed to parse legacy product data:', e);
+      }
     }
 
     if (productName) {


### PR DESCRIPTION
Adds console.warn to the empty catch block in app.js so corrupted localStorage data is logged instead of silently ignored.