### PR TITLE
fix : added zero-height guard to reading-progress.js scroll handler

### DIFF
--- a/js/reading-progress.js
+++ b/js/reading-progress.js
@@ -14,7 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const height =
       document.documentElement.scrollHeight -
       document.documentElement.clientHeight;
-    const scrolled = (winScroll / height) * 100;
+    const scrolled = height > 0 ? (winScroll / height) * 100 : 0;
     progressBar.style.width = scrolled + '%';
   });
 


### PR DESCRIPTION
## 📄 Description
reading-progress.js divided by a scroll height that can be zero on short pages, producing NaN progress-bar widths. This GSSOC PR clamps the width to 0 when the page is not scrollable.

## 🔗 Related Issues
Closes #4443

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.