### PR TITLE
fix : remove console.warn from address-autocomplete fetch error handler

### DIFF
--- a/js/address-autocomplete.js
+++ b/js/address-autocomplete.js
@@ -129,7 +129,6 @@
       const list = await res.json();
       showSuggestions(list);
     } catch (err) {
-      console.warn('Address autocomplete failed:', err);
       hideSuggestions();
     } finally {
       if (loader) {


### PR DESCRIPTION
## 📄 Description
Removed the console.warn call in the catch block of fetchSuggestions() in js/address-autocomplete.js. The function already hides the suggestions dropdown on failure, which is sufficient user-facing behavior — the console warning added production noise.

## 🔗 Related Issues
Closes #4036

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.