### PR TITLE
fix: use console.info instead of console.log in skeleton-loader.js

### DIFF
--- a/js/skeleton-loader.js
+++ b/js/skeleton-loader.js
@@ -1,1 +1,1 @@
-console.log('Skeleton loader initialized');
+console.info('Skeleton loader initialized');


### PR DESCRIPTION
Uses console.info for initialization logging.