### PR TITLE
fix(api): include live demo origin in CORS allowlist

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,3 +8,7 @@
 # Secret key used for signing JWTs — required, server will not start without it.
 # Generate one with: python -c "import secrets; print(secrets.token_hex(32))"
 SECRET_KEY=your-secret-key-here
+
+# Comma-separated browser origins allowed for credentialed CORS requests.
+# Defaults include local Live Server ports and documented Vercel demos when unset.
+# CORS_ORIGINS=http://localhost:5500,https://cara-seven-ashen.vercel.app

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ from .api import auth
 from .limiter import limiter
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
+import os
 # Database schema is now managed externally by Alembic migrations
 
 app = FastAPI(title="Cara AI Outfit Recommendation API")
@@ -12,11 +13,24 @@ app = FastAPI(title="Cara AI Outfit Recommendation API")
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
+_DEFAULT_CORS_ORIGINS = [
+    "http://127.0.0.1:5500",
+    "http://localhost:5500",
+    "https://cara-janavipandoles-projects.vercel.app",
+    "https://cara-seven-ashen.vercel.app",
+]
+
+
+def _cors_allow_origins() -> list[str]:
+    raw = os.environ.get("CORS_ORIGINS", "").strip()
+    if not raw:
+        return list(_DEFAULT_CORS_ORIGINS)
+    return [origin.strip() for origin in raw.split(",") if origin.strip()]
+
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://127.0.0.1:5500",
-    "http://localhost:5500",
-    "https://cara-janavipandoles-projects.vercel.app",],  # update as needed
+    allow_origins=_cors_allow_origins(),
     allow_credentials=True,
     allow_methods=["GET", "POST", "OPTIONS", "PUT", "PATCH", "DELETE"],
     allow_headers=["*"],

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -1,0 +1,38 @@
+"""Tests for CORS allow-origin configuration."""
+import importlib
+import os
+
+import pytest
+
+
+@pytest.fixture()
+def reload_main(monkeypatch):
+    def _reload(**env):
+        monkeypatch.setenv("SECRET_KEY", "test-secret-key-for-pytest")
+        for key, value in env.items():
+            if value is None:
+                monkeypatch.delenv(key, raising=False)
+            else:
+                monkeypatch.setenv(key, value)
+        import app.main as main
+
+        return importlib.reload(main)
+
+    return _reload
+
+
+def test_default_cors_includes_live_demo(reload_main, monkeypatch):
+    monkeypatch.delenv("CORS_ORIGINS", raising=False)
+    main = reload_main(CORS_ORIGINS=None)
+    origins = main._cors_allow_origins()
+    assert "https://cara-seven-ashen.vercel.app" in origins
+    assert "https://cara-janavipandoles-projects.vercel.app" in origins
+    assert "http://localhost:5500" in origins
+
+
+def test_cors_origins_env_override(reload_main):
+    main = reload_main(CORS_ORIGINS="https://example.com, http://localhost:3000")
+    assert main._cors_allow_origins() == [
+        "https://example.com",
+        "http://localhost:3000",
+    ]


### PR DESCRIPTION
# Summary
CORS allowlist omitted the README live demo (`cara-seven-ashen.vercel.app`), so credentialed browser calls from that origin failed. Defaults now include it, and `CORS_ORIGINS` can override.

---

## Related Issue
Closes #4925

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

---

## What Was Changed

- Added `https://cara-seven-ashen.vercel.app` to default CORS origins
- Read optional comma-separated `CORS_ORIGINS` env var
- Documented in `backend/.env.example`
- Added `backend/tests/test_cors.py`

---

## why this needed
Frontend on the documented demo URL could not call the API with cookies.

---

## How Has This Been Tested?

- [x] Tested backend API endpoints manually
- [ ] Ran frontend locally with `npm run dev`
- [ ] Ran `npm run lint` — no errors
- [ ] Ran `npm run build` — no errors
- [ ] Uploaded a test document and verified output
- [ ] Tested on mobile view

`pytest tests/test_cors.py` — 2 passed
pre-commit `npm test`

---

## Screenshots (if applicable)

N/A

---

## Self-Review Checklist

- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #IssueNumber`)
- [x] I have tested my changes locally
- [ ] I have added screenshots for UI changes
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue

---

## Additional Notes

Set `CORS_ORIGINS` in deploy env for any additional frontend hosts.

Made with [Cursor](https://cursor.com)