### PR TITLE
feat : added calculateReviewRatingBreakdown to product-review-aggregator

### DIFF
--- a/js/product-review-aggregator.js
+++ b/js/product-review-aggregator.js
@@ -99,6 +99,26 @@ class ProductReviewAggregator {
     }
     return { success: false };
   }
+
+  /**
+   * Calculates the percentage distribution of star ratings (1-5) for a product.
+   * @param {string} productId
+   * @returns {Object} Map of star level (1-5) to percentage (0-100).
+   */
+  calculateReviewRatingBreakdown(productId) {
+    const stats = this.getStats(productId);
+    const total = stats.count;
+    if (total === 0) {
+      return { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
+    }
+    return {
+      1: Math.round((stats.distribution[1] / total) * 100),
+      2: Math.round((stats.distribution[2] / total) * 100),
+      3: Math.round((stats.distribution[3] / total) * 100),
+      4: Math.round((stats.distribution[4] / total) * 100),
+      5: Math.round((stats.distribution[5] / total) * 100),
+    };
+  }
 }
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/tests/unit/product-review-aggregator.test.js
+++ b/tests/unit/product-review-aggregator.test.js
@@ -36,4 +36,22 @@ describe('ProductReviewAggregator Unit Tests', () => {
     expect(result.success).toBe(true);
     expect(result.helpful).toBe(1);
   });
+
+  it('should calculate rating breakdown percentages', () => {
+    aggregator.submitReview('prod-70', { rating: 5 });
+    aggregator.submitReview('prod-70', { rating: 5 });
+    aggregator.submitReview('prod-70', { rating: 4 });
+    aggregator.submitReview('prod-70', { rating: 3 });
+    const breakdown = aggregator.calculateReviewRatingBreakdown('prod-70');
+    expect(breakdown[5]).toBe(50); // 2 out of 4 = 50%
+    expect(breakdown[4]).toBe(25); // 1 out of 4 = 25%
+    expect(breakdown[3]).toBe(25); // 1 out of 4 = 25%
+    expect(breakdown[2]).toBe(0);
+    expect(breakdown[1]).toBe(0);
+  });
+
+  it('should return all zeros for products with no reviews', () => {
+    const breakdown = aggregator.calculateReviewRatingBreakdown('nonexistent');
+    expect(breakdown).toEqual({ 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 });
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds `calculateReviewRatingBreakdown(productId)` to `ProductReviewAggregator`. Returns a map of star levels (1-5) to percentage (0-100) of reviews at each level. Returns all-zeros for products with no reviews. Two new unit tests cover the percentage calculation and empty-product case.

## 🔗 Related Issues
Closes #4868

## 🧩 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.