### PR TITLE
Consolidate rupee formatting and flag dead code (#3873)

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,7 +11,7 @@ window.logError =
  * Sanitizes return URL query parameters to prevent Open Redirect and SSRF vulnerabilities.
  * Enforces strictly relative URLs and blocks external origins.
  */
-function sanitizeReturnUrl(url) {
+/* NOTE (#3873): no call sites for sanitizeReturnUrl() found in app.js; confirm it is actually wired up elsewhere, otherwise this offers no real protection. */ function sanitizeReturnUrl(url) {
   if (!url || typeof url !== 'string') return 'index.html';
 
   var trimmed = url.trim();
@@ -39,7 +39,7 @@ window.sanitizeReturnUrl = sanitizeReturnUrl;
 /**
  * Verifies object-level authorization (BOLA) to ensure the current authenticated user owns the requested order resource.
  */
-function verifyOrderOwnership(order, currentUserId, isAdmin) {
+/* NOTE (#3873): no call sites for verifyOrderOwnership() found in app.js; confirm it is actually enforced elsewhere, otherwise this offers no real BOLA protection. */ function verifyOrderOwnership(order, currentUserId, isAdmin) {
   if (isAdmin) return true;
   if (!order || typeof order !== 'object') return false;
   if (!currentUserId) return false;
@@ -407,8 +407,7 @@ window.updateWishlistCount = updateWishlistCount;
 
 // GLOBAL WISHLIST LOGIC
 function formatRupee(amount) {
-  const num = parsePriceString(amount);
-  return '₹' + Math.round(num).toLocaleString('en-IN');
+  return formatCurrency(amount); // consolidated: delegates to formatCurrency to avoid duplicate rupee-formatting logic (see #3873)
 }
 
 function hasPriceDropped(item) {
@@ -1695,7 +1694,7 @@ document.addEventListener('DOMContentLoaded', () => {
 window.pendingSharedCart = null;
 
 // NOTE: intentionally named showWardrobeToast to avoid overwriting the global showToast
-function showWardrobeToast(msg, isError) {
+/* NOTE (#3873): showWardrobeToast() has no call sites in app.js (dead code); consider removing it or wiring it up. */ function showWardrobeToast(msg, isError) {
   showToast(msg, isError ? 'error' : 'success');
 }
 


### PR DESCRIPTION
formatRupee() now delegates to formatCurrency() instead of independently re-implementing rupee rounding/formatting, removing the risk of the two drifting apart. Also added inline comments on sanitizeReturnUrl(), verifyOrderOwnership(), and showWardrobeToast() noting that none of them currently have any call sites in app.js, so their effectiveness (including the security guarantees claimed by the first two) should be verified or they should be wired up/removed. Fixes #3873.

# 📋 Summary
Consolidates duplicate rupee-formatting logic and flags dead/unverified code paths called out in #3873.

---

## 🔗 Related Issue
Closes #3873

---

## 🔄 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [x] Refactor
- [ ] Test
- [ ] Chore / dependency update

---

## 🛠️ What Was Changed
- formatRupee(amount) now simply returns formatCurrency(amount) instead of re-implementing the same rounding/formatting logic
- Added inline comments above sanitizeReturnUrl(), verifyOrderOwnership(), and showWardrobeToast() noting they have no call sites within app.js

---
## Why this is needed
- formatCurrency and formatRupee could silently drift apart since they duplicated the same logic independently
- sanitizeReturnUrl() and verifyOrderOwnership() carry detailed security-purpose comments (Open Redirect/SSRF and BOLA protection) but are never invoked in this file, which could give a false sense of security if not actually wired up elsewhere
- showWardrobeToast() is simply unused dead code
---
## 🧪 How Has This Been Tested?

- [x] Ran frontend locally with npm run dev

---

## 📸 Screenshots (if applicable)

Not applicable — this is a logic/comment-only change with no visual impact.

---

## ✅ Self-Review Checklist

- [x] I have linked the related issue (Closes #3873)
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have not pushed any .env file or API keys
- [x] My PR contains only changes related to the linked issue

---

## 📋 Additional Notes

This PR does not remove sanitizeReturnUrl(), verifyOrderOwnership(), or showWardrobeToast() since they may be intended for future/external use — it only flags them for review, per the issue's request to confirm before assuming they're truly dead.