### PR TITLE
fix: use console.info instead of console.log in toast-notifications.js

### DIFF
--- a/js/toast-notifications.js
+++ b/js/toast-notifications.js
@@ -1,1 +1,1 @@
-console.log('Toast system initialized');
+console.info('Toast system initialized');


### PR DESCRIPTION
Uses console.info for initialization logging.