### PR TITLE
fix: add radix 10 to parseInt for digit parsing in checkout.js

### DIFF
--- a/checkout.js
+++ b/checkout.js
@@ -55,7 +55,7 @@ const validators = {
     let sum = 0;
     let shouldDouble = false;
     for (let i = raw.length - 1; i >= 0; i--) {
-      let digit = parseInt(raw.charAt(i));
+      let digit = parseInt(raw.charAt(i), 10);
       if (shouldDouble) {
         digit *= 2;
         if (digit > 9) digit -= 9;


### PR DESCRIPTION
Adds radix 10 to parseInt for credit card digit parsing.