### PR TITLE
feat : added non-string input guards to product-reviews validation

### DIFF
--- a/js/product-reviews.js
+++ b/js/product-reviews.js
@@ -31,12 +31,14 @@ export class ProductReviewManager {
   validateReviewData({ authorName, authorEmail, rating, comment }) {
     const errors = [];
 
-    if (!authorName || authorName.trim().length < 2) {
+    const nameStr = typeof authorName === 'string' ? authorName : '';
+    if (!nameStr || nameStr.trim().length < 2) {
       errors.push('Name must be at least 2 characters.');
     }
 
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!authorEmail || !emailRegex.test(authorEmail.trim())) {
+    const emailStr = typeof authorEmail === 'string' ? authorEmail : '';
+    if (!emailStr || !emailRegex.test(emailStr.trim())) {
       errors.push('Please enter a valid email address.');
     }
 


### PR DESCRIPTION
## 📄 Description
ProductReviewManager.validateReviewData called .trim() on authorName and authorEmail without confirming they are strings, so non-string values threw instead of producing validation errors. This GSSOC PR treats non-string values as invalid rather than crashing.

## 🔗 Related Issues
Closes #4481

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.