### PR TITLE
fix(a11y): add skip links and main landmarks on shop/cart/checkout

### DIFF
--- a/assets/js/skip-link.js
+++ b/assets/js/skip-link.js
@@ -13,8 +13,22 @@ document.addEventListener('DOMContentLoaded', () => {
   skipLink.addEventListener('blur', () => {
     skipLink.style.top = '-100px';
   });
+  skipLink.addEventListener('click', (event) => {
+    const target = document.getElementById('main-content');
+    if (!target) return;
+    event.preventDefault();
+    if (!target.hasAttribute('tabindex')) {
+      target.setAttribute('tabindex', '-1');
+    }
+    target.focus({ preventScroll: false });
+    if (typeof target.scrollIntoView === 'function') {
+      try {
+        target.scrollIntoView({ block: 'start' });
+      } catch {
+        /* jsdom and some older browsers may not support scrollIntoView options */
+      }
+    }
+  });
 
   document.body.insertBefore(skipLink, document.body.firstChild);
 });
-
-// Focus listener positioning bypass button visible upon keyboard tab event.

--- a/cart.html
+++ b/cart.html
@@ -65,6 +65,7 @@
     }
   </script>
     <script type="module" src="js/config.js"></script>
+  <script src="assets/js/skip-link.js" defer></script>
 </head>
 
 <body>
@@ -140,6 +141,7 @@
     </div>
   </section>
 
+  <main id="main-content" tabindex="-1">
   <div id="cart-content-wrapper">
     <div class="cartmain">
 
@@ -239,6 +241,7 @@
 
     </div>
   </div>
+  </main>
 
   <script src="js/shipping-calc.js" defer></script>
   <script src="js/loyalty.js" defer></script>

--- a/checkout.html
+++ b/checkout.html
@@ -33,6 +33,7 @@
   </script>
   <meta name="description" content="Cara - The best ecommerce store for modern fashion and clothing.">
     <script type="module" src="js/config.js"></script>
+  <script src="assets/js/skip-link.js" defer></script>
 </head>
 <body>
 
@@ -53,7 +54,7 @@
 
 
   <!-- PAGE -->
-  <div class="page-wrapper">
+  <main id="main-content" class="page-wrapper" tabindex="-1">
 
     <!-- Back button -->
     <button class="back-btn" onclick="window.location.href='cart.html'">
@@ -270,7 +271,7 @@
       </div>
 
     </form>
-  </div><!-- /page-wrapper -->
+  </main><!-- /page-wrapper -->
 
   <!-- SUCCESS POPUP -->
   <div class="success-overlay" id="successPopup">

--- a/shop.html
+++ b/shop.html
@@ -79,6 +79,7 @@
       }
     </script>
       <script type="module" src="js/config.js"></script>
+      <script src="assets/js/skip-link.js" defer></script>
 </head>
 
   <body>
@@ -158,6 +159,7 @@
       </div>
     </section>
 
+    <main id="main-content" tabindex="-1">
     <!-- Resolves #1356: Added descriptive alt tags to product images across all catalog views -->
     <section id="shop-hero">
       <div class="hero-copy">
@@ -375,6 +377,7 @@
         </button>
       </form>
     </section>
+    </main>
 
     <button id="backToTop" title="Back to Top" aria-label="Back to top">
       ⬆

--- a/tests/unit/skip-link.test.js
+++ b/tests/unit/skip-link.test.js
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('skip-link', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    document.body.innerHTML = '<main id="main-content" tabindex="-1">Shop</main>';
+  });
+
+  it('injects a skip link targeting #main-content', async () => {
+    await import('../../assets/js/skip-link.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const link = document.querySelector('a.skip-to-content-btn');
+    expect(link).toBeTruthy();
+    expect(link.getAttribute('href')).toBe('#main-content');
+    expect(link.textContent).toMatch(/skip to main content/i);
+  });
+
+  it('moves focus to main content when activated', async () => {
+    await import('../../assets/js/skip-link.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const link = document.querySelector('a.skip-to-content-btn');
+    const main = document.getElementById('main-content');
+    const focus = vi.spyOn(main, 'focus').mockImplementation(() => {});
+    link.click();
+    expect(focus).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# Summary
Shop, cart, and checkout lacked skip links and a `#main-content` landmark. They now include `assets/js/skip-link.js` and a main landmark.

---

## Related Issue
Closes #4933

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

---

## What Was Changed

- Included `assets/js/skip-link.js` on shop/cart/checkout
- Wrapped primary content in `<main id="main-content">`
- Focus target on skip-link activation
- Added `tests/unit/skip-link.test.js`

---

## why this needed
Keyboard and screen-reader users could not skip nav chrome on core commerce pages.

---

## How Has This Been Tested?

- [ ] Tested backend API endpoints manually
- [ ] Ran frontend locally with `npm run dev`
- [ ] Ran `npm run lint` — no errors
- [ ] Ran `npm run build` — no errors
- [ ] Uploaded a test document and verified output
- [ ] Tested on mobile view

`npm test -- tests/unit/skip-link.test.js`
pre-commit `npm test`

---

## Screenshots (if applicable)

N/A

---

## Self-Review Checklist

- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #IssueNumber`)
- [x] I have tested my changes locally
- [ ] I have added screenshots for UI changes
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue

---

## Additional Notes

Cart keeps `#cart-content-wrapper` for existing CSS.

Made with [Cursor](https://cursor.com)