### PR TITLE
fix : added empty slide guard to testimonials-carousel.js

### DIFF
--- a/js/testimonials-carousel.js
+++ b/js/testimonials-carousel.js
@@ -54,6 +54,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Initialize slides markup
   function initSlides() {
+    // Guard against an empty source array so the carousel never renders empty.
+    if (TESTIMONIALS.length === 0) {
+      if (wrapper) wrapper.style.display = 'none';
+      return;
+    }
     track.innerHTML = TESTIMONIALS.map((t) => {
       const starsHTML = Array(t.rating)
         .fill('<i class="ri-star-fill"></i>')


### PR DESCRIPTION
## 📄 Description
initSlides always mapped over the testimonial array without a length check. This GSSOC PR hides the carousel when the source array is empty, preventing an empty broken slider.

## 🔗 Related Issues
Closes #4477

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.