### PR TITLE
fix(checkout.js): read both cart image keys for checkout thumbnails (#4751)

### DIFF
--- a/checkout.js
+++ b/checkout.js
@@ -459,7 +459,7 @@ function renderCheckoutItems() {
       return `
       <div class="order-item" style="display: flex; gap: 15px; align-items: center; border-bottom: 1px solid var(--border); padding-bottom: 12px; margin-bottom: 12px;">
         <div class="item-thumb" style="width: 50px; height: 50px; border-radius: 6px; overflow: hidden; border: 1px solid var(--border); display: flex; align-items: center; justify-content: center; background: #fff;">
-          <img src="${item.img || 'images/products/placeholder.jpg'}" alt="${item.name}" style="max-width: 100%; max-height: 100%; object-fit: cover;" onerror="this.src='images/products/placeholder.jpg'">
+          <img src="${item.image || item.img || 'images/products/placeholder.jpg'}" alt="${item.name}" style="max-width: 100%; max-height: 100%; object-fit: cover;" onerror="this.src='images/products/placeholder.jpg'">
         </div>
         <div class="item-info" style="flex: 1;">
           <div class="item-name" style="font-weight: 600; font-size: 14px; color: var(--color-heading);">${item.name}</div>


### PR DESCRIPTION
## Problem

The cart is written with two different image keys: `app.js:750` stores `image`, while `products.js:904` stores `img`. `checkout.js:462` only read `item.img`, so items added from the product-detail page (`window.addToCart` in app.js) have no `img` and their checkout thumbnails always fell back to the placeholder.

## Fix


`renderCheckoutItems()` now reads both keys: `item.image || item.img`, matching the existing pattern already used in `app.js:455`, before falling back to the placeholder.

## Files changed


- `checkout.js`: `item.img` -> `item.image || item.img` in the checkout item thumbnail.

## Testing


- `node --check checkout.js` passes.


Closes #4751
