### PR TITLE
test : add unit tests for toast.js CaraToast class

### DIFF
--- a/js/toast.js
+++ b/js/toast.js
@@ -1,4 +1,4 @@
-class CaraToast {
+export class CaraToast {
   static show(message, type = 'info', duration = 4000) {
     const container =
       document.getElementById('toast-container') ||
@@ -54,4 +54,8 @@ class CaraToast {
     toast.classList.add('toast-hiding');
     setTimeout(() => toast.remove(), 350);
   }
+}
+
+if (typeof window !== 'undefined') {
+  window.CaraToast = CaraToast;
 }

--- a/tests/unit/toast.test.js
+++ b/tests/unit/toast.test.js
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { CaraToast } from '../../js/toast.js';
+
+/**
+ * Unit tests for js/toast.js CaraToast class.
+ */
+
+describe('CaraToast', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    // Remove any existing toast container
+    const existing = document.getElementById('toast-container');
+    if (existing) existing.remove();
+    // Clear timers
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('should be a class with show and _dismiss static methods', () => {
+    expect(typeof CaraToast).toBe('function');
+    expect(typeof CaraToast.show).toBe('function');
+    expect(typeof CaraToast._dismiss).toBe('function');
+  });
+
+  it('creates a toast container if none exists', () => {
+    CaraToast.show('Test message', 'info', 5000);
+    vi.advanceTimersByTime(0);
+    const container = document.getElementById('toast-container');
+    expect(container).not.toBeNull();
+    expect(container.id).toBe('toast-container');
+  });
+
+  it('reuses an existing toast container', () => {
+    const existing = document.createElement('div');
+    existing.id = 'toast-container';
+    document.body.appendChild(existing);
+
+    CaraToast.show('First', 'info', 5000);
+    vi.advanceTimersByTime(0);
+    CaraToast.show('Second', 'success', 5000);
+    vi.advanceTimersByTime(0);
+
+    const container = document.getElementById('toast-container');
+    expect(container.querySelectorAll('.toast').length).toBe(2);
+  });
+
+  it('sets toast type as CSS class', () => {
+    CaraToast.show('Info toast', 'info', 5000);
+    CaraToast.show('Success toast', 'success', 5000);
+    CaraToast.show('Error toast', 'error', 5000);
+    CaraToast.show('Warning toast', 'warning', 5000);
+    vi.advanceTimersByTime(0);
+
+    const toasts = document.querySelectorAll('.toast');
+    expect(toasts[0].className).toContain('toast-info');
+    expect(toasts[1].className).toContain('toast-success');
+    expect(toasts[2].className).toContain('toast-error');
+    expect(toasts[3].className).toContain('toast-warning');
+  });
+
+  it('displays the message in the toast', () => {
+    CaraToast.show('Hello world', 'info', 5000);
+    vi.advanceTimersByTime(0);
+    const msg = document.querySelector('.toast-msg');
+    expect(msg.textContent).toBe('Hello world');
+  });
+
+  it('auto-dismisses after the given duration', () => {
+    CaraToast.show('Auto dismiss', 'info', 3000);
+    const toast = document.querySelector('.toast');
+    expect(toast).not.toBeNull();
+
+    // Advance past the auto-dismiss duration
+    vi.advanceTimersByTime(3000);
+    // The dismiss also has a 350ms setTimeout for removal
+    vi.advanceTimersByTime(350);
+    expect(document.querySelector('.toast')).toBeNull();
+  });
+
+  it('pauses auto-dismiss on mouseenter and resumes on mouseleave', () => {
+    CaraToast.show('Paused toast', 'info', 2000);
+    vi.advanceTimersByTime(0);
+    const toast = document.querySelector('.toast');
+    toast.dispatchEvent(new MouseEvent('mouseenter'));
+
+    // Advance timers while hovered - should NOT dismiss yet
+    vi.advanceTimersByTime(2500);
+    expect(document.querySelector('.toast')).not.toBeNull();
+
+    // Leave - should start new 1500ms timer
+    toast.dispatchEvent(new MouseEvent('mouseleave'));
+    vi.advanceTimersByTime(1500);
+    // Dismiss setTimeout
+    vi.advanceTimersByTime(350);
+    expect(document.querySelector('.toast')).toBeNull();
+  });
+
+  it('dismisses immediately on close button click', () => {
+    CaraToast.show('Click to close', 'info', 5000);
+    vi.advanceTimersByTime(0);
+    const toast = document.querySelector('.toast');
+    const closeBtn = toast.querySelector('.toast-close');
+    closeBtn.dispatchEvent(new MouseEvent('click'));
+    // The dismiss also has a 350ms setTimeout
+    vi.advanceTimersByTime(350);
+    expect(document.querySelector('.toast')).toBeNull();
+  });
+
+  it('uses info icon when type is unknown', () => {
+    CaraToast.show('Unknown type', 'unknowntype', 5000);
+    vi.advanceTimersByTime(0);
+    const toast = document.querySelector('.toast');
+    expect(toast.className).toContain('toast-unknowntype');
+  });
+});


### PR DESCRIPTION
## 📄 Description
js/toast.js exports a CaraToast class that manages toast notifications. This PR adds comprehensive unit tests covering show/hide behavior, type variations (info/success/error/warning), auto-dismiss timing, pause-on-hover behavior, and close button dismissal. The ES module export was also added to enable clean import testing.

## 🔗 Related Issues
Closes #4415

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.