### PR TITLE
fix : add try-catch guards around localStorage calls in theme-engine.js

### DIFF
--- a/js/theme-engine.js
+++ b/js/theme-engine.js
@@ -20,7 +20,11 @@ export function getSystemTheme() {
 
 export function getStoredTheme() {
   if (typeof localStorage !== 'undefined') {
-    return localStorage.getItem('cara_theme') || THEMES.SYSTEM;
+    try {
+      return localStorage.getItem('cara_theme') || THEMES.SYSTEM;
+    } catch (e) {
+      return THEMES.SYSTEM;
+    }
   }
   return THEMES.SYSTEM;
 }
@@ -40,7 +44,11 @@ export function applyTheme(themeChoice) {
   }
 
   if (typeof localStorage !== 'undefined') {
-    localStorage.setItem('cara_theme', themeChoice);
+    try {
+      localStorage.setItem('cara_theme', themeChoice);
+    } catch (e) {
+      // Silently fail if localStorage is unavailable (e.g., Safari private mode, quota exceeded)
+    }
   }
 
   if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {


### PR DESCRIPTION
## 📄 Description
Added try/catch guards around both localStorage.getItem and localStorage.setItem calls in theme-engine.js. In Safari private browsing mode or when the 5MB storage quota is exceeded, these calls throw a DOMException. Without a guard, this would crash the entire theme engine and potentially the page. Now the engine gracefully falls back to the SYSTEM theme on read failures and silently ignores write failures.

## 🔗 Related Issues
Closes #4008

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the \`tmdeveloper007\` account when picking it up.