### PR TITLE
fix(cart): repair empty-cart.js safeParseJSON brace nesting

### DIFF
--- a/empty-cart.js
+++ b/empty-cart.js
@@ -3,12 +3,10 @@ function safeParseJSON(key, fallback = '[]') {
     return JSON.parse(localStorage.getItem(key) || fallback);
   } catch (err) {
     console.warn('Failed to parse stored data:', err);
-  }
     try {
       return JSON.parse(fallback);
-    } catch (err) {
-    console.warn('Failed to parse stored data:', err);
-  }
+    } catch (fallbackErr) {
+      console.warn('Failed to parse fallback data:', fallbackErr);
       return [];
     }
   }
@@ -41,3 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
     handleEmptyCartView();
   }
 });
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { safeParseJSON };
+}

--- a/tests/unit/empty-cart.test.js
+++ b/tests/unit/empty-cart.test.js
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { safeParseJSON } = require('../../empty-cart.js');
+
+describe('empty-cart safeParseJSON', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('parses valid cart JSON from localStorage', () => {
+    localStorage.setItem('productsInCart', JSON.stringify([{ id: 1 }]));
+    expect(safeParseJSON('productsInCart')).toEqual([{ id: 1 }]);
+  });
+
+  it('falls back when localStorage value is corrupt', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    localStorage.setItem('productsInCart', '{not-json');
+    expect(safeParseJSON('productsInCart')).toEqual([]);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('returns empty array when both stored value and fallback are corrupt', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    localStorage.setItem('productsInCart', '{not-json');
+    expect(safeParseJSON('productsInCart', '{also-bad')).toEqual([]);
+  });
+});


### PR DESCRIPTION
# Summary
`empty-cart.js` had broken brace nesting around `safeParseJSON`, so Node rejected the file and the empty-cart UI never ran.

---

## Related Issue
Closes #4918

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

---

## What Was Changed

- Fixed `safeParseJSON` nesting so corrupt `localStorage` values fall back cleanly
- Added `tests/unit/empty-cart.test.js`

---

## why this needed
A syntax error meant empty-cart behavior could not load at all.

---

## How Has This Been Tested?

- [ ] Tested backend API endpoints manually
- [ ] Ran frontend locally with `npm run dev`
- [ ] Ran `npm run lint` — no errors
- [ ] Ran `npm run build` — no errors
- [ ] Uploaded a test document and verified output
- [ ] Tested on mobile view

`node --check empty-cart.js`
`npm test -- tests/unit/empty-cart.test.js`
pre-commit `npm test`

---

## Screenshots (if applicable)

N/A

---

## Self-Review Checklist

- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #IssueNumber`)
- [x] I have tested my changes locally
- [ ] I have added screenshots for UI changes
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue

---

## Additional Notes

N/A

Made with [Cursor](https://cursor.com)