### PR TITLE
feat: Implement Web Share Target API for visual search (#4085)

### DIFF
--- a/assets/css/visual-search.css
+++ b/assets/css/visual-search.css
@@ -1,0 +1,79 @@
+/* Visual Search specific styles */
+.visual-search-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 40px auto;
+  max-width: 1200px;
+  padding: 0 20px;
+}
+
+.preview-container {
+  width: 100%;
+  max-width: 400px;
+  min-height: 200px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  background-color: var(--card);
+  margin-bottom: 40px;
+}
+
+#shared-image-preview {
+  width: 100%;
+  height: auto;
+  object-fit: contain;
+  display: block;
+}
+
+.loading-spinner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: var(--text-color);
+}
+
+.spin-icon {
+  font-size: 2rem;
+  animation: spin 1s linear infinite;
+  margin-bottom: 10px;
+  color: #088178;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.results-container {
+  width: 100%;
+}
+
+.results-container h3 {
+  margin-bottom: 20px;
+  font-size: 1.5rem;
+  color: var(--text-color);
+  text-align: center;
+}
+
+.error-container {
+  text-align: center;
+  padding: 40px;
+  background-color: #ffeaea;
+  border-radius: 8px;
+  color: #d9534f;
+  margin-top: 20px;
+}
+
+.error-container i {
+  font-size: 3rem;
+  margin-bottom: 10px;
+}
+
+.error-container button {
+  margin-top: 20px;
+  background-color: #d9534f;
+}

