### PR TITLE
fix : replace emoji characters with text in inventory-alert-banner.js

### DIFF
--- a/js/inventory-alert-banner.js
+++ b/js/inventory-alert-banner.js
@@ -11,7 +11,7 @@ export function renderInventoryBanner(containerId, message, type = 'warning') {
   banner.setAttribute('aria-live', 'polite');
   banner.innerHTML = `
     <div class="inventory-banner-content">
-      <span class="inventory-banner-icon">${type === 'warning' ? '⚠️' : 'ℹ️'}</span>
+      <span class="inventory-banner-icon">${type === 'warning' ? 'Warning:' : 'Info:'}</span>
       <span class="inventory-banner-text">${message}</span>
     </div>
     <button class="inventory-banner-close" aria-label="Dismiss banner">&times;</button>


### PR DESCRIPTION
## 📄 Description
Replaced Unicode emoji characters (U+26A0 WARNING SIGN and U+2139 INFORMATION SOURCE) with plain text labels ('Warning:' and 'Info:') in js/inventory-alert-banner.js to comply with the project EMOJI POLICY.

## 🔗 Related Issues
Closes #4028

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.