### PR TITLE
fix : added sanitizeReviewAuthorName helper to product-reviews

### DIFF
--- a/js/product-reviews.js
+++ b/js/product-reviews.js
@@ -110,4 +110,19 @@ export class ProductReviewManager {
       distribution,
     };
   }
+
+  /**
+   * Strips HTML tags and dangerous characters from a review author name.
+   * @param {string} name
+   * @returns {string}
+   */
+  sanitizeReviewAuthorName(name) {
+    if (typeof name !== 'string') return '';
+    return name
+      .replace(/<[^>]*>/g, '')   // Remove HTML tags
+      .replace(/[<>"'&]/g, '')     // Remove XSS characters
+      .trim()
+      .slice(0, 80);               // Cap at 80 chars
+  }
+
 }

--- a/tests/unit/product-reviews.test.js
+++ b/tests/unit/product-reviews.test.js
@@ -52,4 +52,22 @@ describe('ProductReviewManager Unit Tests', () => {
     expect(summary.distribution[5]).toBe(1);
     expect(summary.distribution[3]).toBe(1);
   });
+
+  it('should sanitize review author names by stripping HTML and XSS chars', () => {
+    // Tags are stripped, leaving content between them
+    expect(manager.sanitizeReviewAuthorName('<b>Alice</b>')).toBe('Alice');
+    expect(manager.sanitizeReviewAuthorName('Bob<script>x</script>')).toBe('Bobx');
+    expect(manager.sanitizeReviewAuthorName('Tom & Jerry')).toBe('Tom  Jerry');
+    expect(manager.sanitizeReviewAuthorName('"><img onerror=1')).toBe('img onerror=1');
+  });
+
+  it('should cap author name at 80 characters', () => {
+    const longName = 'A'.repeat(100);
+    expect(manager.sanitizeReviewAuthorName(longName).length).toBe(80);
+  });
+
+  it('should return empty string for non-string inputs', () => {
+    expect(manager.sanitizeReviewAuthorName(null)).toBe('');
+    expect(manager.sanitizeReviewAuthorName(undefined)).toBe('');
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds `sanitizeReviewAuthorName(name)` to `ProductReviewManager`. Strips HTML tags and XSS characters (`< > " ' &`) from review submitter names, trims whitespace, and caps output at 80 characters. Guards against non-string inputs. Three new unit tests cover HTML stripping, XSS removal, and null/undefined handling.

## 🔗 Related Issues
Closes #4870

## 🧩 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.