### PR TITLE
feat : added digit requirement to pincode unknown-format fallback

### DIFF
--- a/js/pincode-validation-engine.js
+++ b/js/pincode-validation-engine.js
@@ -19,8 +19,8 @@ export class PincodeValidationEngine {
     }
     const pattern = this.postalPatterns[countryCode.toUpperCase()];
     if (!pattern) {
-      // Fallback basic alphanumeric check
-      const genericValid = /^[a-zA-Z0-9\s-]{3,10}$/.test(code.trim());
+      // Fallback basic alphanumeric check (must contain at least one digit)
+      const genericValid = /^(?=.*[0-9])[a-zA-Z0-9\s-]{3,10}$/.test(code.trim());
       return { valid: genericValid, reason: genericValid ? 'Generic code valid' : 'Invalid generic postal format' };
     }
 


### PR DESCRIPTION
## 📄 Description
The unknown-country postal fallback accepted any short alphanumeric string, including ones with no digits. This GSSOC PR requires the code to contain at least one digit, tightening the generic validation while leaving known-country rules unchanged.

## 🔗 Related Issues
Closes #4452

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.