### PR TITLE
fix(cart.html): load shipping-calc.js once (remove duplicate module load) (#4752)

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -281,7 +281,6 @@
       </div>
     </div>
 
-    <script type="module" src="js/shipping-calc.js" defer></script>
     <script type="module" src="js/loyalty-rewards-engine.js" defer></script>
     <script>
   document.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
## Problem

`cart.html` loads `js/shipping-calc.js` twice: once as a classic script (line 243) and once as a module (line 284). Because the file is a plain `DOMContentLoaded` script (no `import`/`export`), both loads execute, producing a duplicated shipping calculator UI and double cart updates.

## Fix


Removed the duplicate `type="module"` load. `shipping-calc.js` now loads once as a classic script alongside the other classic helpers (`loyalty.js`, `coupon-config.js`, `cart-coupon.js`).

## Files changed


- `cart.html`: removed the duplicate `<script type="module" src="js/shipping-calc.js">` tag.

## Testing


- Verified `js/shipping-calc.js` contains no `import`/`export`, so the classic load is the correct one.
- Grep confirms exactly one `shipping-calc.js` reference remains in `cart.html`.


Closes #4752
