### PR TITLE
fix: add warning log to empty catch in products.js

### DIFF
--- a/products.js
+++ b/products.js
@@ -484,7 +484,9 @@ function safeParseJSON(key, fallback = '[]') {
     }
     try {
       return JSON.parse(fallback);
-    } catch {
+    } catch (err) {
+      console.warn('Failed to process data:', err);
+    }
       return [];
     }
   }


### PR DESCRIPTION
Adds warning logging when product data parsing fails.