### PR TITLE
fix: add warning log to empty catch blocks in checkout.js

### DIFF
--- a/checkout.js
+++ b/checkout.js
@@ -3,10 +3,12 @@ let checkoutIdempotencyKey = null;
 function safeParseJSON(key, fallback = '[]') {
   try {
     return JSON.parse(localStorage.getItem(key) || fallback);
-  } catch {
+  } catch (err) {
+    console.warn('Failed to parse stored data:', err);
     try {
       return JSON.parse(fallback);
-    } catch {
+    } catch (err2) {
+      console.warn('Failed to parse fallback data:', err2);
       return [];
     }
   }


### PR DESCRIPTION
Adds warning logging when JSON parsing fails in checkout.js storage helper.