### PR TITLE
Fix shareWardrobe(): actually copy link to clipboard (#3868)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1734,7 +1734,7 @@ window.shareWardrobe = function () {
       '#share=' +
       base64Payload;
 
-    showToast('Wardrobe share link copied to clipboard!', 'success');
+    if (navigator.clipboard && navigator.clipboard.writeText) { navigator.clipboard.writeText(shareUrl).catch(function(){ fallbackCopyText(shareUrl); }); } else { fallbackCopyText(shareUrl); } showToast('Wardrobe share link copied to clipboard!', 'success');
 
     if (btn) {
       const originalText = btn.innerHTML;


### PR DESCRIPTION
shareWardrobe() previously showed a "copied to clipboard" success toast without ever writing the link to the clipboard. Now it calls navigator.clipboard.writeText(shareUrl), falling back to the existing fallbackCopyText() helper (execCommand-based) if the Clipboard API is unavailable or rejects. Fixes #3868.

# 📋 Summary
Fixes the wardrobe share button so it actually copies the share link to the clipboard instead of only claiming success.

---

## 🔗 Related Issue
Closes #3868

---

## 🔄 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

---

## 🛠️ What Was Changed
- shareWardrobe() now calls navigator.clipboard.writeText(shareUrl) before showing the success toast
- If the Clipboard API is unavailable or the write fails, it falls back to the existing fallbackCopyText() helper (which was previously defined but never called)

---
## Why this is needed
- The button previously showed "Link Copied!" and a success toast even though nothing was ever copied
- Users had to manually select/copy the URL themselves, silently breaking the share feature
---
## 🧪 How Has This Been Tested?

- [x] Ran frontend locally with npm run dev

---

## 📸 Screenshots (if applicable)

Not applicable — this is a logic-only fix with no visual changes.

---

## ✅ Self-Review Checklist

- [x] I have linked the related issue (Closes #3868)
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have not pushed any .env file or API keys
- [x] My PR contains only changes related to the linked issue

---

## 📋 Additional Notes

None.