### PR TITLE
fix : added unknown language fallback in i18n.js

### DIFF
--- a/js/i18n.js
+++ b/js/i18n.js
@@ -69,7 +69,11 @@ function changeLanguage(lang) {
 function initLanguage() {
   let savedLang = "en";
   try {
-    savedLang = localStorage.getItem("selectedLanguage") || "en";
+    const stored = localStorage.getItem("selectedLanguage") || "en";
+    // Fall back to English for any unknown/unrecognised language code.
+    savedLang = Object.prototype.hasOwnProperty.call(translations, stored)
+      ? stored
+      : "en";
   } catch (e) {
     // Fall back to English if localStorage is unavailable
   }


### PR DESCRIPTION
## 📄 Description
initLanguage applied whatever language code was stored without confirming it was supported, leaving the UI in an undefined state for unrecognised codes. This GSSOC PR falls back to English whenever the stored code is not a known translation.

## 🔗 Related Issues
Closes #4474

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.