### PR TITLE
fix : correct malformed catch/finally blocks in compare.js and address-autocomplete.js

### DIFF
--- a/compare.js
+++ b/compare.js
@@ -18,8 +18,7 @@
     try {
       return JSON.parse(sessionStorage.getItem(STORAGE_KEY)) || [];
     } catch (err) {
-    console.warn('Failed to compare products:', err);
-  }
+      console.warn('Failed to compare products:', err);
       return [];
     }
   }

--- a/js/address-autocomplete.js
+++ b/js/address-autocomplete.js
@@ -130,7 +130,6 @@
       showSuggestions(list);
     } catch (err) {
       console.warn('Address autocomplete failed:', err);
-    }
       hideSuggestions();
     } finally {
       if (loader) {


### PR DESCRIPTION
## 📄 Description
Fixed two JavaScript syntax errors that prevented the product comparison and checkout address autocomplete features from loading:

1. compare.js: getCompareList() had a missing closing brace after the catch block and a stray return statement at global scope. Restructured the function body so the catch block properly closes with a return [] statement inside.

2. js/address-autocomplete.js: the try-catch-finally block had a malformed structure where hideSuggestions() was incorrectly placed outside the catch block and an extra closing brace appeared before the finally clause. Restructured so hideSuggestions() is called inside the catch block.

Both files now pass Node.js syntax checks and the affected page features can initialize correctly.

## 🔗 Related Issues
Closes #3983

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.