### PR TITLE
feat : added immediate init for already-loaded DOM in lazyload-observer.js

### DIFF
--- a/js/lazyload-observer.js
+++ b/js/lazyload-observer.js
@@ -41,7 +41,12 @@ export function initLazyLoadObserver(selector = 'img.lazyload', options = {}) {
 }
 
 if (typeof document !== 'undefined') {
-  document.addEventListener('DOMContentLoaded', () => {
+  // Support the case where the DOM is already parsed when this script loads.
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+      initLazyLoadObserver();
+    });
+  } else {
     initLazyLoadObserver();
-  });
+  }
 }


### PR DESCRIPTION
## 📄 Description
The lazy-load initialiser only ran on DOMContentLoaded, so scripts loaded after the DOM was parsed never kick-started lazy images. This GSSOC PR runs the initialiser immediately when the DOM is already in a loaded state, and falls back to the event listener otherwise.

## 🔗 Related Issues
Closes #4454

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.