### PR TITLE
fix(navbar.js): render navbar with innerHTML instead of textContent (#4750)

### DIFF
--- a/navbar.js
+++ b/navbar.js
@@ -109,7 +109,7 @@ function loadNavbar(activePage) {
 
   const container = document.getElementById('navbar-container');
   if (container) {
-    container.textContent = navbarHTML;
+    container.innerHTML = navbarHTML;
   } else {
     // Silently return for pages that use a hardcoded navbar (e.g. index.html)
     return;


### PR DESCRIPTION
## Problem

`loadNavbar()` renders the navbar into `#navbar-container` with `container.textContent = navbarHTML`. Because `navbarHTML` is an HTML string, `textContent` displays it as raw, escaped text on the page instead of rendering the navigation markup.

## Fix


Changed the assignment to `container.innerHTML = navbarHTML` so the nav HTML is actually rendered. The template only interpolates the known `activePage` parameter (no user-supplied data), so there is no injection risk.

## Files changed


- `navbar.js`: `textContent` -> `innerHTML` in `loadNavbar()`.

## Testing


- `node --check navbar.js` passes.


Closes #4750
