### PR TITLE
fix : share wardrobe never copies to clipboard

### DIFF
--- a/app.js
+++ b/app.js
@@ -1734,6 +1734,9 @@ window.shareWardrobe = function () {
       '#share=' +
       base64Payload;
 
+    // Actually copy the URL to clipboard before showing success
+    fallbackCopyText(shareUrl);
+
     showToast('Wardrobe share link copied to clipboard!', 'success');
 
     if (btn) {


### PR DESCRIPTION
## 📄 Description
Fixed shareWardrobe() in app.js to actually copy the generated wardrobe share URL to the clipboard before showing the success toast. The function previously showed a success message but never called fallbackCopyText(shareUrl) or navigator.clipboard.writeText(shareUrl), leaving the clipboard empty. Now the existing fallbackCopyText helper is called before the toast, accurately reflecting the actual clipboard state.

## 🔗 Related Issues
Closes #4009

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the \`tmdeveloper007\` account when picking it up.