### PR TITLE
fix : add localStorage try-catch guards in i18n.js

### DIFF
--- a/js/i18n.js
+++ b/js/i18n.js
@@ -39,7 +39,11 @@ const translations = {
 
 function changeLanguage(lang) {
   if (!translations[lang]) return;
-  localStorage.setItem("selectedLanguage", lang);
+  try {
+    localStorage.setItem("selectedLanguage", lang);
+  } catch (e) {
+    // Silently fail if localStorage is unavailable (private browsing, quota exceeded)
+  }
 
   document.querySelectorAll("[data-i18n]").forEach((el) => {
     const key = el.getAttribute("data-i18n");
@@ -63,7 +67,12 @@ function changeLanguage(lang) {
 }
 
 function initLanguage() {
-  const savedLang = localStorage.getItem("selectedLanguage") || "en";
+  let savedLang = "en";
+  try {
+    savedLang = localStorage.getItem("selectedLanguage") || "en";
+  } catch (e) {
+    // Fall back to English if localStorage is unavailable
+  }
   changeLanguage(savedLang);
 }
 


### PR DESCRIPTION
## 📄 Description
Wrapped localStorage.setItem in changeLanguage() and localStorage.getItem in initLanguage() with try-catch blocks to prevent unhandled exceptions in browsers with restricted storage (private browsing, quota exceeded).

## 🔗 Related Issues
Closes #4035

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.