### PR TITLE
fix : added wrapped localStorage writes in barcode-scanner.js in try-catch

### DIFF
--- a/js/barcode-scanner.js
+++ b/js/barcode-scanner.js
@@ -193,7 +193,11 @@ document.addEventListener("DOMContentLoaded", () => {
       );
       
       if (matchedProduct) {
-        localStorage.setItem("selectedProductId", matchedProduct.name);
+        try {
+          localStorage.setItem("selectedProductId", matchedProduct.name);
+        } catch (err) {
+          // Ignore storage failures, navigation still works.
+        }
         window.location.href = "singleProduct.html";
         return;
       }
@@ -201,7 +205,11 @@ document.addEventListener("DOMContentLoaded", () => {
     
     // Fallback: If no exact match or products not loaded, store the value and redirect anyway
     // The PDP page handles resolving the product.
-    localStorage.setItem("selectedProductId", barcodeValue);
+    try {
+      localStorage.setItem("selectedProductId", barcodeValue);
+    } catch (err) {
+      // Ignore storage failures, navigation still works.
+    }
     window.location.href = "singleProduct.html";
   };
 


### PR DESCRIPTION
## 📄 Description
barcode-scanner.js wrote the selected product to localStorage without guarding against storage failures, which could abort the scan flow in private browsing. This GSSOC PR wraps both writes in try-catch so navigation still completes.

## 🔗 Related Issues
Closes #4437

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.