### PR TITLE
fix(auth): wire login form to POST /api/auth/login

### DIFF
--- a/login.html
+++ b/login.html
@@ -148,8 +148,7 @@
   <script>loadNavbar();</script>
   <script type="module" src="app.js"></script>
   <script type="module" src="js/fetch-timeout.js"></script>
-  
-  <script type="module" src="js/simple-captcha.js" defer></script>
+  <script type="module" src="login.js"></script>
 </body>
 </html>
 

--- a/login.js
+++ b/login.js
@@ -1,0 +1,177 @@
+/* global fetchWithTimeout */
+const API_BASE_URL = window.CARA_API_BASE_URL || '';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('loginForm');
+  if (!form) return;
+
+  const emailInput = document.getElementById('loginEmail');
+  const passwordInput = document.getElementById('loginPassword');
+  const emailError = document.getElementById('emailError');
+  const passwordError = document.getElementById('passwordError');
+  const formError = document.getElementById('formError');
+  const submitBtn = document.getElementById('loginSubmitBtn');
+  const captchaSection = document.getElementById('captcha-section');
+  const captchaInput = document.getElementById('captcha-input');
+  const captchaError = document.getElementById('captchaError');
+  const captchaCanvas = document.getElementById('captcha-canvas');
+  const captchaRefresh = document.getElementById('captcha-refresh');
+  const togglePassword = document.getElementById('togglePassword');
+  const toggleIcon = document.getElementById('toggleIcon');
+
+  let captchaToken = null;
+  let captchaRequired = false;
+
+  function setFieldError(input, errorEl, message) {
+    if (input) input.setAttribute('aria-invalid', message ? 'true' : 'false');
+    if (errorEl) errorEl.textContent = message || '';
+  }
+
+  function setFormError(message) {
+    if (formError) formError.textContent = message || '';
+  }
+
+  function setBusy(isBusy) {
+    if (!submitBtn) return;
+    submitBtn.disabled = isBusy;
+    submitBtn.setAttribute('aria-busy', String(isBusy));
+  }
+
+  async function loadCaptcha() {
+    if (!captchaSection) return;
+    captchaRequired = true;
+    captchaSection.style.display = 'block';
+    setFieldError(captchaInput, captchaError, '');
+
+    try {
+      const fetchFunc =
+        typeof fetchWithTimeout === 'function' ? fetchWithTimeout : fetch;
+      const res = await fetchFunc(`${API_BASE_URL}/api/auth/captcha`, {
+        method: 'GET',
+        credentials: 'include',
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.detail || 'Failed to load captcha');
+      }
+
+      captchaToken = data.captcha_token || null;
+      if (captchaCanvas && data.captcha_image) {
+        const ctx = captchaCanvas.getContext('2d');
+        const image = new Image();
+        image.onload = () => {
+          ctx.clearRect(0, 0, captchaCanvas.width, captchaCanvas.height);
+          ctx.drawImage(image, 0, 0, captchaCanvas.width, captchaCanvas.height);
+        };
+        image.src = data.captcha_image;
+      }
+      if (captchaInput) captchaInput.value = '';
+    } catch (err) {
+      setFieldError(
+        captchaInput,
+        captchaError,
+        err.message || 'Failed to load captcha',
+      );
+    }
+  }
+
+  if (togglePassword && passwordInput) {
+    togglePassword.addEventListener('click', () => {
+      const showing = passwordInput.type === 'text';
+      passwordInput.type = showing ? 'password' : 'text';
+      if (toggleIcon) {
+        toggleIcon.className = showing ? 'ri-eye-line' : 'ri-eye-off-line';
+      }
+      togglePassword.setAttribute(
+        'aria-label',
+        showing ? 'Show password' : 'Hide password',
+      );
+    });
+  }
+
+  if (captchaRefresh) {
+    captchaRefresh.addEventListener('click', () => {
+      loadCaptcha();
+    });
+  }
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+
+    setFieldError(emailInput, emailError, '');
+    setFieldError(passwordInput, passwordError, '');
+    setFieldError(captchaInput, captchaError, '');
+    setFormError('');
+
+    const email = emailInput?.value.trim() || '';
+    const password = passwordInput?.value || '';
+
+    if (!email) {
+      setFieldError(emailInput, emailError, 'Email is required.');
+      return;
+    }
+    if (!password) {
+      setFieldError(passwordInput, passwordError, 'Password is required.');
+      return;
+    }
+    if (captchaRequired && !(captchaInput?.value || '').trim()) {
+      setFieldError(captchaInput, captchaError, 'Enter the security code.');
+      return;
+    }
+
+    const body = { email, password };
+    if (captchaRequired) {
+      body.captcha_token = captchaToken;
+      body.captcha_answer = (captchaInput?.value || '').trim();
+    }
+
+    setBusy(true);
+    try {
+      const fetchFunc =
+        typeof fetchWithTimeout === 'function' ? fetchWithTimeout : fetch;
+      const res = await fetchFunc(`${API_BASE_URL}/api/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(body),
+      });
+
+      let data = {};
+      try {
+        data = await res.json();
+      } catch {
+        data = {};
+      }
+
+      if (!res.ok) {
+        const detail = Array.isArray(data.detail)
+          ? data.detail.map((item) => item.msg || item).join(' ')
+          : data.detail || 'Login failed';
+
+        if (
+          res.status === 403 &&
+          /captcha|security/i.test(String(detail))
+        ) {
+          setFormError(detail);
+          await loadCaptcha();
+          return;
+        }
+
+        if (res.status === 401) {
+          setFormError(detail);
+          await loadCaptcha();
+          return;
+        }
+
+        setFormError(detail);
+        return;
+      }
+
+      window.location.href = 'index.html';
+    } catch (err) {
+      setFormError(err.message || 'Network error. Please try again.');
+    } finally {
+      setBusy(false);
+    }
+  });
+});

--- a/tests/unit/login.test.js
+++ b/tests/unit/login.test.js
@@ -1,0 +1,113 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('login.js', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    document.body.innerHTML = `
+      <form id="loginForm">
+        <input id="loginEmail" />
+        <span id="emailError"></span>
+        <input id="loginPassword" type="password" />
+        <span id="passwordError"></span>
+        <span id="formError"></span>
+        <div id="captcha-section" style="display:none">
+          <canvas id="captcha-canvas" width="150" height="40"></canvas>
+          <button type="button" id="captcha-refresh"></button>
+          <input id="captcha-input" />
+          <span id="captchaError"></span>
+        </div>
+        <button type="submit" id="loginSubmitBtn"><span>Sign In</span></button>
+      </form>
+    `;
+    window.CARA_API_BASE_URL = '';
+  });
+
+  it('posts credentials to /api/auth/login with cookies', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: 'tok', token_type: 'bearer' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const location = { href: 'login.html' };
+    vi.stubGlobal('location', location);
+
+    await import('../../login.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    document.getElementById('loginEmail').value = 'user@example.com';
+    document.getElementById('loginPassword').value = 'Secret@123';
+
+    document.getElementById('loginForm').dispatchEvent(
+      new Event('submit', { bubbles: true, cancelable: true }),
+    );
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/auth/login',
+        expect.objectContaining({
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            email: 'user@example.com',
+            password: 'Secret@123',
+          }),
+        }),
+      );
+      expect(location.href).toBe('index.html');
+    });
+  });
+
+  it('loads server captcha after a failed login attempt', async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).includes('/api/auth/captcha')) {
+        return {
+          ok: true,
+          json: async () => ({
+            captcha_image: 'data:image/png;base64,abc',
+            captcha_token: 'captcha-jwt',
+          }),
+        };
+      }
+      return {
+        ok: false,
+        status: 401,
+        json: async () => ({ detail: 'Invalid email or password.' }),
+      };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
+      clearRect: vi.fn(),
+      drawImage: vi.fn(),
+    }));
+
+    await import('../../login.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    document.getElementById('loginEmail').value = 'user@example.com';
+    document.getElementById('loginPassword').value = 'bad';
+
+    document.getElementById('loginForm').dispatchEvent(
+      new Event('submit', { bubbles: true, cancelable: true }),
+    );
+
+    await vi.waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some((call) =>
+          String(call[0]).includes('/api/auth/captcha'),
+        ),
+      ).toBe(true);
+      expect(document.getElementById('captcha-section').style.display).toBe(
+        'block',
+      );
+      expect(document.getElementById('formError').textContent).toContain(
+        'Invalid email or password.',
+      );
+    });
+  });
+});


### PR DESCRIPTION
# Summary
Login form never hit `/api/auth/login`. It only validated a client-side math captcha, so cookie sessions were never created.

---

## Related Issue
Closes #4913

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

---

## What Was Changed

- Added `login.js` that POSTs email/password to `/api/auth/login` with `credentials: 'include'`
- Shows the existing server captcha UI after failed attempts (`GET /api/auth/captcha`)
- Swapped `js/simple-captcha.js` out of `login.html` (it blocked/replaced the real flow)
- Added `tests/unit/login.test.js`

---

## why this needed
Users could register, but login did nothing useful against the backend. Cookie-auth routes (orders, profile) stayed unreachable after a "login".

Related #657 reported symptoms; this wires the actual missing API call.

---

## How Has This Been Tested?

- [ ] Tested backend API endpoints manually
- [ ] Ran frontend locally with `npm run dev`
- [ ] Ran `npm run lint` — no errors
- [ ] Ran `npm run build` — no errors
- [ ] Uploaded a test document and verified output
- [ ] Tested on mobile view

`npx vitest run tests/unit/login.test.js` — 2 passed
pre-commit `npm test` — 374 passed

---

## Screenshots (if applicable)

N/A

---

## Self-Review Checklist

- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #IssueNumber`)
- [x] I have tested my changes locally
- [ ] I have added screenshots for UI changes
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue

---

## Additional Notes

Matches the register flow pattern (`credentials: 'include'`, no token in localStorage).

Made with [Cursor](https://cursor.com)