### PR TITLE
Refactor order creation and cancellation logic

### DIFF
--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -160,18 +160,20 @@ def create_order(
         zip_code=order_data.zip,
         total_amount=grand_total,
         status="CONFIRMED",
-        idempotency_key=order_data.idempotency_key,   # ADDED
+        idempotency_key=order_data.idempotency_key,
     )
 
     db.add(new_order)
-    db.commit()
-    db.refresh(new_order)
+    # Use flush instead of commit to get new_order.id without finalizing the transaction prematurely
+    db.flush()
 
     for db_item in db_items:
         db_item.order_id = new_order.id
         db.add(db_item)
 
+    # Commit everything atomically in a single transaction
     db.commit()
+    db.refresh(new_order)
 
     return {
         "message": "Order created successfully",


### PR DESCRIPTION
Updated order creation to use flush for ID retrieval and ensured atomic commit for all changes. ### Description
This pull request addresses issue [#2458]
#### Details:
* **Atomic Transaction Flow:** Removed the intermediate `db.commit()` call that committed the parent `Order` before adding its child items. 
* **Prevention of Orphaned Records:** By flushing the `new_order` (`db.flush()`) instead of committing it, the database generates the required `order.id` while keeping the entire transaction pending.
* **All-or-Nothing Guarantee:** Both the order, stock adjustments, and all associated `OrderItem` rows are now committed together in a single final `db.commit()`, ensuring that failures during item insertion roll back cleanly without leaving item-less orders in the database.
