### PR TITLE
fix: use console.info instead of console.log in scroll-top.js

### DIFF
--- a/js/scroll-top.js
+++ b/js/scroll-top.js
@@ -1,1 +1,1 @@
-console.log('FAB initialized');
+console.info('FAB initialized');


### PR DESCRIPTION
Uses console.info for initialization logging.