### PR TITLE
feat : added share-link clipboard copy with fallback in wishlist-export-share.js

### DIFF
--- a/js/wishlist-export-share.js
+++ b/js/wishlist-export-share.js
@@ -42,4 +42,27 @@ export class WishlistExportShare {
     const rows = items.map(item => `"${item.id || ''}","${item.name || ''}","${item.price || ''}"`);
     return [headers.join(','), ...rows].join('\n');
   }
+
+  buildShareLink(items = [], origin = '') {
+    const hash = this.encodeWishlistToHash(items);
+    if (!hash) return '';
+    return origin ? `${origin}?wishlist=${hash}` : `?wishlist=${hash}`;
+  }
+
+  async copyShareLinkToClipboard(items = [], origin = '') {
+    const link = this.buildShareLink(items, origin);
+    if (!link) return { ok: false, link: '' };
+
+    const clipboard = typeof navigator !== 'undefined' ? navigator.clipboard : null;
+    if (clipboard && typeof clipboard.writeText === 'function') {
+      try {
+        await clipboard.writeText(link);
+        return { ok: true, link };
+      } catch (e) {
+        // Fall through and report the link for manual copying.
+      }
+    }
+
+    return { ok: false, link };
+  }
 }


### PR DESCRIPTION
## 📄 Description
WishlistExportShare encoded wishlists to a URL hash but offered no clipboard helper. This GSSOC PR adds buildShareLink and copyShareLinkToClipboard, which use navigator.clipboard when available and fall back to returning the link for manual copying otherwise.

## 🔗 Related Issues
Closes #4480

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.