### PR TITLE
fix : correct malformed parseInt in reviews.js form handler

### DIFF
--- a/js/reviews.js
+++ b/js/reviews.js
@@ -285,7 +285,7 @@
         if (!authorEl || !bodyEl) return;
 
         const author = authorEl.value.trim();
-        const rating = parseInt((ratingEl || {}, 10).value, 10);
+        const rating = parseInt((ratingEl || {value: '0'}).value, 10);
         const title = (titleEl ? titleEl.value : '').trim();
         const body = bodyEl.value.trim();
 


### PR DESCRIPTION
## 📄 Description
The form submit handler in js/reviews.js had a malformed parseInt call on line 288 that always returned NaN because the .value accessor was applied to an incorrect expression. Changed to parseInt((ratingEl || {value: '0'}).value, 10).

## 🔗 Related Issues
Closes #4411

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.