### PR TITLE
fix: add warning log to empty catch blocks in empty-cart.js

### DIFF
--- a/empty-cart.js
+++ b/empty-cart.js
@@ -1,10 +1,14 @@
 function safeParseJSON(key, fallback = '[]') {
   try {
     return JSON.parse(localStorage.getItem(key) || fallback);
-  } catch {
+  } catch (err) {
+    console.warn('Failed to parse stored data:', err);
+  }
     try {
       return JSON.parse(fallback);
-    } catch {
+    } catch (err) {
+    console.warn('Failed to parse stored data:', err);
+  }
       return [];
     }
   }


### PR DESCRIPTION
Adds warning logging when cart data parsing fails.