### PR TITLE
Fix stored XSS: escape cart item fields before innerHTML insertion (#…

### DIFF
--- a/app.js
+++ b/app.js
@@ -338,7 +338,7 @@ document.addEventListener('DOMContentLoaded', () => {
    ============================================================ */
 
 // Robust price parser
-function parsePriceString(priceStr) {
+function escapeHtml(str){return String(str===undefined||str===null?'':str).replace(/[&<>"']/g,function(ch){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch];});} function parsePriceString(priceStr) {
   if (typeof priceStr === 'number') return isFinite(priceStr) ? priceStr : 0;
   if (!priceStr) return 0;
   const cleaned = String(priceStr)
@@ -945,12 +945,12 @@ window.loadCart = async function () {
     row.innerHTML = `
             <div class="cart-item-left">
                 <div class="cart-item-img-wrap">
-                    <img src="${item.image}" alt="${item.name}" loading="lazy" />
+                    <img src="${escapeHtml(item.image)}" alt="${escapeHtml(item.name)}" loading="lazy" />
                 </div>
                 <div class="cart-item-details">
-                    <span class="cart-item-brand">${item.brand || 'Premium Brand'}</span>
-                    <h5 class="cart-item-title">${item.name}</h5>
-                    <span class="cart-item-size">Size: ${item.size}</span>
+                    <span class="cart-item-brand">${escapeHtml(item.brand || 'Premium Brand')}</span>
+                    <h5 class="cart-item-title">${escapeHtml(item.name)}</h5>
+                    <span class="cart-item-size">Size: ${escapeHtml(String(item.size))}</span>
                 </div>
             </div>
             <div class="cart-item-right">
@@ -1974,12 +1974,12 @@ window.loadSavedItems = function () {
     row.innerHTML = `
             <div class="cart-item-left" style="opacity:0.8;">
                 <div class="cart-item-img-wrap">
-                    <img src="${item.image}" alt="${item.name}" loading="lazy" />
+                    <img src="${escapeHtml(item.image)}" alt="${escapeHtml(item.name)}" loading="lazy" />
                 </div>
                 <div class="cart-item-details">
-                    <span class="cart-item-brand">${item.brand || 'Premium Brand'}</span>
-                    <h5 class="cart-item-title">${item.name}</h5>
-                    <span class="cart-item-size">Size: ${item.size}</span>
+                    <span class="cart-item-brand">${escapeHtml(item.brand || 'Premium Brand')}</span>
+                    <h5 class="cart-item-title">${escapeHtml(item.name)}</h5>
+                    <span class="cart-item-size">Size: ${escapeHtml(String(item.size))}</span>
                 </div>
             </div>
             <div class="cart-item-right" style="flex-direction:row;align-items:center;justify-content:space-between;">


### PR DESCRIPTION
…3788)

Adds an escapeHtml() helper and uses it to sanitize item.name, item.image, item.brand, and item.size before they are interpolated into innerHTML in loadCart() and loadSavedItems(). Fixes #3788.

# 📋 Summary
Escapes item.name/item.image/item.brand/item.size before they're inserted via innerHTML in loadCart() and loadSavedItems(), closing the stored-XSS path via crafted wardrobe-share links.

---

## 🔗 Related Issue
Closes #3788

---

please put ✓ symbol on correct block depending n your changes.

## 🔄 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

---

## 🛠️ What Was Changed
Briefly decribe what changes you made.

- 
- 
- 

---
## why this needed
Describe why this project needed this changes.
-
-
-
---
## 🧪 How Has This Been Tested?

Describe how you tested your changes locally.

- [ ] Tested backend API endpoints manually
- [ ] Ran frontend locally with `npm run dev`
- [ ] Ran `npm run lint` — no errors
- [ ] Ran `npm run build` — no errors
- [ ] Uploaded a test document and verified output
- [ ] Tested on mobile view

---

## 📸 Screenshots (if applicable)

If your PR includes UI changes, attach before and after screenshots here.

| Before | After |
|--------|-------|
|        |       |

---

## ✅ Self-Review Checklist

- [ ] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [ ] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [ ] I have linked the related issue (`Closes #IssueNumber`)
- [ ] I have tested my changes locally
- [ ] I have added screenshots for UI changes
- [ ] My changes do not break existing functionality
- [ ] I have not pushed any `.env` file or API keys
- [ ] My PR contains only changes related to the linked issue

---

## 📋 Additional Notes

Any additional information for the reviewer.

