### PR TITLE
fix : added sessionStorage guards to checkout-autosave.js

### DIFF
--- a/js/checkout-autosave.js
+++ b/js/checkout-autosave.js
@@ -1,21 +1,32 @@
 // Session-bound checkout draft form saver
 
 export function saveDraftField(id, value) {
-  if (typeof sessionStorage !== 'undefined') {
+  if (typeof sessionStorage === 'undefined') return;
+  try {
     sessionStorage.setItem(`cara_checkout_draft_${id}`, value);
+  } catch (e) {
+    // Ignore storage failures in restricted environments.
   }
 }
 
 export function getDraftField(id) {
-  if (typeof sessionStorage !== 'undefined') {
+  if (typeof sessionStorage === 'undefined') return '';
+  try {
     return sessionStorage.getItem(`cara_checkout_draft_${id}`) || '';
+  } catch (e) {
+    return '';
   }
-  return '';
 }
 
 export function clearCheckoutDraft(fields = []) {
   if (typeof sessionStorage === 'undefined') return;
-  fields.forEach((id) => sessionStorage.removeItem(`cara_checkout_draft_${id}`));
+  fields.forEach((id) => {
+    try {
+      sessionStorage.removeItem(`cara_checkout_draft_${id}`);
+    } catch (e) {
+      // Ignore storage failures in restricted environments.
+    }
+  });
 }
 
 export function initCheckoutAutosave() {


### PR DESCRIPTION
## 📄 Description
checkout-autosave.js read and wrote the checkout draft through sessionStorage without guarding against storage being unavailable, which could throw during checkout initialisation. This GSSOC PR wraps all sessionStorage calls in try-catch so draft handling degrades gracefully.

## 🔗 Related Issues
Closes #4450

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.