### PR TITLE
fix : added validateEmailDomain helper with TLD length check

### DIFF
--- a/js/newsletter-subscribe.js
+++ b/js/newsletter-subscribe.js
@@ -1,3 +1,16 @@
+/**
+ * Validates that an email address has a properly-formed domain with a
+ * top-level domain of at least two characters.
+ * @param {string} email
+ * @returns {boolean}
+ */
+export function validateEmailDomain(email) {
+  if (!email || typeof email !== 'string') return false;
+  // Basic structural check: local@domain.tld with at least 2-char TLD
+  const domainRegex = /^[^\s@]+@[^\s@]+\.[a-zA-Z]{2,}$/;
+  return domainRegex.test(email.trim());
+}
+
 document.addEventListener('DOMContentLoaded', function () {
   const forms = document.querySelectorAll('.newsletter-form');
 
@@ -8,12 +21,22 @@ document.addEventListener('DOMContentLoaded', function () {
       const email = input ? input.value.trim() : '';
       const button = form.querySelector('button[type="submit"]');
 
-      // Email validation regex
+      // Email validation: structural format and domain TLD check
       const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+      const hasValidDomain = validateEmailDomain(email);
 
       if (!email || !emailRegex.test(email)) {
         if (typeof showToast === 'function') {
           showToast('Please enter a valid email address', 'error');
+        } else {
+          alert('Please enter a valid email address');
+        }
+        return;
+      }
+
+      if (!validateEmailDomain(email)) {
+        if (typeof showToast === 'function') {
+          showToast('Please enter a valid email domain (e.g. example.com)', 'error');
         } else {
           alert('Please enter a valid email address');
         }

--- a/tests/unit/newsletter-subscribe.test.js
+++ b/tests/unit/newsletter-subscribe.test.js
@@ -3,6 +3,7 @@
  * Tests newsletter form submission and email validation.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { validateEmailDomain } from '../../js/newsletter-subscribe.js';
 
 // Mock window.alert before importing the module so the IIFE captures our spy
 const alertSpy = vi.fn();
@@ -93,5 +94,33 @@ describe('newsletter-subscribe Unit Tests', () => {
     expect(input.value).toBe('');
 
     vi.useRealTimers();
+  });
+});
+
+describe('validateEmailDomain', () => {
+  it('should accept valid email addresses with proper TLD', () => {
+    expect(validateEmailDomain('user@example.com')).toBe(true);
+    expect(validateEmailDomain('test@domain.co.uk')).toBe(true);
+    expect(validateEmailDomain('abc@sub.example.org')).toBe(true);
+  });
+
+  it('should reject email with single-character TLD', () => {
+    expect(validateEmailDomain('user@domain.c')).toBe(false);
+    expect(validateEmailDomain('test@x.x')).toBe(false);
+  });
+
+  it('should reject email missing a domain dot', () => {
+    expect(validateEmailDomain('user@domain')).toBe(false);
+    expect(validateEmailDomain('user@domaincom')).toBe(false);
+  });
+
+  it('should reject null, undefined, and empty strings', () => {
+    expect(validateEmailDomain(null)).toBe(false);
+    expect(validateEmailDomain(undefined)).toBe(false);
+    expect(validateEmailDomain('')).toBe(false);
+  });
+
+  it('should reject email with whitespace in domain', () => {
+    expect(validateEmailDomain('user@ example.com')).toBe(false);
   });
 });


### PR DESCRIPTION
## 📄 Description
Adds a `validateEmailDomain` helper to `js/newsletter-subscribe.js` that enforces a properly-formed domain with a top-level domain of at least two characters. The newsletter form submit handler now calls this function to reject emails with single-char TLDs (e.g. `user@domain.c`) or missing dot separators. Five new unit tests cover valid domains, single-char TLDs, missing dots, null/undefined inputs, and whitespace in domains.

## 🔗 Related Issues
Closes #4879

## 🧩 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.