### PR TITLE
Fix: expose product catalog on window.products

### DIFF
--- a/products.js
+++ b/products.js
@@ -998,3 +998,13 @@ if (typeof module !== 'undefined' && module.exports) {
   module.exports = { products };
 }
 
+
+
+// Expose the product catalog on `window` so other scripts that read
+// `window.products` (e.g. js/live-sales-toast.js's getProducts(), and
+// validateSharedCartItems() in app.js) see the real catalog instead of
+// silently treating it as empty/undefined.
+if (typeof window !== 'undefined') {
+    window.products = products;
+}
+  


### PR DESCRIPTION
Summary: js/live-sales-toast.js's getProducts() and validateSharedCartItems() in app.js both read the product catalog via window.products, but nothing in the codebase ever assigns it. products.js declares the catalog as a top-level const products = [...], which lives in the shared script-global scope but is never attached to the window object.

Effect of the bug: the "Live Sales" social-proof toast (wired into index.html via js/live-sales-toast.js) never shows anything, because getProducts() always returns an empty array and showLiveToast() returns early. Also, the shared "wardrobe" cart link validation (validateSharedCartItems(), used by applySharedCart()) silently skips its catalog check and returns items unverified, since its source array is always empty.

Fix: add a small guard at the end of products.js that assigns window.products = products; right after the catalog is defined, so any script reading window.products gets the real data. The change is additive only and does not alter existing behavior for code that already references the products variable directly.

Testing: confirmed products.js still defines products and exports it via module.exports for existing tests unchanged, and manually traced getProducts() and validateSharedCartItems() to confirm they now resolve to the real catalog array.