### PR TITLE
Fix sort-by-price: add fallback when sort value is unrecognized (#3870)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1457,7 +1457,7 @@ document.addEventListener('DOMContentLoaded', () => {
           return nameA.localeCompare(nameB);
         });
       }
-      productsToAppend.forEach((product) => {
+      if (!productsToAppend) { productsToAppend = originalProducts; } productsToAppend.forEach((product) => {
         proContainer.appendChild(product);
       });
     });


### PR DESCRIPTION
The product sort handler only assigned productsToAppend inside a chain of if/else-if branches for known sort values (default, low-high, high-low, rating, alphabetical), with no final else. Any unrecognized sort value left productsToAppend undefined, causing a TypeError on productsToAppend.forEach(). Added a fallback that defaults productsToAppend to originalProducts when it was never assigned. Fixes #3870.

# 📋 Summary
Prevents a crash in the product sort handler when the selected sort value doesn't match any known case.

---

## 🔗 Related Issue
Closes #3870

---

## 🔄 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

---

## 🛠️ What Was Changed
- Added a fallback check right before productsToAppend.forEach(): if productsToAppend was never assigned by the if/else-if chain, it now defaults to originalProducts

---
## Why this is needed
- The sort handler only set productsToAppend for the exact known sort values
- Any other/unexpected value (e.g. a new dropdown option, a typo, or a manipulated DOM value) left productsToAppend undefined, throwing a TypeError and breaking the product listing entirely
---
## 🧪 How Has This Been Tested?

- [x] Ran frontend locally with npm run dev

---

## 📸 Screenshots (if applicable)

Not applicable — this is a logic-only defensive fix.

---

## ✅ Self-Review Checklist

- [x] I have linked the related issue (Closes #3870)
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have not pushed any .env file or API keys
- [x] My PR contains only changes related to the linked issue

---

## 📋 Additional Notes

None.