### PR TITLE
feat : added style tag matching score calculator to outfit compatibility engine

### DIFF
--- a/js/outfit-compatibility-engine.js
+++ b/js/outfit-compatibility-engine.js
@@ -14,6 +14,16 @@ class OutfitCompatibilityEngine {
     };
   }
 
+
+  calculateTagScore(tags1 = [], tags2 = []) {
+    if (!Array.isArray(tags1) || !Array.isArray(tags2) || tags1.length === 0 || tags2.length === 0) {
+      return 0;
+    }
+    const set1 = new Set(tags1.map(t => String(t).toLowerCase()));
+    const shared = tags2.filter(t => set1.has(String(t).toLowerCase()));
+    return Math.round((shared.length / Math.max(tags1.length, tags2.length)) * 100);
+  }
+
   evaluatePair(top, bottom) {
     if (!top || !bottom) return { score: 0, rating: 'Incomplete', feedback: 'Please select both a top and a bottom item.' };
 

--- a/tests/unit/outfit-compatibility-engine.test.js
+++ b/tests/unit/outfit-compatibility-engine.test.js
@@ -28,4 +28,10 @@ describe('OutfitCompatibilityEngine Unit Tests', () => {
     const res = engine.evaluatePair(top, bottom);
     expect(res.score).toBeLessThan(90);
   });
+
+  it('should calculate tag intersection compatibility score correctly', () => {
+    const score = engine.calculateTagScore(['casual', 'summer', 'denim'], ['casual', 'summer']);
+    expect(score).toBe(67);
+  });
+
 });


### PR DESCRIPTION
## 📄 Description
Added `calculateTagScore(tags1, tags2)` method to `OutfitCompatibilityEngine` class in `js/outfit-compatibility-engine.js` and added unit test coverage.

## 🔗 Related Issues
Closes #4769

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.