### PR TITLE
fix : escape untrusted strings before innerHTML in order-timeline.js

### DIFF
--- a/js/order-timeline.js
+++ b/js/order-timeline.js
@@ -3,7 +3,16 @@ document.addEventListener("DOMContentLoaded", () => {
     if (!trackingBox) return;
 
     let stageIndex = 1; // Start at 'Confirmed'/'Processing' (index 1)
-    
+
+    function _escape(str) {
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
     function renderTimeline() {
         let simulator = null;
         let stages = ['Placed', 'Processing', 'Shipped', 'Delivered'];
@@ -29,12 +38,12 @@ document.addEventListener("DOMContentLoaded", () => {
             const bg = isActive ? '#088178' : '#ccc';
             const color = 'white';
             const timeStr = isActive ? (simulator ? simulator.getSimulatedTimestamp(idx, baseTime) : new Date().toLocaleTimeString()) : '';
-            
+
             html += `
                 <div class="timeline-step" style="z-index:3; text-align:center;">
                     <div style="width:28px; height:28px; border-radius:50%; background:${bg}; color:${color}; line-height:28px; margin:0 auto; font-weight:bold;">${idx + 1}</div>
-                    <p style="font-size:12px; margin-top:5px; font-weight:600;">${stage}</p>
-                    <p class="timeline-time" style="font-size:10px; color:#777; margin-top:2px;">${timeStr}</p>
+                    <p style="font-size:12px; margin-top:5px; font-weight:600;">${_escape(stage)}</p>
+                    <p class="timeline-time" style="font-size:10px; color:#777; margin-top:2px;">${_escape(timeStr)}</p>
                 </div>
             `;
         });


### PR DESCRIPTION
## 📄 Description
Added an _escape() helper function to order-timeline.js that HTML-encodes &, <, >, ", and ' characters. Applied _escape() to all user-controlled strings interpolated into innerHTML: the stage names and the timeStr (from simulator.getSimulatedTimestamp() or Date.toLocaleTimeString()). This closes a potential Cross-Site Scripting (XSS) vulnerability where malicious data injected via the simulator could execute arbitrary scripts in the victim's browser.

## 🔗 Related Issues
Closes #4015

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the \`tmdeveloper007\` account when picking it up.