### PR TITLE
fix: add warning log to empty catch in address-autocomplete.js

### DIFF
--- a/js/address-autocomplete.js
+++ b/js/address-autocomplete.js
@@ -127,7 +127,9 @@
       if (!res.ok) throw new Error('API error');
       const list = await res.json();
       showSuggestions(list);
-    } catch {
+    } catch (err) {
+      console.warn('Address autocomplete failed:', err);
+    }
       hideSuggestions();
     } finally {
       if (loader) {


### PR DESCRIPTION
Adds warning logging when address autocomplete parsing fails.