### PR TITLE
fix(orders): scope idempotency keys per buyer and catch races

### DIFF
--- a/backend/alembic/versions/d8e4f1a2b3c4_scope_order_idempotency_per_email.py
+++ b/backend/alembic/versions/d8e4f1a2b3c4_scope_order_idempotency_per_email.py
@@ -1,0 +1,33 @@
+"""scope order idempotency keys per buyer email
+
+Revision ID: d8e4f1a2b3c4
+Revises: c1d7b9ce1707
+Create Date: 2026-08-06 19:10:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d8e4f1a2b3c4"
+down_revision: Union[str, Sequence[str], None] = "c1d7b9ce1707"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_index("ix_orders_idempotency_key", table_name="orders")
+    op.create_index("ix_orders_idempotency_key", "orders", ["idempotency_key"], unique=False)
+    op.create_unique_constraint(
+        "uq_orders_email_idempotency_key",
+        "orders",
+        ["email", "idempotency_key"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_orders_email_idempotency_key", "orders", type_="unique")
+    op.drop_index("ix_orders_idempotency_key", table_name="orders")
+    op.create_index("ix_orders_idempotency_key", "orders", ["idempotency_key"], unique=True)

--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -1,11 +1,33 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
 from .. import models, schemas
 from ..database import get_db
 from .auth import get_current_user
 from datetime import datetime, timezone, timedelta
 
 router = APIRouter()
+
+
+def _existing_order_for_key(db: Session, email: str, idempotency_key: str | None):
+    if not idempotency_key:
+        return None
+    return (
+        db.query(models.Order)
+        .filter(
+            models.Order.email == email,
+            models.Order.idempotency_key == idempotency_key,
+        )
+        .first()
+    )
+
+
+def _idempotent_replay(order_id: int) -> JSONResponse:
+    return JSONResponse(
+        status_code=200,
+        content={"message": "Order already created", "order_id": order_id},
+    )
 
 
 def serialize_order(order: models.Order, db: Session, include_items: bool = True) -> dict:
@@ -67,20 +89,9 @@ def create_order(
     current_user: models.User = Depends(get_current_user)
 ):
     # --- Idempotency check: if this key was already used, return the existing order ---
-    if order_data.idempotency_key:
-        existing = (
-            db.query(models.Order)
-            .filter(
-                models.Order.email == current_user.email,
-                models.Order.idempotency_key == order_data.idempotency_key,
-            )
-            .first()
-        )
-        if existing:
-            return {
-                "message": "Order already created",
-                "order_id": existing.id
-            }
+    existing = _existing_order_for_key(db, current_user.email, order_data.idempotency_key)
+    if existing:
+        return _idempotent_replay(existing.id)
 
     subtotal = 0.0
     db_items = []
@@ -177,15 +188,26 @@ def create_order(
     )
 
     db.add(new_order)
-    # Use flush instead of commit to get new_order.id without finalizing the transaction prematurely
-    db.flush()
+    try:
+        # Use flush instead of commit to get new_order.id without finalizing prematurely
+        db.flush()
 
-    for db_item in db_items:
-        db_item.order_id = new_order.id
-        db.add(db_item)
+        for db_item in db_items:
+            db_item.order_id = new_order.id
+            db.add(db_item)
 
-    # Commit everything atomically in a single transaction
-    db.commit()
+        # Commit everything atomically in a single transaction
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raced = _existing_order_for_key(db, current_user.email, order_data.idempotency_key)
+        if raced:
+            return _idempotent_replay(raced.id)
+        raise HTTPException(
+            status_code=500,
+            detail="Could not create order due to a conflict. Please retry.",
+        )
+
     db.refresh(new_order)
 
     return {

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Float, ForeignKey, JSON, Boolean, DateTime
+from sqlalchemy import Column, Integer, String, Float, ForeignKey, JSON, Boolean, DateTime, UniqueConstraint
 from sqlalchemy.orm import relationship
 from .database import Base
 from datetime import datetime, timezone
@@ -75,6 +75,13 @@ class User(Base):
 
 class Order(Base):
     __tablename__ = "orders"
+    __table_args__ = (
+        UniqueConstraint(
+            "email",
+            "idempotency_key",
+            name="uq_orders_email_idempotency_key",
+        ),
+    )
     id = Column(Integer, primary_key=True, index=True)
     full_name = Column(String, nullable=False)
     email = Column(String, nullable=False)
@@ -84,7 +91,8 @@ class Order(Base):
     total_amount = Column(Float, nullable=False)
     status = Column(String, default="PENDING")
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
-    idempotency_key = Column(String, unique=True, index=True, nullable=True)
+    # Uniqueness is scoped per buyer email via uq_orders_email_idempotency_key
+    idempotency_key = Column(String, index=True, nullable=True)
 
 class PasswordResetToken(Base):
     __tablename__ = "password_reset_tokens"

--- a/backend/tests/test_order_idempotency.py
+++ b/backend/tests/test_order_idempotency.py
@@ -1,0 +1,157 @@
+"""Order idempotency: per-buyer uniqueness and IntegrityError replay."""
+from passlib.context import CryptContext
+
+from app.models import Product, User, Order
+from tests.conftest import TestingSessionLocal
+
+pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def _login_headers(client, email, password, username):
+    db = TestingSessionLocal()
+    user = db.query(User).filter(User.email == email).first()
+    if user is None:
+        user = User(
+            username=username,
+            email=email,
+            hashed_password=pwd.hash(password),
+        )
+        db.add(user)
+        db.commit()
+    db.close()
+
+    response = client.post("/api/auth/login", json={"email": email, "password": password})
+    assert response.status_code == 200, response.text
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+def _seed_product(name="Idempotency Tee", stock=20):
+    db = TestingSessionLocal()
+    product = db.query(Product).filter(Product.name == name).first()
+    if product is None:
+        product = Product(
+            brand="Cara",
+            name=name,
+            price=100.0,
+            img="tee.jpg",
+            rating=4,
+            category="street",
+            stock=stock,
+        )
+        db.add(product)
+        db.commit()
+        db.refresh(product)
+    product_id = product.id
+    db.close()
+    return product_id
+
+
+def _order_payload(key, product_name="Idempotency Tee", email="idem1@example.com"):
+    return {
+        "fullName": "Buyer One",
+        "email": email,
+        "address": "1 Test St",
+        "city": "Testville",
+        "zip": "10001",
+        "items": [{"product_name": product_name, "quantity": 1}],
+        "idempotency_key": key,
+    }
+
+
+def test_duplicate_idempotency_key_returns_existing(client):
+    _seed_product()
+    headers = _login_headers(client, "idem1@example.com", "Secure123@", "idem1")
+    payload = _order_payload("key-same-user-1")
+
+    first = client.post("/api/orders/", json=payload, headers=headers)
+    assert first.status_code == 201
+    order_id = first.json()["order_id"]
+
+    second = client.post("/api/orders/", json=payload, headers=headers)
+    assert second.status_code == 200
+    assert second.json()["message"] == "Order already created"
+    assert second.json()["order_id"] == order_id
+
+
+def test_same_key_allowed_for_different_buyers(client):
+    _seed_product(name="Shared Key Tee")
+    headers_a = _login_headers(client, "idem-a@example.com", "Secure123@", "idema")
+    headers_b = _login_headers(client, "idem-b@example.com", "Secure123@", "idemb")
+
+    first = client.post(
+        "/api/orders/",
+        json=_order_payload(
+            "shared-key-across-users",
+            product_name="Shared Key Tee",
+            email="idem-a@example.com",
+        ),
+        headers=headers_a,
+    )
+    second = client.post(
+        "/api/orders/",
+        json={
+            **_order_payload(
+                "shared-key-across-users",
+                product_name="Shared Key Tee",
+                email="idem-b@example.com",
+            ),
+            "fullName": "Buyer Two",
+        },
+        headers=headers_b,
+    )
+
+    assert first.status_code == 201
+    assert second.status_code == 201
+    assert first.json()["order_id"] != second.json()["order_id"]
+
+
+def test_integrity_error_race_returns_existing_order(client, monkeypatch):
+    _seed_product(name="Race Tee")
+    headers = _login_headers(client, "idem-race@example.com", "Secure123@", "idemrace")
+    key = "race-key-1"
+
+    # Seed a winning order row that a racing request would collide with.
+    db = TestingSessionLocal()
+    db.add(
+        Order(
+            full_name="Winner",
+            email="idem-race@example.com",
+            address="1 Test St",
+            city="Testville",
+            zip_code="10001",
+            total_amount=10.0,
+            status="CONFIRMED",
+            idempotency_key=key,
+        )
+    )
+    db.commit()
+    existing_id = (
+        db.query(Order)
+        .filter(Order.email == "idem-race@example.com", Order.idempotency_key == key)
+        .one()
+        .id
+    )
+    db.close()
+
+    # Force only the pre-check to miss; IntegrityError handler must still look up.
+    from app.api import orders as orders_api
+
+    real_lookup = orders_api._existing_order_for_key
+    calls = {"n": 0}
+
+    def flaky_lookup(db, email, idempotency_key):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return None
+        return real_lookup(db, email, idempotency_key)
+
+    monkeypatch.setattr(orders_api, "_existing_order_for_key", flaky_lookup)
+
+    response = client.post(
+        "/api/orders/",
+        json=_order_payload(key, product_name="Race Tee", email="idem-race@example.com"),
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["order_id"] == existing_id
+    assert response.json()["message"] == "Order already created"


### PR DESCRIPTION
# Summary
Order idempotency is now unique per buyer email, and concurrent duplicates return the existing order instead of 500.

---

## Related Issue
Closes #4929

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

---

## What Was Changed

- Unique constraint `uq_orders_email_idempotency_key` on `(email, idempotency_key)`
- Alembic migration `d8e4f1a2b3c4`
- Catch `IntegrityError` and replay the existing order with HTTP 200
- Tests in `backend/tests/test_order_idempotency.py`

---

## why this needed
Check-then-insert races could 500, and a global unique key blocked unrelated buyers from reusing the same client key.

---

## How Has This Been Tested?

- [x] Tested backend API endpoints manually
- [ ] Ran frontend locally with `npm run dev`
- [ ] Ran `npm run lint` — no errors
- [ ] Ran `npm run build` — no errors
- [ ] Uploaded a test document and verified output
- [ ] Tested on mobile view

`pytest tests/test_order_idempotency.py` — 3 passed
pre-commit `npm test`

---

## Screenshots (if applicable)

N/A

---

## Self-Review Checklist

- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #IssueNumber`)
- [x] I have tested my changes locally
- [ ] I have added screenshots for UI changes
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue

---

## Additional Notes

Orders are keyed by buyer email today (no `user_id` on `Order`), so uniqueness is `(email, idempotency_key)`.

Made with [Cursor](https://cursor.com)