### PR TITLE
fix : added NaN guard for amounts in currency-converter.js

### DIFF
--- a/js/currency-converter.js
+++ b/js/currency-converter.js
@@ -90,14 +90,16 @@ export function setActiveCurrency(currencyCode) {
 }
 
 export function convertPrice(amountInUSD, targetCurrency = getActiveCurrency()) {
+  const amount =
+    typeof amountInUSD === 'number' && isFinite(amountInUSD) ? amountInUSD : 0;
   const rate = EXCHANGE_RATES[targetCurrency] || 1.0;
-  return amountInUSD * rate;
+  return amount * rate;
 }
 
 export function formatCurrency(amountInUSD, targetCurrency = getActiveCurrency()) {
   const converted = convertPrice(amountInUSD, targetCurrency);
   const symbol = CURRENCY_SYMBOLS[targetCurrency] || '$';
-  return `${symbol}${converted.toFixed(2)}`;
+  return `${symbol}${isFinite(converted) ? converted.toFixed(2) : '0.00'}`;
 }
 
 export function initCurrencySelector(selectElementId = 'currencySelect') {


### PR DESCRIPTION
## 📄 Description
convertPrice and formatCurrency rendered NaN when handed a non-numeric amount. This GSSOC PR falls back invalid amounts to zero and only formats finite results, so the UI never shows NaN prices.

## 🔗 Related Issues
Closes #4438

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.