### PR TITLE
fix: broaden input-shield selector to cover search, url, and tel input types

### DIFF
--- a/js/input-shield.js
+++ b/js/input-shield.js
@@ -4,7 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!form) return;
 
   form.addEventListener('submit', (e) => {
-    const textInputs = form.querySelectorAll("input[type='text'], textarea");
+    const textInputs = form.querySelectorAll("input[type='text'], input[type='search'], input[type='url'], input[type='tel'], textarea");
     let blocked = false;
 
     textInputs.forEach((input) => {


### PR DESCRIPTION
Expands the CSS selector in input-shield.js to also cover input[type=search], input[type=url], and input[type=tel] which could also be vectors for XSS injection.