### PR TITLE
fix(orders): add owner-scoped GET /api/orders/{id}

### DIFF
--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -60,6 +60,26 @@ def get_user_orders(
     return [serialize_order(order, db, include_items=False) for order in orders]
 
 
+@router.get("/{order_id}")
+def get_order_detail(
+    order_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    order = (
+        db.query(models.Order)
+        .filter(
+            models.Order.id == order_id,
+            models.Order.email == current_user.email,
+        )
+        .first()
+    )
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+
+    return serialize_order(order, db, include_items=True)
+
+
 @router.post("/", status_code=201)
 def create_order(
     order_data: schemas.OrderCreate,

--- a/backend/tests/test_order_detail.py
+++ b/backend/tests/test_order_detail.py
@@ -1,0 +1,88 @@
+"""Tests for GET /api/orders/{id}."""
+from passlib.context import CryptContext
+
+from app.models import Order, OrderItem, User
+from tests.conftest import TestingSessionLocal
+
+ORDERS_URL = "/api/orders/"
+pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def _auth_headers(client, *, username="detailuser", email="detail@example.com"):
+    db = TestingSessionLocal()
+    user = db.query(User).filter(User.email == email).first()
+    if user is None:
+        user = User(
+            username=username,
+            email=email,
+            hashed_password=pwd.hash("Test@1234"),
+        )
+        db.add(user)
+        db.commit()
+    db.close()
+
+    response = client.post(
+        "/api/auth/login",
+        json={"email": email, "password": "Test@1234"},
+    )
+    assert response.status_code == 200, response.text
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+def _seed_order(*, email: str, product_name: str = "Detail Shirt") -> Order:
+    db = TestingSessionLocal()
+    order = Order(
+        full_name="Detail User",
+        email=email,
+        address="1 Detail St",
+        city="Detail City",
+        zip_code="99999",
+        total_amount=120.0,
+        status="CONFIRMED",
+    )
+    db.add(order)
+    db.flush()
+    db.add(
+        OrderItem(
+            order_id=order.id,
+            product_name=product_name,
+            quantity=2,
+            price=60.0,
+        )
+    )
+    db.commit()
+    db.refresh(order)
+    order_id = order.id
+    db.close()
+    return order_id
+
+
+def test_get_order_detail_returns_items_for_owner(client):
+    headers = _auth_headers(client)
+    order_id = _seed_order(email="detail@example.com")
+
+    response = client.get(f"{ORDERS_URL}{order_id}", headers=headers)
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["id"] == order_id
+    assert data["email"] == "detail@example.com"
+    assert len(data["items"]) == 1
+    assert data["items"][0]["product_name"] == "Detail Shirt"
+    assert data["items"][0]["quantity"] == 2
+
+
+def test_get_order_detail_forbidden_for_other_user(client):
+    _auth_headers(client, username="owneruser", email="owner@example.com")
+    order_id = _seed_order(email="owner@example.com", product_name="Owner Shirt")
+
+    other_headers = _auth_headers(
+        client, username="otheruser", email="other@example.com"
+    )
+    response = client.get(f"{ORDERS_URL}{order_id}", headers=other_headers)
+    assert response.status_code == 404
+
+
+def test_get_order_detail_requires_auth(client):
+    order_id = _seed_order(email="anon@example.com")
+    response = client.get(f"{ORDERS_URL}{order_id}")
+    assert response.status_code == 401


### PR DESCRIPTION
# Summary
Order history "View details" calls `GET /api/orders/{id}`, but that route did not exist. Added an owner-scoped detail endpoint that includes line items.

---

## Related Issue
Closes #4917

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

---

## What Was Changed

- Added `GET /api/orders/{order_id}` using `serialize_order(..., include_items=True)`
- Scoped to `current_user.email` (404 for other users / missing orders)
- Added `backend/tests/test_order_detail.py`

---

## why this needed
Detail button always failed. List worked; single-order fetch had nowhere to go.

---

## How Has This Been Tested?

- [x] Tested backend API endpoints manually
- [ ] Ran frontend locally with `npm run dev`
- [ ] Ran `npm run lint` — no errors
- [ ] Ran `npm run build` — no errors
- [ ] Uploaded a test document and verified output
- [ ] Tested on mobile view

`pytest tests/test_order_detail.py` — 3 passed
pre-commit `npm test` — 372 passed

---

## Screenshots (if applicable)

N/A

---

## Self-Review Checklist

- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #IssueNumber`)
- [x] I have tested my changes locally
- [ ] I have added screenshots for UI changes
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue

---

## Additional Notes

Pairs with order-history auth work (#4749) but this PR only adds the missing route.

Made with [Cursor](https://cursor.com)