### PR TITLE
fix : added localStorage guards to contact-autosave.js

### DIFF
--- a/js/contact-autosave.js
+++ b/js/contact-autosave.js
@@ -16,7 +16,12 @@ document.addEventListener('DOMContentLoaded', () => {
     if (el) {
       inputs[field] = el;
       // Load saved draft
-      const savedVal = localStorage.getItem(`cara_contact_draft_${field}`);
+      let savedVal = null;
+      try {
+        savedVal = localStorage.getItem(`cara_contact_draft_${field}`);
+      } catch (err) {
+        // Silently ignore localStorage failures in restricted environments
+      }
       if (savedVal) {
         el.value = savedVal;
       }
@@ -60,7 +65,11 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
     fields.forEach((field) => {
-      localStorage.removeItem(`cara_contact_draft_${field}`);
+      try {
+        localStorage.removeItem(`cara_contact_draft_${field}`);
+      } catch (err) {
+        // Silently ignore localStorage failures in restricted environments
+      }
     });
   });
 });


### PR DESCRIPTION
## 📄 Description
contact-autosave.js read and cleared the contact draft from localStorage without guarding against storage failures. This GSSOC PR wraps the reads and removals in try-catch so autosave degrades gracefully in restricted environments.

## 🔗 Related Issues
Closes #4448

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.