### PR TITLE
fix : correct parseInt expressions in products.js star-rating handler

### DIFF
--- a/products.js
+++ b/products.js
@@ -391,7 +391,7 @@ function renderStars(baseRating, productId) {
     // ── User rating on click ──
     starIcon.addEventListener('click', (e) => {
       e.stopPropagation();
-      const clickedValue = parseInt(star, 10)Icon.dataset.value);
+      const clickedValue = parseInt(starIcon.dataset.value, 10);
       saveUserRating(productId, clickedValue, starDiv);
     });
 
@@ -447,7 +447,7 @@ function saveUserRating(productId, rating, starDiv) {
 function highlightStars(starDiv, upTo) {
   const stars = starDiv.querySelectorAll('i[data-value]');
   stars.forEach((star) => {
-    const val = parseInt(star, 10).dataset.value);
+    const val = parseInt(star.dataset.value, 10);
     star.className = val <= upTo ? 'ri-star-fill' : 'ri-star-line';
   });
 }
@@ -460,7 +460,7 @@ function highlightStars(starDiv, upTo) {
 function updateStarDisplay(starDiv, rating) {
   const stars = starDiv.querySelectorAll('i[data-value]');
   stars.forEach((star) => {
-    const i = parseInt(star, 10).dataset.value);
+    const i = parseInt(star.dataset.value, 10);
     if (i <= Math.floor(rating)) {
       star.className = 'ri-star-fill';
     } else if (i === Math.ceil(rating) && rating % 1 !== 0) {
@@ -486,7 +486,6 @@ function safeParseJSON(key, fallback = '[]') {
       return JSON.parse(fallback);
     } catch (err) {
       console.warn('Failed to process data:', err);
-    }
       return [];
     }
   }


### PR DESCRIPTION
## 📄 Description
Fixed three malformed parseInt expressions in the shared products.js bundle that caused a JavaScript SyntaxError, blocking all storefront pages from rendering. The expressions used an invalid fusion of parseInt and dataset access: parseInt(star, 10)Icon.dataset.value) and parseInt(star, 10).dataset.value). Corrected all three to parseInt(starIcon.dataset.value, 10) or parseInt(star.dataset.value, 10) with the correct variable scope. Also fixed a secondary syntax error (misaligned return statement) discovered during verification.

## 🔗 Related Issues
Closes #4006

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.