### PR TITLE
fix : added street address whitespace and HTML sanitization guards

### DIFF
--- a/js/address-validation-service.js
+++ b/js/address-validation-service.js
@@ -56,7 +56,7 @@ class AddressValidationService {
       errors,
       sanitized: isValid
         ? {
-            street: street.trim(),
+            street: street.trim().replace(/<[^>]*>/g, ''),
             city: city.trim(),
             state: state.trim().toUpperCase(),
             postalCode: postalCode.trim().toUpperCase(),

--- a/tests/unit/address-validation-service.test.js
+++ b/tests/unit/address-validation-service.test.js
@@ -35,4 +35,17 @@ describe('AddressValidationService Unit Tests', () => {
     expect(result.isValid).toBe(true);
     expect(result.sanitized.city).toBe('San Francisco');
   });
+
+  it('should sanitize HTML tags from street address field', () => {
+    const result = service.validateAddress({
+      street: '123 Main St <script>alert(1)</script>',
+      city: 'Boston',
+      state: 'MA',
+      postalCode: '02108',
+      country: 'US'
+    });
+    expect(result.isValid).toBe(true);
+    expect(result.sanitized.street).toBe('123 Main St alert(1)');
+  });
+
 });


### PR DESCRIPTION
## 📄 Description
Added HTML tag stripping regex sanitization to street address field output in `js/address-validation-service.js` and added unit test coverage.

## 🔗 Related Issues
Closes #4767

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.