### PR TITLE
fix(auth): rotate refresh tokens and clear logout cookies correctly

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -17,6 +17,7 @@ import random
 import secrets
 import hashlib
 from collections import OrderedDict
+import hmac
 
 # In-memory tracking of failed attempts with an LRU bound to prevent OOM DOS attacks
 failed_login_attempts = OrderedDict()
@@ -31,10 +32,19 @@ if not SECRET_KEY:
 ALGORITHM  = "HS256"
 ACCESS_TOKEN_MINUTES = 15
 REFRESH_TOKEN_DAYS = 7
+COOKIE_SAMESITE = "lax"
+COOKIE_PATH = "/"
+
+# email -> currently valid refresh token jti (rotation / revoke store)
+active_refresh_jtis: dict[str, str] = {}
 
 pwd    = CryptContext(schemes=["bcrypt"], deprecated="auto")
 router = APIRouter()
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/login", auto_error=False)
+
+
+def cookie_secure() -> bool:
+    return os.environ.get("COOKIE_SECURE", "true").lower() in ("1", "true", "yes")
 
 
 # -- Helper: build JWT --
@@ -50,33 +60,60 @@ def create_access_token(email: str) -> str:
     )
 
 def create_refresh_token(email: str) -> str:
-    return jwt.encode(
+    jti = secrets.token_urlsafe(32)
+    token = jwt.encode(
         {
             "sub": email,
             "type": "refresh",
-            "exp": datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_DAYS)
+            "jti": jti,
+            "exp": datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_DAYS),
         },
         SECRET_KEY,
-        algorithm=ALGORITHM
+        algorithm=ALGORITHM,
     )
+    active_refresh_jtis[email] = jti
+    return token
 
 def set_auth_cookies(response: Response, access_token: str, refresh_token: str):
+    secure = cookie_secure()
     response.set_cookie(
         key="access_token",
         value=f"Bearer {access_token}",
         httponly=True,
-        secure=True,
-        samesite="lax",
-        max_age=ACCESS_TOKEN_MINUTES * 60
+        secure=secure,
+        samesite=COOKIE_SAMESITE,
+        path=COOKIE_PATH,
+        max_age=ACCESS_TOKEN_MINUTES * 60,
     )
     response.set_cookie(
         key="refresh_token",
         value=refresh_token,
         httponly=True,
-        secure=True,
-        samesite="lax",
-        max_age=REFRESH_TOKEN_DAYS * 24 * 60 * 60
+        secure=secure,
+        samesite=COOKIE_SAMESITE,
+        path=COOKIE_PATH,
+        max_age=REFRESH_TOKEN_DAYS * 24 * 60 * 60,
     )
