### PR TITLE
fix(config): add missing js/config.js and coupon-config.js

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,29 @@
+/**
+ * Shared frontend config loaded early by most HTML pages.
+ * Values mirror the defaults also set in app.js so pages that do not
+ * load app.js still get API base URL, tax/shipping, and coupon codes.
+ */
+(() => {
+  if (typeof window.CARA_API_BASE_URL === 'undefined') {
+    window.CARA_API_BASE_URL = '';
+  }
+
+  window.CARA_CONFIG = window.CARA_CONFIG || {
+    TAX_RATE: 0.18,
+    SHIPPING: {
+      FEE: 150,
+      FREE_THRESHOLD: 3000,
+    },
+    URGENCY_DISCOUNT_PCT: 0.05,
+    GIFT_WRAP_CHARGE: 99,
+    LOYALTY: {
+      POINTS_PER_RUPEE: 10,
+      DEFAULT_BALANCE: 150,
+    },
+  };
+
+  window.CARA_COUPONS = window.CARA_COUPONS || {
+    CARA20: 20,
+    WELCOME10: 10,
+  };
+})();

--- a/js/coupon-config.js
+++ b/js/coupon-config.js
@@ -1,0 +1,11 @@
+/**
+ * Coupon catalog for cart.html (classic script).
+ * Kept as a thin dedicated file because cart.html loads it with defer
+ * separately from the module-based js/config.js.
+ */
+(() => {
+  window.CARA_COUPONS = window.CARA_COUPONS || {
+    CARA20: 20,
+    WELCOME10: 10,
+  };
+})();

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -1,0 +1,41 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('js/config.js', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete window.CARA_API_BASE_URL;
+    delete window.CARA_CONFIG;
+    delete window.CARA_COUPONS;
+  });
+
+  it('defines API base URL, checkout config, and coupon codes', async () => {
+    await import('../../js/config.js');
+
+    expect(window.CARA_API_BASE_URL).toBe('');
+    expect(window.CARA_CONFIG.TAX_RATE).toBe(0.18);
+    expect(window.CARA_CONFIG.SHIPPING.FREE_THRESHOLD).toBe(3000);
+    expect(window.CARA_COUPONS.CARA20).toBe(20);
+    expect(window.CARA_COUPONS.WELCOME10).toBe(10);
+  });
+
+  it('does not overwrite a pre-set API base URL', async () => {
+    window.CARA_API_BASE_URL = 'http://localhost:8000';
+    await import('../../js/config.js');
+    expect(window.CARA_API_BASE_URL).toBe('http://localhost:8000');
+  });
+});
+
+describe('js/coupon-config.js', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete window.CARA_COUPONS;
+  });
+
+  it('exposes known coupon codes for the cart page', async () => {
+    await import('../../js/coupon-config.js');
+    expect(window.CARA_COUPONS.CARA20).toBe(20);
+  });
+});


### PR DESCRIPTION
# Summary
Pages include `js/config.js` / `js/coupon-config.js` but the files were missing (404). Added them with API base URL, checkout config, and coupon codes.

---

## Related Issue
Closes #4924

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

---

## What Was Changed

- Added `js/config.js` (`CARA_API_BASE_URL`, `CARA_CONFIG`, `CARA_COUPONS`)
- Added `js/coupon-config.js` for cart.html's defer script
- Unit tests in `tests/unit/config.test.js`

---

## why this needed
Every page that referenced those scripts hit 404s. Login/register/checkout fell back to empty API base / hardcoded defaults inconsistently.

---

## How Has This Been Tested?

- [ ] Tested backend API endpoints manually
- [ ] Ran frontend locally with `npm run dev`
- [ ] Ran `npm run lint` — no errors
- [ ] Ran `npm run build` — no errors
- [ ] Uploaded a test document and verified output
- [ ] Tested on mobile view

`npx vitest run tests/unit/config.test.js`
pre-commit `npm test`

---

## Screenshots (if applicable)

N/A

---

## Self-Review Checklist

- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #IssueNumber`)
- [x] I have tested my changes locally
- [ ] I have added screenshots for UI changes
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue

---

## Additional Notes

Defaults match `app.js`. Override `window.CARA_API_BASE_URL` before the script for a remote API host.

Made with [Cursor](https://cursor.com)