--- a/js/visual-search.js
+++ b/js/visual-search.js
@@ -1,0 +1,93 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const loadingIndicator = document.getElementById('loading-indicator');
+  const imagePreview = document.getElementById('shared-image-preview');
+  const resultsContainer = document.getElementById('search-results');
+  const errorContainer = document.getElementById('error-message');
+  
+  // Check for error in URL params
+  const urlParams = new URLSearchParams(window.location.search);
+  if (urlParams.get('error')) {
+    showError();
+    return;
+  }
+
+  try {
+    // Attempt to read the shared image from the cache
+    const cache = await caches.open('shared-image-cache');
+    const cachedResponse = await cache.match('/shared-image');
+
+    if (!cachedResponse) {
+      // If there's no shared image, perhaps they navigated here directly
+      // In a real app, maybe show an upload button here instead.
+      throw new Error('No shared image found.');
+    }
+
+    const blob = await cachedResponse.blob();
+    const objectURL = URL.createObjectURL(blob);
+    
+    // Display the image
+    imagePreview.src = objectURL;
+    imagePreview.style.display = 'block';
+    
+    // Clean up cache after retrieving
+    await cache.delete('/shared-image');
+    
+    // Simulate visual search processing delay
+    setTimeout(() => {
+      loadingIndicator.style.display = 'none';
+      
+      // We would normally upload the blob to our backend here for vector search
+      // e.g., const formData = new FormData(); formData.append('image', blob);
+      // await fetch('/api/visual-search', { method: 'POST', body: formData });
+      
+      // For now, load dummy similar products to demonstrate handoff to UI
+      loadSimilarProducts();
+    }, 2000);
+
+  } catch (err) {
+    console.error('Visual Search Error:', err);
+    showError();
+  }
+
+  function showError() {
+    loadingIndicator.style.display = 'none';
+    imagePreview.style.display = 'none';
+    errorContainer.style.display = 'block';
+  }
+
+  function loadSimilarProducts() {
+    resultsContainer.style.display = 'block';
+    const productsGrid = document.getElementById('similar-products-grid');
+    
+    // Mock similar products
+    const mockProducts = [
+      { id: 1, name: 'Floral Print Shirt', brand: 'adidas', price: 78, img: 'images/products/f1.jpg' },
+      { id: 2, name: 'Floral Leaf Shirt', brand: 'adidas', price: 78, img: 'images/products/f2.jpg' },
+      { id: 3, name: 'Vintage Flower Shirt', brand: 'adidas', price: 78, img: 'images/products/f3.jpg' }
+    ];
+    
+    let html = '';
+    mockProducts.forEach(p => {
+      html += `
+        <div class="pro" onclick="window.location.href='singleProduct.html?id=${p.id}'">
+          <img src="${p.img}" alt="${p.name}">
+          <div class="des">
+            <span>${p.brand}</span>
+            <h5>${p.name}</h5>
+            <div class="star">
+              <i class="fas fa-star"></i>
+              <i class="fas fa-star"></i>
+              <i class="fas fa-star"></i>
+              <i class="fas fa-star"></i>
+              <i class="fas fa-star"></i>
+            </div>
+            <h4>$${p.price}</h4>
+          </div>
+          <a href="#"><i class="fa-solid fa-cart-shopping cart"></i></a>
+        </div>
+      `;
+    });
+    
+    productsGrid.innerHTML = html;
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "Cara - E-commerce Platform",
   "short_name": "Cara",
   "start_url": "/index.html",
@@ -8,5 +8,21 @@
   "icons": [
     { "src": "/images/Dlogo.png", "sizes": "192x192", "type": "image/png" },
     { "src": "/images/Dlogo.png", "sizes": "512x512", "type": "image/png" }
-  ]
+  ],
+  "share_target": {
+    "action": "/visual-search.html",
+    "method": "POST",
+    "enctype": "multipart/form-data",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "url",
+      "files": [
+        {
+          "name": "image",
+          "accept": ["image/*"]
+        }
+      ]
+    }
+  }
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-﻿const CACHE_NAME = 'cara-cache-v1';
+const CACHE_NAME = 'cara-cache-v1';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',
@@ -39,6 +39,33 @@ self.addEventListener('activate', (event) => {
 });
 
 self.addEventListener('fetch', (event) => {
+  // Handle POST requests from Web Share Target API
+  if (event.request.method === 'POST' && event.request.url.endsWith('/visual-search.html')) {
+    event.respondWith(
+      (async () => {
+        try {
+          const formData = await event.request.formData();
+          const image = formData.get('image');
+          
+          if (image) {
+            const cache = await caches.open('shared-image-cache');
+            await cache.put('/shared-image', new Response(image, {
+              headers: {
+                'Content-Type': image.type,
+                'Content-Length': image.size.toString()
+              }
+            }));
+          }
+          return Response.redirect('/visual-search.html', 303);
+        } catch (error) {
+          console.error('Error processing shared image:', error);
+          return Response.redirect('/visual-search.html?error=1', 303);
+        }
+      })()
+    );
+    return;
+  }
+
   // Only handle http/https GET requests - skip chrome-extension://, etc.
   if (event.request.method !== 'GET' || !event.request.url.startsWith('http')) {
     return;

--- a/visual-search.html
+++ b/visual-search.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cara — Visual Search</title>
+  <link rel="icon" type="image/jpeg" sizes="32x32" href="images/favicon.jpg" />
+  
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="assets/css/visual-search.css" />
+  <link href="https://cdn.jsdelivr.net/npm/remixicon@4.5.0/fonts/remixicon.css" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css" />
+</head>
+
+<body>
+<section id="header" role="banner">
+  <a href="index.html">
+    <img src="images/logo.png" alt="Cara Logo" />
+  </a>
+  <div>
+    <ul id="navbar" role="navigation">
+      <li><a href="index.html">Home</a></li>
+      <li><a href="shop.html">Shop</a></li>
+      <li><a href="blog.html">Blog</a></li>
+      <li><a href="about.html">About</a></li>
+      <li><a href="contact.html">Contact</a></li>
+      <li class="nav-icon"><a href="cart.html" id="lg-bag"><i class="ri-shopping-bag-4-line"></i></a></li>
+      <li class="nav-icon">
+        <button class="theme-toggle" id="themeToggleDesktop"><i class="ri-moon-line" id="themeIcon"></i></button>
+      </li>
+    </ul>
+  </div>
+</section>
+
+<main>
+  <section id="page-header" class="about-header" style="text-align: center; padding: 40px; background-color: var(--card); color: white;">
+    <h2>Visual Search</h2>
+    <p>Find similar products using your inspiration</p>
+  </section>
+
+  <section id="visual-search-section" class="section-p1">
+    <div class="visual-search-container">
+      <div id="image-preview-container" class="preview-container">
+        <div id="loading-indicator" class="loading-spinner">
+          <i class="ri-loader-4-line spin-icon"></i>
+          <p>Analyzing your image...</p>
+        </div>
+        <img id="shared-image-preview" src="" alt="Shared inspiration" style="display: none;" />
+      </div>
+
+      <div id="search-results" class="results-container" style="display: none;">
+        <h3>Similar Products</h3>
+        <div class="pro-container" id="similar-products-grid">
+          <!-- Products will be injected here via JS -->
+        </div>
+      </div>
+      
+      <div id="error-message" class="error-container" style="display: none;">
+        <i class="ri-error-warning-line"></i>
+        <p>Sorry, we couldn't process the shared image. Please try again.</p>
+        <button class="normal" onclick="window.location.href='shop.html'">Browse Shop</button>
+      </div>
+    </div>
+  </section>
+</main>
+
+<script src="js/visual-search.js"></script>
+<script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
# 📋 Summary
This PR implements the Web Share Target API to allow users to seamlessly share inspiration images directly into Cara from other native applications (like Instagram or their photo gallery). When an image is shared to Cara, it automatically opens the PWA and hands off the image to a new visual search interface.

---

## 🔗 Related Issue
Closes #4085

---

## 🔄 Type of Change

- [ ] Bug fix
- [✓] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

---

## 🛠️ What Was Changed
- Updated `manifest.json` with a `share_target` configuration to register Cara as an image share target.
- Modified `service-worker.js` to intercept POST requests from the native share sheet, temporarily cache the shared image payload, and redirect to the visual search UI.
- Created `visual-search.html`, `js/visual-search.js`, and `assets/css/visual-search.css` to handle the frontend presentation, retrieve the shared image from the service worker cache, and preview it before displaying mock similar product results.

---
## why this needed
- To eliminate the massive friction of manually saving an image, opening the Cara website, and uploading it for visual discovery.
- To bridge the gap between external inspiration (e.g. social media) and Cara's internal visual search engine in a single tap.
- To improve user engagement and UX by natively integrating the PWA into the host device's share sheet.
---
## 🧪 How Has This Been Tested?

- [ ] Tested backend API endpoints manually
- [ ] Ran frontend locally with `npm run dev`
- [ ] Ran `npm run lint` — no errors
- [ ] Ran `npm run build` — no errors
- [✓] Uploaded a test document and verified output (Verified image passing flow through service worker cache to UI mock)
- [✓] Tested on mobile view

---

## ✅ Self-Review Checklist

- [✓] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [✓] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [✓] I have linked the related issue (`Closes #IssueNumber`)
- [✓] I have tested my changes locally
- [ ] I have added screenshots for UI changes
- [✓] My changes do not break existing functionality
- [✓] I have not pushed any `.env` file or API keys
- [✓] My PR contains only changes related to the linked issue

---

## 📋 Additional Notes

The frontend currently uses mock product data to simulate the visual search processing delay, laying the groundwork for the actual vector search backend integration.