### PR TITLE
fix(pwa): network-first for API and HTML; stop caching API GETs

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'cara-cache-v1';
+const CACHE_NAME = 'cara-cache-v2';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',
@@ -20,10 +20,69 @@ const ASSETS_TO_CACHE = [
   '/images/Dlogo.png',
 ];
 
+const STATIC_EXTENSIONS = [
+  '.css',
+  '.js',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.webp',
+  '.gif',
+  '.svg',
+  '.ico',
+  '.woff',
+  '.woff2',
+];
+
+function isApiRequest(url) {
+  return url.pathname.startsWith('/api/');
+}
+
+function isNavigationRequest(request) {
+  if (request.mode === 'navigate') return true;
+  const accept = request.headers.get('accept') || '';
+  return accept.includes('text/html');
+}
+
+function isStaticAsset(url) {
+  return STATIC_EXTENSIONS.some((ext) => url.pathname.endsWith(ext));
+}
+
+function shouldBypassCache(request, url) {
+  // Never cache API JSON / credentialed backends or HTML navigations.
+  return isApiRequest(url) || isNavigationRequest(request);
+}
+
+function networkFirst(request) {
+  return fetch(request)
+    .then((networkResponse) => networkResponse)
+    .catch(() =>
+      caches.match(request).then((cached) => cached || caches.match('/offline.html')),
+    );
+}
+
+function cacheFirstStatic(request) {
+  return caches.match(request).then((cachedResponse) => {
+    if (cachedResponse) return cachedResponse;
+    return fetch(request).then((networkResponse) => {
+      if (
+        networkResponse &&
+        networkResponse.ok &&
+        networkResponse.type === 'basic'
+      ) {
+        const copy = networkResponse.clone();
+        caches.open(CACHE_NAME).then((cache) => cache.put(request, copy));
+      }
+      return networkResponse;
+    });
+  });
+}
+
 self.addEventListener('install', (event) => {
   event.waitUntil(
     caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS_TO_CACHE)),
   );
+  self.skipWaiting();
 });
 
 self.addEventListener('activate', (event) => {
@@ -34,7 +93,8 @@ self.addEventListener('activate', (event) => {
         Promise.all(
           keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)),
         ),
-      ),
+      )
+      .then(() => self.clients.claim()),
   );
 });
 
@@ -46,22 +106,25 @@ self.addEventListener('fetch', (event) => {
         try {
           const formData = await event.request.formData();
           const image = formData.get('image');
-          
+
           if (image) {
             const cache = await caches.open('shared-image-cache');
-            await cache.put('/shared-image', new Response(image, {
-              headers: {
-                'Content-Type': image.type,
-                'Content-Length': image.size.toString()
-              }
-            }));
+            await cache.put(
+              '/shared-image',
+              new Response(image, {
+                headers: {
+                  'Content-Type': image.type,
+                  'Content-Length': image.size.toString(),
+                },
+              }),
+            );
           }
           return Response.redirect('/visual-search.html', 303);
         } catch (error) {
           console.error('Error processing shared image:', error);
           return Response.redirect('/visual-search.html?error=1', 303);
         }
-      })()
+      })(),
     );
     return;
   }
@@ -71,19 +134,39 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  event.respondWith(
-    caches.match(event.request).then((cachedResponse) => {
-      return (
-        cachedResponse ||
-        fetch(event.request)
-          .then((networkResponse) => {
-            return caches.open(CACHE_NAME).then((cache) => {
-              cache.put(event.request, networkResponse.clone());
-              return networkResponse;
-            });
-          })
-          .catch(() => caches.match('/offline.html'))
-      );
-    }),
-  );
+  let url;
+  try {
+    url = new URL(event.request.url);
+  } catch {
+    return;
+  }
+
+  // Cross-origin: do not intercept (avoid caching opaque/third-party responses).
+  if (url.origin !== self.location.origin) {
+    return;
+  }
+
+  if (shouldBypassCache(event.request, url)) {
+    event.respondWith(networkFirst(event.request));
+    return;
+  }
+
+  if (isStaticAsset(url)) {
+    event.respondWith(cacheFirstStatic(event.request));
+    return;
+  }
+
+  // Default: network-first for anything else on-origin.
+  event.respondWith(networkFirst(event.request));
 });
+
+// Exported for unit tests (ignored in the service worker runtime).
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    isApiRequest,
+    isNavigationRequest,
+    isStaticAsset,
+    shouldBypassCache,
+    CACHE_NAME,
+  };
+}

--- a/tests/unit/service-worker.test.js
+++ b/tests/unit/service-worker.test.js
@@ -1,0 +1,54 @@
+import { createRequire } from 'node:module';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+beforeAll(() => {
+  globalThis.self = globalThis;
+  globalThis.self.addEventListener = vi.fn();
+  globalThis.self.skipWaiting = vi.fn();
+  globalThis.self.clients = { claim: vi.fn() };
+  globalThis.self.location = { origin: 'https://cara.example' };
+});
+
+const require = createRequire(import.meta.url);
+const {
+  isApiRequest,
+  isNavigationRequest,
+  isStaticAsset,
+  shouldBypassCache,
+  CACHE_NAME,
+} = require('../../service-worker.js');
+
+describe('service-worker cache strategy', () => {
+  it('bumps cache version past v1', () => {
+    expect(CACHE_NAME).not.toBe('cara-cache-v1');
+  });
+
+  it('treats /api paths as network-only', () => {
+    const url = new URL('https://cara.example/api/products/');
+    expect(isApiRequest(url)).toBe(true);
+    expect(
+      shouldBypassCache({ mode: 'cors', headers: new Headers() }, url),
+    ).toBe(true);
+  });
+
+  it('treats navigations as network-first', () => {
+    const url = new URL('https://cara.example/shop.html');
+    expect(
+      isNavigationRequest({
+        mode: 'navigate',
+        headers: new Headers({ accept: 'text/html' }),
+      }),
+    ).toBe(true);
+    expect(
+      shouldBypassCache(
+        { mode: 'navigate', headers: new Headers({ accept: 'text/html' }) },
+        url,
+      ),
+    ).toBe(true);
+  });
+
+  it('allows cache-first for static assets only', () => {
+    expect(isStaticAsset(new URL('https://cara.example/style.css'))).toBe(true);
+    expect(isStaticAsset(new URL('https://cara.example/api/orders'))).toBe(false);
+  });
+});


### PR DESCRIPTION
# Summary
The service worker no longer cache-firsts every GET. API and HTML use network-first; only same-origin static assets are cache-first.

---

## Related Issue
Closes #4926

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

---

## What Was Changed

- Bumped `CACHE_NAME` to `cara-cache-v2`
- Network-first for `/api/*` and navigations
- Cache-first only for static extensions on the same origin
- Added `tests/unit/service-worker.test.js`

---

## why this needed
Cache-first on API/HTML served stale catalog/auth data and made deploys sticky.

---

## How Has This Been Tested?

- [ ] Tested backend API endpoints manually
- [ ] Ran frontend locally with `npm run dev`
- [ ] Ran `npm run lint` — no errors
- [ ] Ran `npm run build` — no errors
- [ ] Uploaded a test document and verified output
- [ ] Tested on mobile view

`npm test -- tests/unit/service-worker.test.js`
pre-commit `npm test`

---

## Screenshots (if applicable)

N/A

---

## Self-Review Checklist

- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #IssueNumber`)
- [x] I have tested my changes locally
- [ ] I have added screenshots for UI changes
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue

---

## Additional Notes

N/A

Made with [Cursor](https://cursor.com)