### PR TITLE
fix(app.js): close top-level IIFE to restore all page JS (#4747)

### DIFF
--- a/app.js
+++ b/app.js
@@ -2414,3 +2414,4 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 });
+})();


### PR DESCRIPTION
## Problem

app.js wraps all page logic in a top-level IIFE (`(() => {`) but the closing `})();` was missing at the end of the file. The script never parsed, so the entire site's JavaScript was disabled with a `SyntaxError: Unexpected end of input`.

## Fix


Appended the missing `})();` after the final `document.addEventListener('DOMContentLoaded', ...)` block to close and invoke the IIFE.

## Files changed


- `app.js`: added the missing IIFE closing line.

## Testing


- `node --check app.js` passes (previously failed with `SyntaxError: Unexpected end of input` at EOF).
- Verified with an Acorn/V8 token replay that the brace/paren stack is fully balanced after the change.


Closes #4747
