### PR TITLE
fix(a11y): pause live sales toasts for reduced motion and hidden tabs

### DIFF
--- a/js/live-sales-toast.js
+++ b/js/live-sales-toast.js
@@ -156,12 +156,45 @@
   }
 
   function startToastCycle() {
-    // Show first toast after 6 seconds of landing
-    setTimeout(() => {
-      showLiveToast();
-      // Setup recurring timer afterwards
-      setInterval(showLiveToast, POPUP_INTERVAL);
-    }, 6000);
+    if (
+      window.matchMedia &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    ) {
+      return;
+    }
+
+    let cycleTimer = null;
+    let initialTimer = null;
+
+    const clearCycle = () => {
+      if (initialTimer !== null) {
+        clearTimeout(initialTimer);
+        initialTimer = null;
+      }
+      if (cycleTimer !== null) {
+        clearInterval(cycleTimer);
+        cycleTimer = null;
+      }
+    };
+
+    const beginCycle = () => {
+      if (cycleTimer !== null) return;
+      initialTimer = setTimeout(() => {
+        showLiveToast();
+        cycleTimer = setInterval(showLiveToast, POPUP_INTERVAL);
+      }, 6000);
+    };
+
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) {
+        clearCycle();
+      } else {
+        beginCycle();
+      }
+    });
+
+    window.addEventListener('pagehide', clearCycle);
+    beginCycle();
   }
 
   // Auto-init on DOMContentLoaded


### PR DESCRIPTION
# Summary
Live sales toasts started a permanent `setInterval` and ignored `prefers-reduced-motion`. Timers are cleared when the tab is hidden, and the feature is skipped under reduced motion.

---

## Related Issue
Closes #4934

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

---

## What Was Changed

- Skip toast cycle when `prefers-reduced-motion: reduce`
- Clear timeout/interval on `visibilitychange` (hidden) and `pagehide`
- Restart cleanly when the tab becomes visible again

---

## why this needed
Permanent timers burn battery and the popups are hostile for vestibular / reduced-motion users.

---

## How Has This Been Tested?

- [ ] Tested backend API endpoints manually
- [ ] Ran frontend locally with `npm run dev`
- [ ] Ran `npm run lint` — no errors
- [ ] Ran `npm run build` — no errors
- [ ] Uploaded a test document and verified output
- [ ] Tested on mobile view

pre-commit `npm test`

---

## Screenshots (if applicable)

N/A

---

## Self-Review Checklist

- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #IssueNumber`)
- [x] I have tested my changes locally
- [ ] I have added screenshots for UI changes
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue

---

## Additional Notes

None.

Made with [Cursor](https://cursor.com)