### PR TITLE
feat : added persisted gift wrap selection in gift-options.js

### DIFF
--- a/js/gift-options.js
+++ b/js/gift-options.js
@@ -5,12 +5,27 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (!giftCheckbox) return;
 
+  const STORAGE_KEY = 'cara_gift_wrap';
+
+  // Restore the saved gift wrap choice so it survives page reloads.
+  let saved = false;
+  try {
+    saved = localStorage.getItem(STORAGE_KEY) === '1';
+  } catch (e) {
+    // Ignore storage failures in restricted environments.
+  }
+  giftCheckbox.checked = saved;
+  if (giftMsgArea) giftMsgArea.style.display = saved ? 'block' : 'none';
+
   // Toggle message area
   giftCheckbox.addEventListener('change', () => {
-    if (giftCheckbox.checked) {
-      if (giftMsgArea) giftMsgArea.style.display = 'block';
-    } else {
-      if (giftMsgArea) giftMsgArea.style.display = 'none';
+    const checked = giftCheckbox.checked;
+    if (giftMsgArea) giftMsgArea.style.display = checked ? 'block' : 'none';
+
+    try {
+      localStorage.setItem(STORAGE_KEY, checked ? '1' : '0');
+    } catch (e) {
+      // Ignore storage failures in restricted environments.
     }
 
     // Trigger centralized checkout summary update


### PR DESCRIPTION
## 📄 Description
The gift wrap toggle reset on every page reload. This GSSOC PR persists the choice to localStorage, restores it on load, and guards the storage calls so the feature degrades gracefully in restricted environments.

## 🔗 Related Issues
Closes #4453

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.