+
+def clear_auth_cookies(response: Response):
+    # Flags must match set_cookie or browsers may keep the session cookies.
+    secure = cookie_secure()
+    for key in ("access_token", "refresh_token"):
+        response.delete_cookie(
+            key,
+            path=COOKIE_PATH,
+            secure=secure,
+            samesite=COOKIE_SAMESITE,
+        )
+
+def revoke_refresh_token(email: str | None):
+    if email:
+        active_refresh_jtis.pop(email, None)
+
+def assert_refresh_jti(email: str, jti: str | None):
+    expected = active_refresh_jtis.get(email)
+    if not jti or not expected or not hmac.compare_digest(expected, jti):
+        raise HTTPException(401, "Invalid or revoked refresh token.")
 
 # -- Helper: get current user from token --
 def get_current_user(
@@ -217,7 +254,7 @@ def login(request: Request, response: Response, payload: UserLogin, db: Session 
     )
 
 @router.post("/refresh")
-def refresh_token(request: Request, response: Response, db: Session = Depends(get_db)):
+def refresh_access_token(request: Request, response: Response, db: Session = Depends(get_db)):
     token = request.cookies.get("refresh_token")
     if not token:
         raise HTTPException(status_code=401, detail="Refresh token missing")
@@ -228,24 +265,19 @@ def refresh_token(request: Request, response: Response, db: Session = Depends(ge
         email: str = payload.get("sub")
         if not email:
             raise HTTPException(401, "Invalid token.")
+        assert_refresh_jti(email, payload.get("jti"))
     except JWTError:
         raise HTTPException(401, "Invalid or expired refresh token.")
-        
+
     user = db.query(models.User).filter(models.User.email == email).first()
     if not user or not user.is_active:
         raise HTTPException(401, "User not found or inactive.")
-        
+
     access_token = create_access_token(user.email)
-    # Issue a new access token while keeping the same refresh token
-    response.set_cookie(
-        key="access_token",
-        value=f"Bearer {access_token}",
-        httponly=True,
-        secure=True,
-        samesite="lax",
-        max_age=ACCESS_TOKEN_MINUTES * 60
-    )
+    new_refresh_token = create_refresh_token(user.email)
+    set_auth_cookies(response, access_token, new_refresh_token)
     return {"message": "Token refreshed successfully"}
+
 
 @router.post("/forgot-password")
 @limiter.limit("5/minute")
@@ -303,9 +335,16 @@ def reset_password(
 
 
 @router.post("/logout")
-def logout(response: Response):
-    response.delete_cookie("access_token")
-    response.delete_cookie("refresh_token")
+def logout(request: Request, response: Response):
+    token = request.cookies.get("refresh_token")
+    if token:
+        try:
+            payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+            if payload.get("type") == "refresh":
+                revoke_refresh_token(payload.get("sub"))
+        except JWTError:
+            pass
+    clear_auth_cookies(response)
     return {"message": "Successfully logged out"}
 
 @router.get("/me", response_model=UserOut)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,3 +1,8 @@
+import os
+
+# TestClient speaks HTTP; Secure cookies would not round-trip otherwise.
+os.environ.setdefault("COOKIE_SECURE", "false")
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine

--- a/backend/tests/test_refresh_logout.py
+++ b/backend/tests/test_refresh_logout.py
@@ -1,0 +1,66 @@
+"""Refresh token rotation and logout cookie clearing."""
+from jose import jwt
+
+from app.api.auth import (
+    ALGORITHM,
+    SECRET_KEY,
+    active_refresh_jtis,
+    create_refresh_token,
+)
+
+
+def _register_and_login(client, email="rotate@example.com", username="rotateuser"):
+    password = "Secure123@"
+    client.post(
+        "/api/auth/register",
+        json={"username": username, "email": email, "password": password},
+    )
+    login = client.post("/api/auth/login", json={"email": email, "password": password})
+    assert login.status_code == 200
+    return login
+
+
+def test_refresh_rotates_refresh_token(client):
+    login = _register_and_login(client)
+    old_refresh = login.cookies.get("refresh_token")
+    assert old_refresh
+    old_jti = jwt.decode(old_refresh, SECRET_KEY, algorithms=[ALGORITHM])["jti"]
+
+    refresh = client.post("/api/auth/refresh")
+    assert refresh.status_code == 200
+    new_refresh = refresh.cookies.get("refresh_token")
+    assert new_refresh
+    assert new_refresh != old_refresh
+    new_jti = jwt.decode(new_refresh, SECRET_KEY, algorithms=[ALGORITHM])["jti"]
+    assert new_jti != old_jti
+    assert active_refresh_jtis["rotate@example.com"] == new_jti
+
+    # Old refresh token must no longer work after rotation.
+    client.cookies.set("refresh_token", old_refresh)
+    reuse = client.post("/api/auth/refresh")
+    assert reuse.status_code == 401
+
+
+def test_logout_revokes_refresh_and_clears_cookies(client):
+    login = _register_and_login(
+        client, email="logout@example.com", username="logoutuser"
+    )
+    assert login.cookies.get("refresh_token")
+    assert "logout@example.com" in active_refresh_jtis
+
+    logout = client.post("/api/auth/logout")
+    assert logout.status_code == 200
+    assert "logout@example.com" not in active_refresh_jtis
+
+    # Set-cookie clearing attributes should be present on the response.
+    set_cookie_headers = logout.headers.get_list("set-cookie")
+    joined = " ".join(set_cookie_headers).lower()
+    assert "access_token=" in joined
+    assert "refresh_token=" in joined
+    assert "samesite=lax" in joined
+
+
+def test_create_refresh_token_registers_jti():
+    token = create_refresh_token("jti-check@example.com")
+    payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    assert payload["jti"] == active_refresh_jtis["jti-check@example.com"]


### PR DESCRIPTION
# Summary
Refresh rotates the refresh JWT (jti allowlist) instead of reusing it. Logout revokes the jti and deletes cookies with matching security attributes.

---

## Related Issue
Closes #4928

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

---

## What Was Changed

- Refresh tokens include `jti`; server tracks the active jti per email
- `/api/auth/refresh` rotates access + refresh cookies
- Reused refresh tokens after rotation return 401
- `/api/auth/logout` revokes jti and `delete_cookie` with matching flags
- `COOKIE_SECURE` env (default true; tests use false for TestClient HTTP)
- Tests in `backend/tests/test_refresh_logout.py`

---

## why this needed
Stolen refresh tokens stayed valid forever across refresh, and logout could leave cookies when delete flags did not match set-cookie.

---

## How Has This Been Tested?

- [x] Tested backend API endpoints manually
- [ ] Ran frontend locally with `npm run dev`
- [ ] Ran `npm run lint` — no errors
- [ ] Ran `npm run build` — no errors
- [ ] Uploaded a test document and verified output
- [ ] Tested on mobile view

`pytest tests/test_refresh_logout.py` — 3 passed
pre-commit `npm test`

---

## Screenshots (if applicable)

N/A

---

## Self-Review Checklist

- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #IssueNumber`)
- [x] I have tested my changes locally
- [ ] I have added screenshots for UI changes
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue

---

## Additional Notes

jti store is in-memory (same pattern as failed-login tracking). Multi-worker deploys should later move it to shared storage.

Made with [Cursor](https://cursor.com)