### PR TITLE
test : added unit tests for admin-products.js

### DIFF
--- a/tests/unit/admin-products.test.js
+++ b/tests/unit/admin-products.test.js
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+beforeEach(() => {
+  vi.resetModules();
+  delete window.AdminProducts;
+  global.fetch = vi.fn();
+});
+
+async function load() {
+  await import('../../js/admin-products.js');
+  return window.AdminProducts;
+}
+
+describe('admin-products', () => {
+  it('create posts to the admin products endpoint and returns the product', async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 11, name: 'Shirt' }),
+    });
+    const api = await load();
+    const res = await api.create({ name: 'Shirt' });
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/admin/products/'),
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(res.name).toBe('Shirt');
+  });
+
+  it('delete issues a DELETE request', async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ deleted: true }),
+    });
+    const api = await load();
+    await api.delete(7);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/admin/products/7'),
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+
+  it('rejects with the server detail on a non-ok response', async () => {
+    global.fetch.mockResolvedValue({
+      ok: false,
+      json: async () => ({ detail: 'Forbidden' }),
+    });
+    const api = await load();
+    await expect(api.update(1, { name: 'x' })).rejects.toThrow('Forbidden');
+  });
+});


### PR DESCRIPTION
## 📄 Description
admin-products.js previously had no unit test coverage. This GSSOC PR adds vitest tests covering the CRUD wrappers and the error path of the admin request helper using a mocked fetch.

## 🔗 Related Issues
Closes #4465

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.