### PR TITLE
fix : added NaN guard to admin-analytics.js revenue formatting

### DIFF
--- a/js/admin-analytics.js
+++ b/js/admin-analytics.js
@@ -24,9 +24,11 @@
 
   // ── Format helpers ─────────────────────────────────────────────────────────
   function _fmtRev(val) {
+    const num = parseFloat(val);
+    const safe = isFinite(num) ? num : 0;
     return (
       '₹' +
-      parseFloat(val)
+      safe
         .toFixed(2)
         .replace(/\d(?=(\d{3})+\.)/g, '$&,')
     );


### PR DESCRIPTION
## 📄 Description
admin-analytics.js formatted revenue with parseFloat(val).toFixed(2), rendering NaN when a metric was missing or non-numeric. This GSSOC PR falls back to 0 for non-finite values.

## 🔗 Related Issues
Closes #4444

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.