### PR TITLE
fix: use shared window.CARA_COUPONS in checkout instead of hardcoded duplicate

### DIFF
--- a/checkout.js
+++ b/checkout.js
@@ -482,7 +482,7 @@ window.updateCheckoutSummary = function () {
 
   // Check coupon discount
   const couponCode = localStorage.getItem('appliedCoupon') || '';
-  const COUPONS = { CARA20: 20, WELCOME10: 10 };
+  const COUPONS = window.CARA_COUPONS || {};
   const couponPct = COUPONS[couponCode] || 0;
   const couponDiscount = subtotal * (couponPct / 100);
 


### PR DESCRIPTION
Replaces the hardcoded COUPONS object in checkout.js with window.CARA_COUPONS from coupon-config.js, eliminating the third duplicate source of coupon definitions.