### PR TITLE
fix: add input validation for price filter fields to prevent non-numeric values

### DIFF
--- a/js/product-search.js
+++ b/js/product-search.js
@@ -271,6 +271,11 @@
 
   if (priceMinInput) {
     priceMinInput.addEventListener('change', () => {
+      const val = parseFloat(priceMinInput.value);
+      if (priceMinInput.value !== '' && (isNaN(val) || val < 0)) {
+        priceMinInput.value = '';
+        return;
+      }
       filters.min_price = priceMinInput.value;
       filters.page = 1;
       fetchAndRender();
@@ -279,6 +284,11 @@
 
   if (priceMaxInput) {
     priceMaxInput.addEventListener('change', () => {
+      const val = parseFloat(priceMaxInput.value);
+      if (priceMaxInput.value !== '' && (isNaN(val) || val < 0)) {
+        priceMaxInput.value = '';
+        return;
+      }
       filters.max_price = priceMaxInput.value;
       filters.page = 1;
       fetchAndRender();


### PR DESCRIPTION
Adds parseFloat validation and range checking for min_price and max_price filter inputs. Non-numeric values are silently rejected.