### PR TITLE
feat: Implement Screen Wake Lock API (#4722)

### DIFF
--- a/checkout.js
+++ b/checkout.js
@@ -1,4 +1,39 @@
 let checkoutIdempotencyKey = null;
+let checkoutWakeLock = null;
+let isCheckoutProcessing = false;
+
+async function requestWakeLock() {
+  if ('wakeLock' in navigator && isCheckoutProcessing) {
+    try {
+      checkoutWakeLock = await navigator.wakeLock.request('screen');
+      checkoutWakeLock.addEventListener('release', () => {
+        console.log('Screen Wake Lock released');
+      });
+      console.log('Screen Wake Lock acquired');
+    } catch (err) {
+      console.error(`Wake Lock error: ${err.name}, ${err.message}`);
+    }
+  }
+}
+
+function releaseWakeLock() {
+  isCheckoutProcessing = false;
+  if (checkoutWakeLock !== null) {
+    checkoutWakeLock.release()
+      .catch(err => console.error(err))
+      .finally(() => {
+        checkoutWakeLock = null;
+      });
+  }
+}
+
+window.addEventListener('beforeunload', releaseWakeLock);
+window.addEventListener('unload', releaseWakeLock);
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible' && isCheckoutProcessing) {
+    requestWakeLock();
+  }
+});
 
 function safeParseJSON(key, fallback = '[]') {
   try {
@@ -316,6 +351,9 @@ function submitCheckoutForm() {
     submitBtn.disabled = true;
   }
 
+  isCheckoutProcessing = true;
+  requestWakeLock();
+
   if (!checkoutIdempotencyKey) {
     checkoutIdempotencyKey = crypto.randomUUID();
   }
@@ -392,6 +430,8 @@ function submitCheckoutForm() {
           submitBtn.getAttribute('data-original-html') || 'Place Order';
       }
 
+      releaseWakeLock();
+
       form.reset();
 
       // HIDE CARD DETAILS AGAIN
@@ -414,6 +454,8 @@ function submitCheckoutForm() {
         submitBtn.classList.remove('btn-loading');
         submitBtn.disabled = false;
       }
+      
+      releaseWakeLock();
     });
 }
 


### PR DESCRIPTION
# 📋 Summary
This PR integrates the Screen Wake Lock API (`navigator.wakeLock.request('screen')`) during the checkout process. This ensures that the user's device screen remains active and does not automatically dim or lock while waiting for backend order processing and potential payment authorizations to complete.

---

## 🔗 Related Issue
Closes #4722

---

## 🔄 Type of Change

- [ ] Bug fix
- [✓] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

---

## 🛠️ What Was Changed

- Added `requestWakeLock()` to initiate a screen wake lock when the user submits their checkout form.
- Added `releaseWakeLock()` to reliably release the wake lock upon successful order creation or if an error is caught.
- Attached `beforeunload`, `unload`, and `visibilitychange` event listeners to ensure the lock is safely released if the component unmounts, the tab is closed, or the user navigates away.

---

## ❓ Why this needed

- During complex payment flows, mobile devices will often automatically dim and lock the screen due to inactivity, which interrupts the session and can cause failed transactions if the OS aggressively suspends the background tab.
- Applying a wake lock guarantees that the active tab remains in the foreground executing logic until the transaction safely concludes.

---

## 🧪 How Has This Been Tested?

- [ ] Tested backend API endpoints manually
- [✓] Ran frontend locally with `npm run dev`
- [✓] Ran `npm run lint` — no errors
- [✓] Ran `npm run build` — no errors
- [ ] Uploaded a test document and verified output
- [ ] Tested on mobile view
*(Note: Vitest automated unit tests successfully passed during the pre-commit hook)*

---

## 📸 Screenshots (if applicable)

| Before | After |
|--------|-------|
| N/A (Background API change) | N/A |

---

## ✅ Self-Review Checklist

- [✓] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [✓] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [✓] I have linked the related issue (`Closes #4722`)
- [✓] I have tested my changes locally
- [ ] I have added screenshots for UI changes
- [✓] My changes do not break existing functionality
- [✓] I have not pushed any `.env` file or API keys
- [✓] My PR contains only changes related to the linked issue

---

## 📋 Additional Notes

The wake lock requires a secure context (HTTPS) to function correctly and is supported in most modern browsers. Fallback logic is built-in so that unsupported browsers will safely ignore the wake lock requests without breaking the checkout flow.