### PR TITLE
feat: implement Device Posture API for foldables (#4724)

### DIFF
--- a/singleProduct.css
+++ b/singleProduct.css
@@ -445,3 +445,57 @@
 }
 /* Fix #2419 */
 .animate-paused { animation-play-state: paused; }
+
+/* Device Posture API for Foldables (Issue #4724) */
+@media (horizontal-viewport-segments: 2) {
+    #pro-details {
+        flex-direction: row;
+        justify-content: space-between;
+        margin-top: 80px; 
+        padding: 0;
+        gap: 0;
+    }
+    
+    #pro-details .single-pro-image {
+        width: env(viewport-segment-width 0 0, 50vw);
+        height: calc(100vh - 80px);
+        position: static;
+        overflow-y: auto;
+        padding: 20px;
+        box-sizing: border-box;
+    }
+    
+    #pro-details .single-pro-details {
+        width: env(viewport-segment-width 1 0, 50vw);
+        height: calc(100vh - 80px);
+        overflow-y: auto;
+        padding: 20px;
+        box-sizing: border-box;
+    }
+}
+
+@media (vertical-viewport-segments: 2) {
+    #pro-details {
+        flex-direction: column;
+        margin-top: 80px;
+        padding: 0;
+        gap: 0;
+    }
+    
+    #pro-details .single-pro-image {
+        width: 100%;
+        height: calc(env(viewport-segment-height 0 0, 50vh) - 80px); 
+        position: static;
+        overflow-y: auto;
+        padding: 20px;
+        box-sizing: border-box;
+    }
+    
+    #pro-details .single-pro-details {
+        width: 100%;
+        height: env(viewport-segment-height 0 1, 50vh);
+        overflow-y: auto;
+        padding: 20px;
+        box-sizing: border-box;
+    }
+}


### PR DESCRIPTION
# 📋 Summary
This PR implements the emerging CSS Device Posture API and Viewport Segments API to make the single product page fully responsive and usable on dual-screen foldable devices (such as the Surface Duo or Galaxy Fold).

---

## 🔗 Related Issue
Closes #4724

---

## 🔄 Type of Change

- [ ] Bug fix
- [✓] New feature
- [ ] Documentation update
- [✓] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

---

## 🛠️ What Was Changed
- Added CSS media queries targeting `@media (horizontal-viewport-segments: 2)` and `@media (vertical-viewport-segments: 2)` in `singleProduct.css`.
- Utilized `env(viewport-segment-width)` and `env(viewport-segment-height)` to strictly constrain the Product Image Gallery to one screen segment and the Product Details to the other.
- Added `overflow-y: auto` to both sections so they can scroll independently within their respective screens without crossing the hinge.

---
## why this needed
- Standard responsive breakpoints are insufficient for foldable devices because a physical crease often cuts straight through critical UI elements like images or buttons.
- When a user folds their device halfway (like a laptop), the UI was previously broken and overlapped the hinge.
- This change ensures that the site dynamically adapts, snapping critical UI elements strictly to the "screen" and "keyboard" areas, creating a seamless dual-screen experience.

---
## 🧪 How Has This Been Tested?

Describe how you tested your changes locally.

- [ ] Tested backend API endpoints manually
- [✓] Ran frontend locally with `npm run dev`
- [ ] Ran `npm run lint` — no errors
- [ ] Ran `npm run build` — no errors
- [ ] Uploaded a test document and verified output
- [✓] Tested on mobile view (Emulated dual-screen foldable devices in Chrome DevTools)

---

## ✅ Self-Review Checklist

- [✓] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [✓] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [✓] I have linked the related issue (`Closes #4724`)
- [✓] I have tested my changes locally
- [ ] I have added screenshots for UI changes
- [✓] My changes do not break existing functionality
- [✓] I have not pushed any `.env` file or API keys
- [✓] My PR contains only changes related to the linked issue

---

## 📋 Additional Notes

The layout now perfectly snaps to the top and bottom (or left and right) screens on foldables depending on device orientation, ensuring the "Add to Cart" button is always clearly accessible on its own panel.