### PR TITLE
fix(orders): restore product stock when an order is cancelled

### DIFF
--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -207,6 +207,7 @@ def cancel_order(
             models.Order.id == order_id,
             models.Order.email == current_user.email,
         )
+        .with_for_update()
         .first()
     )
     if not order:
@@ -221,6 +222,25 @@ def cancel_order(
             status_code=400,
             detail=f"Orders can only be cancelled within {CANCELLABLE_WINDOW_HOURS} hours of placing them.",
         )
+
+    items = (
+        db.query(models.OrderItem)
+        .filter(models.OrderItem.order_id == order.id)
+        .all()
+    )
+    product_names = [item.product_name for item in items]
+    if product_names:
+        products = (
+            db.query(models.Product)
+            .filter(models.Product.name.in_(product_names))
+            .with_for_update()
+            .all()
+        )
+        product_map = {product.name: product for product in products}
+        for item in items:
+            product = product_map.get(item.product_name)
+            if product is not None:
+                product.stock += item.quantity
 
     order.status = "CANCELLED"
     db.commit()

--- a/backend/tests/test_order_cancel.py
+++ b/backend/tests/test_order_cancel.py
@@ -1,0 +1,122 @@
+"""Tests for order cancel stock restoration."""
+from passlib.context import CryptContext
+
+from app.models import Product, Order, User
+from tests.conftest import TestingSessionLocal
+
+ORDERS_URL = "/api/orders/"
+pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def _auth_headers(client, *, username="canceluser", email="cancel@example.com"):
+    db = TestingSessionLocal()
+    user = db.query(User).filter(User.email == email).first()
+    if user is None:
+        user = User(
+            username=username,
+            email=email,
+            hashed_password=pwd.hash("Test@1234"),
+        )
+        db.add(user)
+        db.commit()
+    db.close()
+
+    response = client.post(
+        "/api/auth/login",
+        json={"email": email, "password": "Test@1234"},
+    )
+    assert response.status_code == 200, response.text
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _seed_product(db, **kwargs) -> Product:
+    defaults = dict(
+        brand="TestBrand",
+        name="Cancel Restock Shirt",
+        price=100.0,
+        img="img.jpg",
+        rating=4,
+        category="minimal",
+        subcategory="top",
+        color="white",
+        style="casual",
+        stock=10,
+    )
+    defaults.update(kwargs)
+    product = Product(**defaults)
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+    return product
+
+
+def test_cancel_order_restores_stock(client):
+    headers = _auth_headers(client)
+    db = TestingSessionLocal()
+    _seed_product(db, name="Cancel Restock Shirt", stock=10)
+    db.close()
+
+    create = client.post(
+        ORDERS_URL,
+        headers=headers,
+        json={
+            "fullName": "Test User",
+            "email": "cancel@example.com",
+            "address": "1 Test St",
+            "city": "Testville",
+            "zip": "12345",
+            "items": [{"product_name": "Cancel Restock Shirt", "quantity": 3}],
+        },
+    )
+    assert create.status_code == 201, create.text
+    order_id = create.json()["order_id"]
+
+    db = TestingSessionLocal()
+    after_create = db.query(Product).filter(Product.name == "Cancel Restock Shirt").first()
+    assert after_create.stock == 7
+    db.close()
+
+    cancel = client.post(f"{ORDERS_URL}{order_id}/cancel", headers=headers)
+    assert cancel.status_code == 200, cancel.text
+    assert cancel.json()["status"] == "CANCELLED"
+
+    db = TestingSessionLocal()
+    after_cancel = db.query(Product).filter(Product.name == "Cancel Restock Shirt").first()
+    assert after_cancel.stock == 10
+    order = db.query(Order).filter(Order.id == order_id).first()
+    assert order.status == "CANCELLED"
+    db.close()
+
+
+def test_cancel_already_cancelled_does_not_double_restock(client):
+    headers = _auth_headers(client)
+    db = TestingSessionLocal()
+    _seed_product(db, name="Double Cancel Shirt", stock=5)
+    db.close()
+
+    create = client.post(
+        ORDERS_URL,
+        headers=headers,
+        json={
+            "fullName": "Test User",
+            "email": "cancel@example.com",
+            "address": "1 Test St",
+            "city": "Testville",
+            "zip": "12345",
+            "items": [{"product_name": "Double Cancel Shirt", "quantity": 2}],
+        },
+    )
+    assert create.status_code == 201, create.text
+    order_id = create.json()["order_id"]
+
+    first = client.post(f"{ORDERS_URL}{order_id}/cancel", headers=headers)
+    assert first.status_code == 200
+
+    second = client.post(f"{ORDERS_URL}{order_id}/cancel", headers=headers)
+    assert second.status_code == 400
+
+    db = TestingSessionLocal()
+    product = db.query(Product).filter(Product.name == "Double Cancel Shirt").first()
+    assert product.stock == 5
+    db.close()


### PR DESCRIPTION
# Summary
Cancel was only flipping order status to `CANCELLED`. Stock deducted at create time never came back.

---

## Related Issue
Closes #4915

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

---

## What Was Changed

- On cancel, restock each order line against matching products
- Row-lock the order + products so a double cancel can't inflate stock
- Skip restock for missing products (still cancel the order)
- Added `backend/tests/test_order_cancel.py`

---

## why this needed
Every cancel permanently reduced inventory. That drifts stock and causes false OOS.

---

## How Has This Been Tested?

- [x] Tested backend API endpoints manually
- [ ] Ran frontend locally with `npm run dev`
- [ ] Ran `npm run lint` — no errors
- [ ] Ran `npm run build` — no errors
- [ ] Uploaded a test document and verified output
- [ ] Tested on mobile view

`pytest tests/test_order_cancel.py` — 2 passed
pre-commit `npm test` — 372 passed

---

## Screenshots (if applicable)

N/A

---

## Self-Review Checklist

- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #IssueNumber`)
- [x] I have tested my changes locally
- [ ] I have added screenshots for UI changes
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue

---

## Additional Notes

Restock still keys off `product_name` because that's what order create uses today.

Made with [Cursor](https://cursor.com)