### PR TITLE
fix : added missing parentNode guard to terms-print.js

### DIFF
--- a/js/terms-print.js
+++ b/js/terms-print.js
@@ -8,7 +8,8 @@ document.addEventListener('DOMContentLoaded', () => {
   btn.style.cssText =
     'padding:10px 18px; background:#088178; color:white; border:none; border-radius:4px; font-weight:600; cursor:pointer; margin-bottom:20px; font-family:sans-serif;';
 
-  parentContainer.parentNode.insertBefore(btn, parentContainer);
+  const insertTarget = parentContainer.parentNode || document.body;
+  insertTarget.insertBefore(btn, parentContainer);
 
   btn.addEventListener('click', () => {
     window.print();


### PR DESCRIPTION
## 📄 Description
terms-print.js called insertBefore on parentContainer.parentNode which can be null on unusual layouts. This GSSOC PR falls back to document.body so the print button always injects safely.

## 🔗 Related Issues
Closes #4442

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.