### PR TITLE
Guard unguarded CaraErrorBoundary.wrap() call (#3871)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1215,7 +1215,7 @@ window.buyNow = function (
   const productSection = document.getElementById('product1');
   if (!productSection) return;
 
-  CaraErrorBoundary.wrap('#product1', function () {
+  if (!window.CaraErrorBoundary || typeof window.CaraErrorBoundary.wrap !== 'function') { window.CaraErrorBoundary = window.CaraErrorBoundary || {}; window.CaraErrorBoundary.wrap = function (selector, fn) { try { return fn(); } catch (e) { if (typeof window.logError === 'function') { window.logError('CaraErrorBoundary fallback caught error for ' + selector, e); } else { console.error('CaraErrorBoundary fallback caught error for ' + selector, e); } } }; } CaraErrorBoundary.wrap('#product1', function () {
     const productsPerPage = 16;
 
     const productContainers = Array.from(


### PR DESCRIPTION
The product initialization code called CaraErrorBoundary.wrap(...) directly with no check that window.CaraErrorBoundary (or its wrap method) actually exists. If that dependency failed to load or was ever removed, this call would throw a TypeError and abort setup for the whole product section. Added a guard that installs a safe fallback wrap() (which just calls the function in a try/catch and logs any error) when CaraErrorBoundary or its wrap method is missing. Fixes #3871.

# 📋 Summary
Prevents a page-breaking crash if the CaraErrorBoundary helper is ever missing or fails to load before it is used.

---

## 🔗 Related Issue
Closes #3871

---

## 🔄 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

---

## 🛠️ What Was Changed
- Added a guard before the CaraErrorBoundary.wrap('#product1', ...) call that checks window.CaraErrorBoundary and its wrap method exist
- If missing, installs a minimal safe fallback wrap(selector, fn) that runs fn() in a try/catch and logs any error instead of throwing

---
## Why this is needed
- CaraErrorBoundary.wrap was called unconditionally with no existence check
- If the script defining CaraErrorBoundary failed to load, was removed, or loaded after this code ran, the call would throw a TypeError and break product section initialization entirely
---
## 🧪 How Has This Been Tested?

- [x] Ran frontend locally with npm run dev

---

## 📸 Screenshots (if applicable)

Not applicable — this is a defensive logic-only fix.

---

## ✅ Self-Review Checklist

- [x] I have linked the related issue (Closes #3871)
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have not pushed any .env file or API keys
- [x] My PR contains only changes related to the linked issue

---

## 📋 Additional Notes

None.