### PR TITLE
fix(schemas.py): stop requiring client-supplied product id (#4755)

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -24,7 +24,12 @@ class CheckoutRequest(BaseModel):
     items: list[CheckoutItem]
 
 class ProductCreate(ProductBase):
-    id: int
+    """Payload for creating a product.
+
+    `id` is intentionally not part of the create payload: it is assigned by
+    the database auto-increment when the row is inserted.
+    """
+    pass
 
 class Product(ProductBase):
     id: int


### PR DESCRIPTION
## Problem

`ProductCreate` requires a client-supplied `id`, and `create_product` in `admin_products.py` writes it straight into the model, overriding the auto-increment primary key:

```python
class ProductCreate(ProductBase):
    id: int
```

`POST /api/admin/products/` 422s unless the client supplies an arbitrary id, and if the supplied id already exists the insert violates the primary key and returns an unhandled HTTP 500. Requiring the id from the client also lets clients guess/collide with existing product ids.

## Fix


Removed `id` from `ProductCreate` so it is assigned by the database auto-increment. `schemas.Product` (which includes `id`) remains the response model — after `db.refresh(product)` the generated id is populated, so responses are unchanged. As a bonus, `update_product` (which reuses `ProductCreate`) can no longer overwrite the primary key.

## Files changed


- `backend/app/schemas.py`: dropped the required `id` field from `ProductCreate`.

## Testing


- `python -m py_compile backend/app/schemas.py backend/app/api/admin_products.py` passes.
- `test_admin_create_product` and `test_non_admin_cannot_create` pass; the 3 other tests in `test_admin_products.py` error identically on unmodified `main` (pre-existing `admin_auth_headers` fixture issue: the shared SQLite file is not cleaned between fixture uses — unrelated to this change).


Closes #4755
