### PR TITLE
Optimize product fetching in order processing

### DIFF
--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -85,14 +85,21 @@ def create_order(
     subtotal = 0.0
     db_items = []
 
+    # --- Fetch all products in a single query to prevent N+1 issue ---
+    product_names = [item.product_name for item in order_data.items]
+    
+    db_products = (
+        db.query(models.Product)
+        .filter(models.Product.name.in_(product_names))
+        .with_for_update() # Apply row locks to all matching products simultaneously
+        .all()
+    )
+    
+    # Create a fast lookup map for the fetched products
+    product_map = {product.name: product for product in db_products}
+
     for item in order_data.items:
-        # --- Row lock: prevent two concurrent requests from reading stale stock ---
-        db_product = (
-            db.query(models.Product)
-            .filter(models.Product.name == item.product_name)
-            .with_for_update()
-            .first()
-        )
+        db_product = product_map.get(item.product_name)
 
         if not db_product:
             raise HTTPException(
@@ -106,6 +113,7 @@ def create_order(
                 detail=f"Insufficient stock for product: {item.product_name}"
             )
 
+        # Deduct stock in memory (will be committed later)
         db_product.stock -= item.quantity
 
         real_price = db_product.price


### PR DESCRIPTION
Refactored product fetching to reduce database queries and prevent N+1 issue by using a single query for all products. ### Description
This pull request resolves the N+1 database query performance issue identified in the `create_order` API endpoint ([Issue #2413](https://github.com/issues/created?reload=1&issue=janavipandole%7CCara%7C2413)).

#### Details:
* **Current Behavior:** The `create_order` endpoint previously looped through every item in `order_data.items` and executed a separate database query with a row lock for each product. For an order with 20 items, this resulted in 20 distinct sequential database calls, heavily degrading performance under high load.
* **Proposed Resolution:** Refactored the endpoint to extract all product names upfront and execute a single database query using the `in_()` clause coupled with `.with_for_update()`. The results are then mapped into memory as a dictionary, allowing the rest of the validation and stock deduction logic to run instantaneously without redundant database round-trips.

Closes #2413

