### PR TITLE
fix(order-history.js): remove undefined getAuthToken() to unstick order history (#4749)

### DIFF
--- a/order-history.js
+++ b/order-history.js
@@ -156,13 +156,6 @@ function renderOrderDetails(order) {
 }
 
 async function fetchOrders() {
-  const token = getAuthToken();
-
-  if (!token) {
-    window.location.href = 'login.html';
-    return;
-  }
-
   setStateVisibility({ loading: true });
 
   try {


### PR DESCRIPTION
## Problem

`fetchOrders()` in `order-history.js` calls `getAuthToken()`, which is defined nowhere in the repository. The `ReferenceError` is thrown before the function's `try` block, so the promise rejects unhandled: the order list stays on the loading spinner forever and the unauthenticated redirect to `login.html` never happens.

## Fix


Removed the `getAuthToken()` check. Auth is carried by the httpOnly `access_token` cookie (attached automatically via `authFetch`'s `credentials: 'include'`, per the file's own comment), and the existing `401` handler already clears legacy localStorage values and redirects to `login.html`.

## Files changed


- `order-history.js`: removed the undefined `getAuthToken()` call and its redirect block from `fetchOrders()`.

## Testing


- `node --check order-history.js` passes.
- Repo-wide search confirms no remaining references to `getAuthToken` in the codebase.


Closes #4749
