### PR TITLE
Fix: remove JWT from localStorage, rely on httpOnly cookie

### DIFF
--- a/checkout.js
+++ b/checkout.js
@@ -16,23 +16,12 @@ function safeParseJSON(key, fallback = '[]') {
 
 const API_BASE_URL = window.CARA_API_BASE_URL || '';
 
-function getStoredAuthToken() {
-  return (
-    localStorage.getItem('access_token') ||
-    localStorage.getItem('cara_user_token') ||
-    ''
-  );
-}
 
 function buildAuthHeaders(extraHeaders = {}) {
-  const headers = { ...extraHeaders };
-  const token = getStoredAuthToken();
-
-  if (token) {
-    headers.Authorization = `Bearer ${token}`;
-  }
-
-  return headers;
+  // Auth is handled entirely by the httpOnly access_token cookie, which the
+  // browser attaches automatically because these fetch calls use
+  // credentials: 'include'. There is nothing to read from localStorage.
+  return { ...extraHeaders };
 }
 
 const paymentMethod = document.getElementById('paymentMethod');

--- a/js/admin-products.js
+++ b/js/admin-products.js
@@ -1,15 +1,13 @@
 var API_BASE = window.CARA_API_BASE_URL || '';
 
-function getAuthToken() {
-  return localStorage.getItem('access_token') || '';
-}
+
 
 function adminRequest(method, path, body) {
   var opts = {
     method: method,
+    credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: 'Bearer ' + getAuthToken(),
     },
   };
   if (body) opts.body = JSON.stringify(body);
@@ -33,18 +31,18 @@ window.AdminProducts = {
     return adminRequest('DELETE', '/api/admin/products/' + id);
   },
   updateStock: function (id, stock) {
-    return fetch(
-      API_BASE + '/api/admin/products/' + id + '/stock?stock=' + stock,
-      {
-        method: 'PATCH',
-        headers: { Authorization: 'Bearer ' + getAuthToken() },
-      },
-    ).then(function (r) {
-      if (!r.ok)
-        return r.json().then(function (d) {
-          throw new Error(d.detail || 'Request failed');
-        });
-      return r.json();
-    }).catch(err => console.warn("[AdminProducts] Failed:", err));
-  },
-};
+  return fetch(
+    API_BASE + '/api/admin/products/' + id + '/stock?stock=' + stock,
+    {
+      method: 'PATCH',
+      credentials: 'include',
+    },
+  ).then(function (r) {
+    if (!r.ok)
+      return r.json().then(function (d) {
+        throw new Error(d.detail || 'Request failed');
+      });
+    return r.json();
+  }).catch(err => console.warn("[AdminProducts] Failed:", err));
+},
+}

--- a/js/session-lock.js
+++ b/js/session-lock.js
@@ -9,13 +9,27 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   const lockSession = () => {
+    // Clear any legacy identity values left over from before tokens moved
+    // to httpOnly cookies.
     localStorage.removeItem('cara_user_session');
     localStorage.removeItem('cara_user_token');
     localStorage.removeItem('access_token');
     localStorage.removeItem('cara_user_email');
     localStorage.removeItem('cara_user_name');
     localStorage.removeItem('cara_user_role');
-    console.info('Session cleared due to inactivity.');
+
+    // The real session lives in httpOnly cookies, which JS can't clear
+    // directly, so ask the server to invalidate them.
+    const apiBase = window.CARA_API_BASE_URL || '';
+    fetch(`${apiBase}/api/auth/logout`, {
+      method: 'POST',
+      credentials: 'include',
+    })
+      .catch((err) => console.warn('Failed to end session on server:', err))
+      .finally(() => {
+        console.info('Session cleared due to inactivity.');
+        window.location.href = 'login.html';
+      });
   };
 
   // User activity listeners

--- a/order-history.js
+++ b/order-history.js
@@ -1,12 +1,6 @@
 const ORDER_API_BASE_URL = window.CARA_API_BASE_URL || '';
 
