### PR TITLE
fix : add try-catch guards around JSON.parse in checkout-vault.js

### DIFF
--- a/js/checkout-vault.js
+++ b/js/checkout-vault.js
@@ -3,13 +3,22 @@
  */
 class AddressVault {
     getAddresses() {
-        return JSON.parse(localStorage.getItem('cara_saved_addresses') || '[]');
+        try {
+            const raw = localStorage.getItem('cara_saved_addresses');
+            return JSON.parse(raw || '[]');
+        } catch (err) {
+            return [];
+        }
     }
 
     saveAddress(addr) {
-        const list = this.getAddresses();
-        list.push(addr);
-        localStorage.setItem('cara_saved_addresses', JSON.stringify(list));
+        try {
+            const list = this.getAddresses();
+            list.push(addr);
+            localStorage.setItem('cara_saved_addresses', JSON.stringify(list));
+        } catch (err) {
+            // Silently fail if localStorage is unavailable or full
+        }
     }
 }
 window.addressVault = new AddressVault();


### PR DESCRIPTION
## 📄 Description
Wrapped JSON.parse in getAddresses() and the localStorage write in saveAddress() with try-catch blocks. getAddresses() now returns an empty array if localStorage is corrupted or contains invalid JSON. saveAddress() silently fails if localStorage is unavailable. This prevents unhandled exceptions from crashing the module.

## 🔗 Related Issues
Closes #4241

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

This task is being handled by tmdeveloper007 as part of GSSOC
(GirlScript Summer of Code) — please assign this PR to the
\`tmdeveloper007\` account when picking it up.
