### PR TITLE
fix(products): register /search/* routes before /{product_id}

### DIFF
--- a/backend/app/api/products.py
+++ b/backend/app/api/products.py
@@ -21,22 +21,13 @@ def get_products(
     return db.query(models.Product).offset(skip).limit(limit).all()
 
 
-@router.get("/{product_id}", response_model=schemas.Product)
-def get_product(product_id: int, db: Session = Depends(get_db)):
-    product = db.query(models.Product).filter(models.Product.id == product_id).first()
-    if not product:
-        raise HTTPException(status_code=404, detail="Product not found")
-    return product
-
-
 # ---------------------------------------------------------------------------
-# New: Search & Filter endpoint
+# Search & Filter endpoints (literal paths must be registered before /{product_id})
 # ---------------------------------------------------------------------------
 
 class ProductSearchResponse:
     """Non-Pydantic helper — response is built as a plain dict for flexibility."""
     pass
-
 
 @router.get("/search/query", response_model=schemas.PaginatedProductsResponse)
 def search_products(
@@ -182,3 +173,16 @@ def get_category_summary(db: Session = Depends(get_db)) -> dict:
             "max": price_range[1] if price_range[1] is not None else 0,
         },
     }
+
+
+# ---------------------------------------------------------------------------
+# Product by ID (must stay after literal /search/* paths)
+# ---------------------------------------------------------------------------
+
+@router.get("/{product_id}", response_model=schemas.Product)
+def get_product(product_id: int, db: Session = Depends(get_db)):
+    product = db.query(models.Product).filter(models.Product.id == product_id).first()
+    if not product:
+        raise HTTPException(status_code=404, detail="Product not found")
+    return product
+

--- a/backend/tests/test_product_search.py
+++ b/backend/tests/test_product_search.py
@@ -16,6 +16,51 @@ from fastapi.testclient import TestClient
 
 
 class TestProductSearchQuery:
+    def test_search_query_not_shadowed_by_product_id_route(self, client: TestClient):
+        """Literal /search/query must not be captured by /{product_id} as product_id='search'."""
+        resp = client.get("/api/products/search/query?q=shirt")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "total" in body
+        assert "products" in body
+        assert "detail" not in body or not isinstance(body.get("detail"), list)
+
+    def test_search_categories_not_shadowed_by_product_id_route(self, client: TestClient):
+        """Literal /search/categories must resolve (not 422 int validation on 'search')."""
+        resp = client.get("/api/products/search/categories")
+        assert resp.status_code == 200
+        assert "categories" in resp.json()
+
+    def test_numeric_product_id_still_works(self, client: TestClient):
+        """Valid integer product IDs continue to hit get_product after route reorder."""
+        from app.models import Product
+        from tests.conftest import TestingSessionLocal
+
+        db = TestingSessionLocal()
+        p = Product(
+            brand="RouteTest",
+            name="Route Order Shirt",
+            price=19.99,
+            img="img.jpg",
+            rating=4,
+            category="minimal",
+            subcategory="top",
+            color="blue",
+            style="casual",
+        )
+        db.add(p)
+        db.commit()
+        db.refresh(p)
+        pid = p.id
+        db.close()
+
+        resp = client.get(f"/api/products/{pid}")
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Route Order Shirt"
+
+        resp_missing = client.get("/api/products/999999")
+        assert resp_missing.status_code == 404
+
     def test_search_no_params_returns_all(self, client: TestClient):
         """With no filters, endpoint returns a paginated response."""
         resp = client.get("/api/products/search/query")


### PR DESCRIPTION
## 📄 Description

GET /search/query and /search/categories were registered after /{product_id}, so FastAPI treated search as a product id and returned 422. Literal search paths are registered first now.

## 🔗 Related Issues

Closes #4916

## 🧩 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## 🛠️ What Was Changed

- Moved /search/query and /search/categories above /{product_id} in backend/app/api/products.py
- Added route-order regression tests in tests/test_product_search.py

## why this needed

Product search never ran — every /search/query request hit integer validation on product_id.

## 🧪 How Has This Been Tested?

pytest tests/test_product_search.py tests/test_products.py — 22 passed

## ✅ Checklist

- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #IssueNumber`)
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue