### PR TITLE
fix(products.js): close safeParseJSON function body to fix product grids (#4748)

### DIFF
--- a/products.js
+++ b/products.js
@@ -489,7 +489,7 @@ function safeParseJSON(key, fallback = '[]') {
     }
     return [];
   }
-
+}
 
 
 // Wishlist logic has been migrated to app.js for global availability.


### PR DESCRIPTION
## Problem

The `safeParseJSON()` function in `products.js` opens its function body at line 474 but the closing `}` is missing — only the `catch` block is closed. Everything after it (including `appendHighlightedText()` and the rest of the file) is parsed as part of the function body, so the script fails with `SyntaxError: Unexpected end of input` at EOF and the product grids never render.

## Fix


Added the missing closing `}` for the `safeParseJSON()` function body after the `catch` block's closing brace.

## Files changed


- `products.js`: added the missing function-closing brace in `safeParseJSON()`.

## Testing


- `node --check products.js` passes (previously failed with `SyntaxError: Unexpected end of input`).


Closes #4748
