### PR TITLE
fix: use Indian Rupee symbol instead of dollar in product prices

### DIFF
--- a/products.js
+++ b/products.js
@@ -588,7 +588,7 @@ function renderProducts(containerId, list, query = '') {
       const selectedProduct = {
         id: p.id,
         name: p.name,
-        price: '$' + p.price,
+        price: '₹' + Math.round(Number(p.price)).toLocaleString('en-IN'),
         brand: p.brand,
         image: p.img,
       };


### PR DESCRIPTION
Changes the price prefix from $ to ₹ in products.js to match the rest of the application which uses Indian Rupee formatting.