### PR TITLE
fix : add try-catch around JSON.parse in error-logger.js

### DIFF
--- a/js/error-logger.js
+++ b/js/error-logger.js
@@ -1,17 +1,26 @@
 // Client-Side Error Boundary and Logger
 window.addEventListener('error', (event) => {
   console.error('Runtime exception caught: ', event.error);
-  const errors = JSON.parse(localStorage.getItem('cara_runtime_errors')) || [];
+  let errors = [];
+  try {
+    errors = JSON.parse(localStorage.getItem('cara_runtime_errors')) || [];
+  } catch (e) {
+    errors = [];
+  }
   errors.push({
     message: event.message,
     filename: event.filename,
     lineno: event.lineno,
     timestamp: new Date().toISOString(),
   });
-  localStorage.setItem(
-    'cara_runtime_errors',
-    JSON.stringify(errors.slice(-10)),
-  );
+  try {
+    localStorage.setItem(
+      'cara_runtime_errors',
+      JSON.stringify(errors.slice(-10)),
+    );
+  } catch (e) {
+    // Silently ignore if localStorage is unavailable
+  }
 
   // Display fallback crash notice if main app component fails
   if (event.filename.includes('app.js')) {


### PR DESCRIPTION
## 📄 Description
Wrapped JSON.parse(localStorage.getItem(...)) in a try/catch block in error-logger.js. If localStorage contains corrupted or non-JSON data, the parse throws an uncaught exception that would crash the error logger and prevent all subsequent error reporting. The fix initializes errors to an empty array on parse failure. Also added a try/catch around the localStorage.setItem call for robustness.

## 🔗 Related Issues
Closes #4012

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the \`tmdeveloper007\` account when picking it up.