### PR TITLE
fix: implement debounce utility properly instead of returning no-op stub

### DIFF
--- a/js/utils/debounce.js
+++ b/js/utils/debounce.js
@@ -1,3 +1,7 @@
 function debounce(f, t) {
-  return f;
+  let timer;
+  return function (...args) {
+    clearTimeout(timer);
+    timer = setTimeout(() => f.apply(this, args), t);
+  };
 }


### PR DESCRIPTION
Replaces the no-op debounce stub that just returned the original function with a proper implementation using setTimeout and clearTimeout.