### PR TITLE
fix : added oversized entry guard to error-logger.js

### DIFF
--- a/js/error-logger.js
+++ b/js/error-logger.js
@@ -8,8 +8,8 @@ window.addEventListener('error', (event) => {
     errors = [];
   }
   errors.push({
-    message: event.message,
-    filename: event.filename,
+    message: String(event.message || '').slice(0, 2000),
+    filename: String(event.filename || '').slice(0, 500),
     lineno: event.lineno,
     timestamp: new Date().toISOString(),
   });


### PR DESCRIPTION
## 📄 Description
A single oversized runtime error could blow past the localStorage quota and drop the entire error log. This GSSOC PR truncates message and filename fields before persisting so the capped history is never lost to a quota error.

## 🔗 Related Issues
Closes #4475

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.