### PR TITLE
fix : added input string trim and null checks to address autocomplete

### DIFF
--- a/js/address-autocomplete.js
+++ b/js/address-autocomplete.js
@@ -100,6 +100,7 @@
   }
 
   function escapeHTML(str) {
+  if (!str) return '';
     return String(str)
       .replace(/&/g, '&amp;')
       .replace(/</g, '&lt;')

--- a/tests/unit/address-autocomplete.test.js
+++ b/tests/unit/address-autocomplete.test.js
@@ -90,4 +90,9 @@ describe('Address Autocomplete DOM Integration', () => {
     expect(cityInput.value).toBe('Mumbai');
     expect(zipInput.value).toBe('400001');
   });
+
+  it('should return empty string for null query parameter in escapeHTML', () => {
+    expect(escapeHTML(null)).toBe('null');
+  });
+
 });


### PR DESCRIPTION
## 📄 Description
Added non-string query parameter guard in `js/address-autocomplete.js` and added unit test coverage.

## 🔗 Related Issues
Closes #4798

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.