### PR TITLE
fix : added empty container guard to shimmer-loader.js

### DIFF
--- a/js/shimmer-loader.js
+++ b/js/shimmer-loader.js
@@ -6,6 +6,8 @@ document.addEventListener('DOMContentLoaded', () => {
   // Simulate skeleton state loading
   const showSkeletons = () => {
     const originalContent = productsContainer.innerHTML;
+    // Bail out if there is nothing to restore, avoiding a skeleton flash.
+    if (!originalContent.trim()) return;
     productsContainer.innerHTML = '';
 
     for (let i = 0; i < 4; i++) {


### PR DESCRIPTION
## 📄 Description
shimmer-loader.js replaced the products container with skeleton cards and restored it after a timeout, causing a flash on pages with no product content. This GSSOC PR bails out when there is nothing to restore.

## 🔗 Related Issues
Closes #4449

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.