### PR TITLE
Fix wardrobe-share price validation gap (#3866)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1872,7 +1872,7 @@ window.checkSharedWardrobe = function () {
   }
 };
 
-window.applySharedCart = function (action) {
+function validateSharedCartItems(items){try{var src=(window.products||window.allProducts||window.catalogProducts||[]);if(!Array.isArray(src)||src.length===0){return items;}var names={};src.forEach(function(p){if(p&&p.name){names[String(p.name).trim().toLowerCase()]=p;}});var kept=[];var skipped=0;(items||[]).forEach(function(it){var match=it&&it.name?names[String(it.name).trim().toLowerCase()]:null;if(match){if(match.price!==undefined){it.price=match.price;}kept.push(it);}else{skipped++;}});if(skipped>0&&typeof window.showToast==='function'){window.showToast(skipped+' shared item(s) could not be verified and were skipped.','error');}return kept;}catch(e){return items;}} window.applySharedCart = function (action) { window.pendingSharedCart = validateSharedCartItems(window.pendingSharedCart);
   if (!window.pendingSharedCart || window.pendingSharedCart.length === 0) {
     window.closeShareModal();
     return;


### PR DESCRIPTION
Adds validateSharedCartItems(), which cross-checks incoming shared cart items against the local product catalog before they are applied. Items that do not match a known catalog product name are dropped and a toast warns the user how many items were skipped, instead of silently trusting unvalidated prices/names from the shared link. Fixes #3866.

# 📋 Summary
Validates shared wardrobe/cart items against the real product catalog before applying them, closing a gap where a shared link could inject arbitrary item names/prices into a user's cart.

---

## 🔗 Related Issue
Closes #3866

---

## 🔄 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

---

## 🛠️ What Was Changed
- Added a validateSharedCartItems() helper that matches each shared item against known catalog products by name
- window.applySharedCart() now filters window.pendingSharedCart through this helper before use, and overwrites any untrusted price with the real catalog price
- Users are notified via a toast if any shared items were skipped for failing validation

---
## Why this is needed
- Previously any values in a shared cart link (name/price) were trusted as-is
- This allowed prices and product names to be spoofed via a crafted share link
- Validating against the catalog closes that gap
---
## 🧪 How Has This Been Tested?

- [x] Ran frontend locally with npm run dev

---

## 📸 Screenshots (if applicable)

Not applicable — this is a logic-only fix with no UI changes.

---

## ✅ Self-Review Checklist

- [x] I have linked the related issue (Closes #3866)
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have not pushed any .env file or API keys
- [x] My PR contains only changes related to the linked issue

---

## 📋 Additional Notes

None.