### PR TITLE
fix: add warning log to empty catch in compare.js

### DIFF
--- a/compare.js
+++ b/compare.js
@@ -16,7 +16,9 @@
   function getCompareList() {
     try {
       return JSON.parse(sessionStorage.getItem(STORAGE_KEY)) || [];
-    } catch {
+    } catch (err) {
+    console.warn('Failed to compare products:', err);
+  }
       return [];
     }
   }


### PR DESCRIPTION
Adds warning logging when product comparison parsing fails.