### PR TITLE
feat : added roundScrollProgressPercent helper to reading-progress

### DIFF
--- a/js/reading-progress.js
+++ b/js/reading-progress.js
@@ -35,3 +35,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 });
+
+// ── roundScrollProgressPercent ──────────────────────────────────────────────
+// Rounds a raw scroll-progress percentage (e.g. 45.678) to the nearest integer
+// for clean DOM display.
+export function roundScrollProgressPercent(rawPercent) {
+  if (typeof rawPercent !== 'number' || Number.isNaN(rawPercent)) return 0;
+  return Math.round(Math.max(0, Math.min(100, rawPercent)));
+}

--- a/tests/unit/reading-progress.test.js
+++ b/tests/unit/reading-progress.test.js
@@ -48,3 +48,29 @@ describe('reading-progress', () => {
     expect(bar.style.width).toBe('50%');
   });
 });
+
+import { roundScrollProgressPercent } from '../../js/reading-progress.js';
+
+describe('roundScrollProgressPercent', () => {
+  it('rounds a float percentage to nearest integer', () => {
+    expect(roundScrollProgressPercent(45.678)).toBe(46);
+    expect(roundScrollProgressPercent(45.321)).toBe(45);
+  });
+
+  it('clamps to 0 for negative values', () => {
+    expect(roundScrollProgressPercent(-10)).toBe(0);
+  });
+
+  it('clamps to 100 for values over 100', () => {
+    expect(roundScrollProgressPercent(150)).toBe(100);
+  });
+
+  it('returns 0 for NaN inputs', () => {
+    expect(roundScrollProgressPercent(NaN)).toBe(0);
+  });
+
+  it('handles non-number inputs gracefully', () => {
+    expect(roundScrollProgressPercent('forty-five')).toBe(0);
+    expect(roundScrollProgressPercent(null)).toBe(0);
+  });
+});


### PR DESCRIPTION
## 📄 Description
Adds `roundScrollProgressPercent(rawPercent)` to `js/reading-progress.js`. Rounds a raw scroll-progress percentage (e.g. 45.678) to the nearest integer (0-100) with NaN/non-number guards. Five new unit tests cover rounding, clamping to 0 and 100, and NaN inputs.

## 🔗 Related Issues
Closes #4876

## 🧩 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.