### PR TITLE
Fix: remove stray closing braces breaking js/reviews.js

### DIFF
--- a/js/reviews.js
+++ b/js/reviews.js
@@ -34,8 +34,7 @@
     }
       return [];
     }
-  }
-
+  
   function _saveReviews(productId, reviews) {
     // Cap stored reviews to prevent unbounded localStorage growth
     const trimmed = reviews.slice(0, MAX_REVIEWS_STORED);
@@ -65,8 +64,7 @@
     }
       return iso;
     }
-  }
-
+  
   // ── Calculate aggregate stats ─────────────────────────────────────────────
 
   function _calcStats(reviews) {
@@ -365,7 +363,6 @@
           productId = 'unknown';
         }
       }
-    }
     productId = productId || 'unknown';
     _render(container, productId);
   }


### PR DESCRIPTION
Summary: js/reviews.js has three stray extra closing braces (after _readReviews, after _formatDate, and inside init before the productId fallback assignment). Each extra brace closes an enclosing scope one token too early, which is a JavaScript syntax error. Since the whole file fails to parse, none of the review or rating code ever runs on any product page, silently breaking the entire review widget.

Related issue: I could not find an existing open issue describing this exact syntax error. It was found through direct source review while investigating other review-related issues in this repo.

Type of change: Bug fix.

What was changed: Removed the three stray closing braces so the file parses correctly. No other logic, formatting, or behavior was changed.

Why this is needed: A syntax error in a script means the browser aborts parsing that entire file and none of its code executes. This silently breaks star ratings, review submission, and rating aggregation on every product page, with no visible error shown to most users.

How this was tested: Verified brace balance across the full file so open and close counts match, and traced each function boundary manually to confirm correct nesting after the fix. Confirmed via the diff view that only the three stray lines were removed and nothing else changed.

Screenshots: Not applicable, this is a logic only fix with no visual changes.

Additional notes: None.