### PR TITLE
fix(checkout.js): declare subtotal/taxCents/giftChargeCents/urgencyDiscountCents/loyaltyDiscountCents in updateCheckoutSummary (#4746)

### DIFF
--- a/checkout.js
+++ b/checkout.js
@@ -481,6 +481,7 @@ window.updateCheckoutSummary = function () {
       sum + Math.round(parsePriceString(item.price) * 100) * (parseInt(item.quantity, 10) || 1),
     0,
   );
+  const subtotal = subtotalCents / 100;
 
   // Check coupon discount
   const couponCode = localStorage.getItem('appliedCoupon') || '';
@@ -505,6 +506,11 @@ window.updateCheckoutSummary = function () {
   const loyaltyPoints =
     parseInt(localStorage.getItem('cara_applied_loyalty_points'), 10) || 0;
   const loyaltyDiscount = loyaltyPoints / (window.CARA_CONFIG ? window.CARA_CONFIG.LOYALTY.POINTS_PER_RUPEE : 10);
+
+  const taxCents = Math.round(subtotalCents * (window.CARA_CONFIG ? window.CARA_CONFIG.TAX_RATE : 0.18));
+  const giftChargeCents = Math.round(giftCharge * 100);
+  const urgencyDiscountCents = Math.round(urgencyDiscount * 100);
+  const loyaltyDiscountCents = Math.round(loyaltyDiscount * 100);
 
   // Grand Total in cents (integer, safe for Stripe)
   const grandTotalCents = Math.max(
@@ -577,7 +583,7 @@ window.updateCheckoutSummary = function () {
       const divider = document.querySelector('.summary-divider');
       if (divider) divider.parentNode.insertBefore(urgencyRow, divider);
     }
-    urgencyRow.innerHTML = `<span>Urgency Promo (${window.CARA_CONFIG ? window.CARA_CONFIG.URGENCY_DISCOUNT_PCT * 100 : 5}%)</span><span id='urgency-discount-val'>-${formatCurrency(urgencyDiscount)}</span>`;
+    urgencyRow.innerHTML = `<span>Urgency Promo (${window.CARA_CONFIG ? window.CARA_CONFIG.URGENCY_DISCOUNT_PCT * 100 : 5}%)</span><span id='urgency-discount-val'>-${formatCurrency(urgencyDiscountCents)}</span>`;
   } else {
     if (urgencyRow) urgencyRow.remove();
   }


### PR DESCRIPTION
## Problem

`updateCheckoutSummary` in `checkout.js` references several variables that are never declared: `subtotal`, `taxCents`, `giftChargeCents`, `urgencyDiscountCents`, and `loyaltyDiscountCents`. Every invocation throws `ReferenceError: subtotal is not defined` before any DOM update happens, so the checkout summary (subtotal, tax, discounts, grand total) never renders and the totals shown are stale/absent. This fires on init, coupon applied/removed, gift-option change, checkout-timer tick, and coupon validation.

## Fix

- Add `const subtotal = subtotalCents / 100;` so the rupee value used by the percentage-based discounts and tax is defined.
- Derive the missing cent values from the existing rupee amounts:
  - `taxCents` from `subtotalCents` and `CARA_CONFIG.TAX_RATE`
  - `giftChargeCents` = `giftCharge * 100`
  - `urgencyDiscountCents` = `urgencyDiscount * 100`
  - `loyaltyDiscountCents` = `loyaltyDiscount * 100`
- The urgency discount row now displays `formatCurrency(urgencyDiscountCents)` (formatCurrency expects integer cents, so this also fixes the rendered urgency value).


## Files changed


- `checkout.js`


## Testing


- `node --check checkout.js` passes.
- Ran `updateCheckoutSummary` with a stubbed DOM/localStorage: no `ReferenceError`; subtotal ₹250, tax ₹45 (18%), and grand total ₹223 (subtotal + tax − 20% coupon − 5% urgency − loyalty points) are all rendered correctly.


Closes #4746
