### PR TITLE
feat : added isOutfitWithinBudget to outfit-compatibility

### DIFF
--- a/js/outfit-compatibility.js
+++ b/js/outfit-compatibility.js
@@ -30,6 +30,18 @@ class OutfitCompatibility {
     const cleanColor = color.toLowerCase().trim();
     return this.complementaryColors[cleanColor] || ['white', 'black'];
   }
+
+  /**
+   * Checks whether a total outfit price is within a given budget.
+   * @param {number} totalPrice
+   * @param {number} budget
+   * @returns {boolean}
+   */
+  isOutfitWithinBudget(totalPrice, budget) {
+    if (typeof totalPrice !== 'number' || Number.isNaN(totalPrice)) return false;
+    if (typeof budget !== 'number' || Number.isNaN(budget) || budget < 0) return true; // no limit
+    return totalPrice <= budget;
+  }
 }
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/tests/unit/outfit-compatibility.test.js
+++ b/tests/unit/outfit-compatibility.test.js
@@ -24,4 +24,23 @@ describe('js/outfit-compatibility.js OutfitCompatibility tests', () => {
     expect(compatibility.getRecommendedFallbacks('red')).toEqual(['white', 'black', 'navy']);
     expect(compatibility.getRecommendedFallbacks('nonexistent')).toEqual(['white', 'black']);
   });
+
+
+  it('should return true when outfit is within budget', () => {
+    const c = new OutfitCompatibility();
+    expect(c.isOutfitWithinBudget(80, 100)).toBe(true);
+    expect(c.isOutfitWithinBudget(100, 100)).toBe(true); // inclusive
+  });
+
+  it('should return false when outfit exceeds budget', () => {
+    const c = new OutfitCompatibility();
+    expect(c.isOutfitWithinBudget(150, 100)).toBe(false);
+  });
+
+  it('should return true when budget is undefined (no limit)', () => {
+    const c = new OutfitCompatibility();
+    expect(c.isOutfitWithinBudget(9999, undefined)).toBe(true);
+    expect(c.isOutfitWithinBudget(9999, NaN)).toBe(true);
+  });
+
 });


### PR DESCRIPTION
## 📄 Description
Adds `isOutfitWithinBudget(totalPrice, budget)` to `OutfitCompatibility`. Returns true when the outfit total is within budget (inclusive). Treats undefined/NaN/negative budget as no limit. Three new unit tests cover within-budget, over-budget, and undefined-budget cases.

## 🔗 Related Issues
Closes #4862

## 🧩 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.