### PR TITLE
fix: add warning log to silent catch block in category dropdown fetch

### DIFF
--- a/js/product-search.js
+++ b/js/product-search.js
@@ -237,8 +237,8 @@
           .join('');
         categorySelect.innerHTML = placeholder + opts;
       })
-      .catch(() => {
-        // Silently fail — static options in HTML serve as fallback
+      .catch((err) => {
+        console.warn('[product-search] Failed to load categories:', err);
       });
   }
 


### PR DESCRIPTION
Replaces the silent catch block in category fetch with console.warn so failed category API calls are logged for debugging.