-function getAuthToken() {
-  return (
-    localStorage.getItem('access_token') ||
-    localStorage.getItem('cara_user_token') ||
-    ''
-  );
-}
+
 
 function formatCurrency(amount) {
   return new Intl.NumberFormat('en-IN', {
@@ -16,16 +10,10 @@ function formatCurrency(amount) {
 }
 
 function authFetch(url, options = {}) {
-  const headers = { ...(options.headers || {}) };
-  const token = getAuthToken();
-
-  if (token) {
-    headers.Authorization = `Bearer ${token}`;
-  }
-
+  // Auth is carried by the httpOnly access_token cookie, attached
+  // automatically because of credentials: 'include'.
   return fetch(url, {
     ...options,
-    headers,
     credentials: 'include',
   });
 }

--- a/register.js
+++ b/register.js
@@ -123,13 +123,12 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!res.ok) {
         throw new Error(data.detail || 'Registration failed');
       }
-
-      localStorage.setItem('access_token', data.access_token);
-      localStorage.setItem('cara_user_token', data.access_token);
-      localStorage.setItem('cara_user_email', data.user.email);
-      localStorage.setItem('cara_user_name', data.user.username);
-      localStorage.setItem('cara_user_role', data.user.role);
-
+  
+        // The server already issued the access/refresh tokens as httpOnly,
+       // Secure, SameSite cookies (see set_auth_cookies in backend/app/api/auth.py).
+      // Do NOT mirror them into localStorage - that would defeat the whole
+     // point of httpOnly cookies and expose the JWT to any XSS on the page.
+     
       messageBox.style.color = 'green';
       messageBox.innerText = 'Account created successfully! Redirecting...';
 


### PR DESCRIPTION
The backend already issues access/refresh tokens as httpOnly, Secure, SameSite cookies, but the frontend was also mirroring the JWT into localStorage and manually attaching it as an Authorization header, which exposed it to XSS. This removes all localStorage token reads/ writes and lets credentials: 'include' carry auth via the cookie.

Closes #3732

# 📋 Summary
Closes #3732

register.js was storing the JWT access token (and several identity fields) in localStorage even though the backend already issues them as httpOnly, Secure, SameSite cookies (set_auth_cookies() in backend/app/api/auth.py). Several frontend files were then reading that token back out of localStorage and manually attaching it as an Authorization: Bearer <token> header. Since localStorage is readable by any JavaScript on the page, a single XSS bug anywhere in the app was enough to steal the token and fully impersonate a user — the httpOnly protection on the cookie was being bypassed entirely by this parallel code path.

---

## 🔗 Related Issue
Closes #3732
---

please put ✓ symbol on correct block depending n your changes.

## 🔄 Type of Change

- [ ✓] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

---

## 🛠️ What Was Changed

register.js — stopped writing access_token, cara_user_token, cara_user_email, cara_user_name, and cara_user_role to localStorage. None of these were actually read anywhere for UI purposes — they existed only as a duplicate, insecure copy of data the cookie already carries.
checkout.js, order-history.js — removed the localStorage → Authorization header logic. Both already send credentials: 'include' on their fetch calls, so the browser now authenticates purely via the cookie, automatically.
js/admin-products.js — same fix, but this file was missing credentials: 'include' entirely (it relied solely on the Authorization header), so that's been added so cookie-based auth actually works here.
order-history.js — removed a client-side "no token found → redirect to login" pre-check. This would always fire once the token is no longer readable by JS. The server's 401 response (already handled) is now the single source of truth for auth failures.
js/session-lock.js — the inactivity-lock handler previously only cleared localStorage, which did nothing to the real session once the token lives in a cookie JS can't touch. It now calls POST /api/auth/logout to actually invalidate the session server-side before redirecting to the login page.

---
## why this needed
The JWT was readable by any script on the page via localStorage, so any XSS anywhere in the app (e.g. an innerHTML bug like the one referenced in the original issue) could exfiltrate it and let an attacker impersonate the user with no further interaction needed.
Tokens leaked this way can't be revoked server-side once stolen, unlike the httpOnly cookie flow the backend already supports.
The backend had already done the secure half of this fix (issuing httpOnly cookies); the frontend just hadn't been updated to stop working around it.
--

## 🧪 How Has This Been Tested?


Describe how you tested your changes locally.

- [ ] Tested backend API endpoints manually
- [ ] Ran frontend locally with `npm run dev`
- [ ✓] Ran `npm run lint` — no errors
- [ ] Ran `npm run build` — no errors
- [ ] Uploaded a test document and verified output
- [ ] Tested on mobile view

---

## 📸 Screenshots (if applicable)

If your PR includes UI changes, attach before and after screenshots here.

| Before | After |
|--------|-------|
|        |       |

---

## ✅ Self-Review Checklist

- [✓ ] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [ ✓] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [ ✓] I have linked the related issue (`Closes #IssueNumber`)
- [ ✓] I have tested my changes locally
- [ ] I have added screenshots for UI changes
- [ ✓] My changes do not break existing functionality
- [ ✓] I have not pushed any `.env` file or API keys
- [ ✓] My PR contains only changes related to the linked issue

---

## 📋 Additional Notes
No backend changes were required — get_current_user() in backend/app/api/auth.py already reads the token from the cookie first and only falls back to an Authorization header if present, so removing the header entirely doesn't break auth; it just removes the insecure path. Happy to add backend test coverage for cookie-only auth if maintainers want it as a follow-up.
Any additional information for the reviewer.

