### PR TITLE
fix(api): remove unauthenticated products checkout stock drain

### DIFF
--- a/backend/app/api/products.py
+++ b/backend/app/api/products.py
@@ -29,41 +29,6 @@ def get_product(product_id: int, db: Session = Depends(get_db)):
     return product
 
 
-@router.post("/checkout")
-def checkout_cart(request: schemas.CheckoutRequest, db: Session = Depends(get_db)):
-    # Sort items to prevent deadlocks when locking multiple rows
-    items = sorted(request.items, key=lambda x: x.name)
-
-    try:
-        # Atomic block
-        for item in items:
-            product = db.query(models.Product).filter(
-                models.Product.name == item.name
-            ).with_for_update().first()
-
-            if not product:
-                db.rollback()
-                raise HTTPException(status_code=400, detail=f"Product '{item.name}' not found")
-
-            if product.stock < item.quantity:
-                db.rollback()
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Insufficient stock for '{product.name}'. Only {product.stock} remaining.",
-                )
-
-            product.stock -= item.quantity
-
-        db.commit()
-        return {"status": "success", "message": "Order placed successfully"}
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        db.rollback()
-        raise HTTPException(status_code=500, detail=f"Internal server error during checkout: {str(e)}")
-
-
 # ---------------------------------------------------------------------------
 # New: Search & Filter endpoint
 # ---------------------------------------------------------------------------

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -16,13 +16,6 @@ class ProductBase(BaseModel):
     style: Optional[str] = None
     stock: int = 10
 
-class CheckoutItem(BaseModel):
-    name: str
-    quantity: int
-
-class CheckoutRequest(BaseModel):
-    items: list[CheckoutItem]
-
 class ProductCreate(ProductBase):
     id: int
 

--- a/backend/tests/test_products.py
+++ b/backend/tests/test_products.py
@@ -1,7 +1,6 @@
 """Tests for GET /api/products/ and GET /api/products/{id}."""
 from app.models import Product
-from app.database import get_db
-from tests.conftest import override_get_db, TestingSessionLocal
+from tests.conftest import TestingSessionLocal
 
 PRODUCTS_URL = "/api/products/"
 
@@ -50,3 +49,24 @@ def test_get_product_by_id(client):
 def test_get_product_not_found(client):
     r = client.get(f"{PRODUCTS_URL}999999")
     assert r.status_code == 404
+
+
+def test_products_checkout_endpoint_removed(client):
+    """Unauthenticated stock deduction via /api/products/checkout must not exist."""
+    db = TestingSessionLocal()
+    product = _seed_product(db, name="Stock Drain Target", stock=5)
+    starting_stock = product.stock
+    db.close()
+
+    response = client.post(
+        f"{PRODUCTS_URL}checkout",
+        json={"items": [{"name": "Stock Drain Target", "quantity": 5}]},
+    )
+
+    assert response.status_code in (404, 405, 422)
+
+    db = TestingSessionLocal()
+    remaining = db.query(Product).filter(Product.name == "Stock Drain Target").first()
+    assert remaining is not None
+    assert remaining.stock == starting_stock
+    db.close()


### PR DESCRIPTION
# Summary
Removes `POST /api/products/checkout`, which deducted product stock without auth and without creating an order. Real checkout already mutates stock through `/api/orders/`.

---

## Related Issue
Closes #4914

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

---

## What Was Changed

- Deleted the unauthenticated `checkout_cart` handler in `backend/app/api/products.py`
- Removed unused `CheckoutItem` / `CheckoutRequest` schemas
- Added a regression test that asserts stock is unchanged when posting to `/api/products/checkout`

---

## why this needed
Anyone could hit that endpoint and drain inventory. No login, no order row — just stock going down. Order creation already handles stock correctly.

---

## How Has This Been Tested?

- [x] Tested backend API endpoints manually
- [ ] Ran frontend locally with `npm run dev`
- [x] Ran `npm run lint` — no errors
- [ ] Ran `npm run build` — no errors
- [ ] Uploaded a test document and verified output
- [ ] Tested on mobile view

Backend: `SECRET_KEY=... PYTHONPATH=. pytest tests/test_products.py` — 5 passed
Frontend pre-commit: `npm test` — 372 passed

---

## Screenshots (if applicable)

N/A (API-only change)

---

## Self-Review Checklist

- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #IssueNumber`)
- [x] I have tested my changes locally
- [ ] I have added screenshots for UI changes
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue

---

## Additional Notes

Frontend checkout already posts to `/api/orders/`; nothing called `/api/products/checkout`.

Made with [Cursor](https://cursor.com)