### PR TITLE
docs : added frontend utility module documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,21 @@ Cara/
 | style.css | Contains global styles and layouts |
 | images/ | Stores static image assets |
 
+### Frontend Utility Modules
+
+The frontend keeps small, focused helpers in `js/` that are reusable across pages:
+
+- `currency-converter.js` — multi-currency conversion and locale-aware price formatting.
+- `coupon-validator.js` / `cart-coupon.js` — checkout and cart coupon application and feedback.
+- `lazyload-observer.js` — IntersectionObserver-based lazy image loading with a no-observer fallback.
+- `csrf-protection.js` — CSRF token generation and header injection for forms.
+- `checkout-autosave.js` / `contact-autosave.js` — local draft persistence for forms.
+- `recently-viewed.js` — capped, de-duplicated recently-viewed product tracking and carousel.
+- `theme-engine.js` — light/dark/high-contrast theme resolution with localStorage persistence.
+- `input-shield.js` — client-side XSS script-injection filtering on form submit.
+- `i18n.js`, `loyalty-rewards-engine.js`, `error-logger.js` — translation, loyalty points, and error logging helpers.
+
+Many of these expose their logic on `window` (or as ES module exports) so they can be exercised by unit tests in `tests/unit/`.
 
 ## 📸 Screenshots
 Homepage - 


### PR DESCRIPTION
## 📄 Description
README listed page responsibilities but not the many small frontend utility modules in js/. This GSSOC PR adds a Frontend Utility Modules subsection describing currency-converter, coupon-validator, lazyload-observer, csrf-protection, recently-viewed, theme-engine, input-shield, and the other js/ helpers.

## 🔗 Related Issues
Closes #4471

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.