### PR TITLE
feat : added accessible milestone labels to order-tracking-visualizer.js

### DIFF
--- a/js/order-tracking-visualizer.js
+++ b/js/order-tracking-visualizer.js
@@ -35,7 +35,7 @@ export class OrderTrackingVisualizer {
       const isCompleted = idx <= activeIndex;
       const isCurrent = idx === activeIndex;
       return `
-        <div class="timeline-node ${isCompleted ? 'completed' : ''} ${isCurrent ? 'current' : ''}">
+        <div class="timeline-node ${isCompleted ? 'completed' : ''} ${isCurrent ? 'current' : ''}" role="listitem" ${isCurrent ? 'aria-current="step"' : ''}>
           <div class="node-icon">${isCompleted ? '✓' : idx + 1}</div>
           <span class="node-label">${stage}</span>
         </div>
@@ -47,7 +47,7 @@ export class OrderTrackingVisualizer {
         <div class="timeline-bar-bg">
           <div class="timeline-bar-fill" style="width: ${progress}%"></div>
         </div>
-        <div class="timeline-nodes">
+        <div class="timeline-nodes" role="list">
           ${nodesHtml}
         </div>
       </div>


### PR DESCRIPTION
## 📄 Description
The order timeline had no ARIA semantics, so screen readers presented it as an unlabeled region. This GSSOC PR adds role=list, role=listitem, and aria-current=step to the milestone nodes.

## 🔗 Related Issues
Closes #4478

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.