### PR TITLE
fix : added XSS hardening to toast.js message rendering

### DIFF
--- a/js/toast.js
+++ b/js/toast.js
@@ -20,7 +20,7 @@ class CaraToast {
     toast.className = `toast toast-${type}`;
     toast.innerHTML = `
       <span class="toast-icon">${icons[type] || icons.info}</span>
-      <span class="toast-msg">${message}</span>
+      <span class="toast-msg">${this._escapeHtml(message)}</span>
       <button class="toast-close" aria-label="Close">&times;</button>
       <span class="toast-progress" style="animation-duration:${duration}ms"></span>
     `;
@@ -45,6 +45,20 @@ class CaraToast {
       const bar = toast.querySelector('.toast-progress');
       if (bar) bar.style.animationPlayState = 'running';
     });
+  }
+
+  static _escapeHtml(value) {
+    return String(value).replace(
+      /[&<>"']/g,
+      (char) =>
+        ({
+          '&': '&amp;',
+          '<': '&lt;',
+          '>': '&gt;',
+          '"': '&quot;',
+          "'": '&#39;',
+        })[char],
+    );
   }
 
   static _dismiss(toast) {


### PR DESCRIPTION
## 📄 Description
toast.js interpolated the toast message directly into innerHTML, so a message containing HTML executed script when shown. This GSSOC PR escapes the message text before injecting it, preserving plain-text behavior while closing the XSS vector.

## 🔗 Related Issues
Closes #4451

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.