### PR TITLE
fix(auth): only arm session lock for authenticated users

### DIFF
--- a/js/session-lock.js
+++ b/js/session-lock.js
@@ -1,7 +1,8 @@
-// Automated Inactivity Logout Monitor
+// Automated Inactivity Logout Monitor (authenticated sessions only)
 document.addEventListener('DOMContentLoaded', () => {
   let timeout;
   const maxInactivity = 15 * 60 * 1000; // 15 Minutes
+  const apiBase = window.CARA_API_BASE_URL || '';
 
   const resetTimer = () => {
     clearTimeout(timeout);
@@ -20,7 +21,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // The real session lives in httpOnly cookies, which JS can't clear
     // directly, so ask the server to invalidate them.
-    const apiBase = window.CARA_API_BASE_URL || '';
     fetch(`${apiBase}/api/auth/logout`, {
       method: 'POST',
       credentials: 'include',
@@ -31,12 +31,28 @@ document.addEventListener('DOMContentLoaded', () => {
       });
   };
 
-  // User activity listeners
-  ['click', 'mousemove', 'keypress', 'scroll', 'touchstart'].forEach(
-    (event) => {
-      document.addEventListener(event, resetTimer);
-    },
-  );
+  const startMonitor = () => {
+    ['click', 'mousemove', 'keypress', 'scroll', 'touchstart'].forEach(
+      (event) => {
+        document.addEventListener(event, resetTimer);
+      },
+    );
+    resetTimer();
+  };
 
-  resetTimer();
+  const fetchFunc =
+    typeof fetchWithTimeout === 'function' ? fetchWithTimeout : fetch;
+
+  fetchFunc(`${apiBase}/api/auth/me`, {
+    method: 'GET',
+    credentials: 'include',
+  })
+    .then((res) => {
+      if (res.ok) {
+        startMonitor();
+      }
+    })
+    .catch(() => {
+      // Anonymous / offline visitors should keep shopping.
+    });
 });

--- a/tests/unit/session-lock.test.js
+++ b/tests/unit/session-lock.test.js
@@ -1,0 +1,64 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('session-lock', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    vi.unstubAllGlobals();
+    document.body.innerHTML = '<div id="app"></div>';
+    window.CARA_API_BASE_URL = '';
+    delete window.location;
+    window.location = { href: 'shop.html' };
+  });
+
+  it('does not redirect anonymous visitors after inactivity', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 401 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await import('../../js/session-lock.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    vi.advanceTimersByTime(16 * 60 * 1000);
+    await Promise.resolve();
+
+    expect(window.location.href).toBe('shop.html');
+    expect(
+      fetchMock.mock.calls.some((call) =>
+        String(call[0]).includes('/api/auth/logout'),
+      ),
+    ).toBe(false);
+  });
+
+  it('locks an authenticated session after inactivity', async () => {
+    const fetchMock = vi.fn(async (url, options = {}) => {
+      if (String(url).includes('/api/auth/me')) {
+        return { ok: true, status: 200, json: async () => ({ email: 'a@b.c' }) };
+      }
+      if (String(url).includes('/api/auth/logout')) {
+        expect(options.method).toBe('POST');
+        return { ok: true, status: 200, json: async () => ({}) };
+      }
+      return { ok: false, status: 404 };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await import('../../js/session-lock.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await vi.waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some((call) =>
+          String(call[0]).includes('/api/auth/me'),
+        ),
+      ).toBe(true),
+    );
+    await Promise.resolve();
+
+    vi.advanceTimersByTime(15 * 60 * 1000);
+    await vi.waitFor(() => expect(window.location.href).toBe('login.html'));
+  });
+});


### PR DESCRIPTION
# Summary
Session lock always started a 15-minute inactivity timer and sent visitors to `login.html`, even when they were never logged in. It now probes `/api/auth/me` first.

---

## Related Issue
Closes #4930

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

---

## What Was Changed

- `js/session-lock.js` only starts the inactivity monitor after `/api/auth/me` succeeds
- Added `tests/unit/session-lock.test.js`

---

## why this needed
Guests browsing the shop got kicked to login after sitting idle.

---

## How Has This Been Tested?

- [ ] Tested backend API endpoints manually
- [ ] Ran frontend locally with `npm run dev`
- [ ] Ran `npm run lint` — no errors
- [ ] Ran `npm run build` — no errors
- [ ] Uploaded a test document and verified output
- [ ] Tested on mobile view

`npx vitest run tests/unit/session-lock.test.js` — 2 passed
pre-commit `npm test`

---

## Screenshots (if applicable)

N/A

---

## Self-Review Checklist

- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #IssueNumber`)
- [x] I have tested my changes locally
- [ ] I have added screenshots for UI changes
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue

---

## Additional Notes

None.

Made with [Cursor](https://cursor.com)