### PR TITLE
fix: add warning log to empty catch in app.js wishlist parsing

### DIFF
--- a/app.js
+++ b/app.js
@@ -344,7 +344,8 @@ function updateWishlistCount() {
 
   try {
     wishlist = JSON.parse(localStorage.getItem('wishlist')) || [];
-  } catch {
+  } catch (err) {
+    console.warn('Failed to parse wishlist:', err);
     wishlist = [];
   }
 


### PR DESCRIPTION
Adds warning logging when wishlist JSON parsing fails in app.js.