### PR TITLE
fix: use relative URL default instead of hardcoded HTTP localhost for API base

### DIFF
--- a/checkout.js
+++ b/checkout.js
@@ -12,7 +12,7 @@ function safeParseJSON(key, fallback = '[]') {
   }
 }
 
-const API_BASE_URL = window.CARA_API_BASE_URL || 'http://127.0.0.1:8000';
+const API_BASE_URL = window.CARA_API_BASE_URL || '';
 
 function getStoredAuthToken() {
   return (

--- a/forgotPassword.js
+++ b/forgotPassword.js
@@ -104,7 +104,7 @@ document.addEventListener('DOMContentLoaded', function () {
         submitBtn.disabled = true;
       }
 
-      const API_BASE = window.CARA_API_BASE_URL || 'http://127.0.0.1:8000';
+      const API_BASE = window.CARA_API_BASE_URL || '';
 
       fetch(API_BASE + '/api/auth/forgot-password', {
         method: 'POST',

--- a/js/admin-products.js
+++ b/js/admin-products.js
@@ -1,4 +1,4 @@
-var API_BASE = window.CARA_API_BASE_URL || 'http://127.0.0.1:8000';
+var API_BASE = window.CARA_API_BASE_URL || '';
 
 function getAuthToken() {
   return localStorage.getItem('access_token') || '';

--- a/order-history.js
+++ b/order-history.js
@@ -1,4 +1,4 @@
-const ORDER_API_BASE_URL = window.CARA_API_BASE_URL || 'http://127.0.0.1:8000';
+const ORDER_API_BASE_URL = window.CARA_API_BASE_URL || '';
 
 function getAuthToken() {
   return (

--- a/register.js
+++ b/register.js
@@ -1,5 +1,5 @@
 /* global fetchWithTimeout */
-const API_BASE_URL = window.CARA_API_BASE_URL || 'http://127.0.0.1:8000';
+const API_BASE_URL = window.CARA_API_BASE_URL || '';
 
 document.addEventListener('DOMContentLoaded', () => {
   const btn = document.getElementById('registerSubmitBtn');


### PR DESCRIPTION
Changes the default API_BASE_URL from 'http://127.0.0.1:8000' (HTTP) to '' (relative) across 5 files. The HTTP hardcoded default poses a mixed-content security risk in production.