### PR TITLE
accessibility : added clear announcements method to a11y announcer

### DIFF
--- a/js/a11y-announcer.js
+++ b/js/a11y-announcer.js
@@ -39,3 +39,9 @@ export function announce(message, politeness = 'polite') {
     }, 50);
   }
 }
+
+export function clearAnnouncements() {
+  if (typeof document === 'undefined') return;
+  if (liveRegionPolite) liveRegionPolite.textContent = '';
+  if (liveRegionAssertive) liveRegionAssertive.textContent = '';
+}

--- a/tests/unit/a11y-announcer.test.js
+++ b/tests/unit/a11y-announcer.test.js
@@ -3,7 +3,7 @@
  * Tests ARIA live region announcement management for screen readers.
  */
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { initAnnouncer, announce } from '../../js/a11y-announcer.js';
+import { initAnnouncer, announce, clearAnnouncements } from '../../js/a11y-announcer.js';
 
 describe('a11y-announcer Unit Tests', () => {
   beforeEach(() => {
@@ -73,4 +73,13 @@ describe('a11y-announcer Unit Tests', () => {
       expect(polite.textContent).toBe('Cart updated');
     });
   });
+
+  it('should clear live region text when clearAnnouncements is called', () => {
+    initAnnouncer();
+    const polite = document.getElementById('a11y-announcer-polite');
+    polite.textContent = 'Stale text';
+    clearAnnouncements();
+    expect(polite.textContent).toBe('');
+  });
+
 });


### PR DESCRIPTION
## 📄 Description
Exported `clearAnnouncements()` function in `js/a11y-announcer.js` to clear polite and assertive ARIA live regions, and added unit test coverage.

## 🔗 Related Issues
Closes #4765

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.