### PR TITLE
fix(orders): resolve order items by product_id instead of name

### DIFF
--- a/app.js
+++ b/app.js
@@ -752,13 +752,14 @@ function withCartLock(fn) {
   return cartLockPromise;
 }
 
-function addToCart(productName, productPrice, productImage, quantity, size) {
+function addToCart(productName, productPrice, productImage, quantity, size, productId) {
   return withCartLock(() => {
     let cart = JSON.parse(localStorage.getItem('productsInCart')) || [];
     let parsedQty = parseInt(quantity, 10);
     if (isNaN(parsedQty) || parsedQty < 1) parsedQty = 1;
 
     let item = {
+      id: productId != null && productId !== '' ? Number(productId) : undefined,
       name: productName,
       price: parsePriceString(productPrice),
       image: productImage,
@@ -772,10 +773,14 @@ function addToCart(productName, productPrice, productImage, quantity, size) {
     }
 
     let existingItem = cart.find(
-      (p) => p.name === item.name && p.size === item.size,
+      (p) =>
+        (item.id != null && p.id != null
+          ? p.id === item.id
+          : p.name === item.name) && p.size === item.size,
     );
     if (existingItem) {
       existingItem.quantity += item.quantity;
+      if (existingItem.id == null && item.id != null) existingItem.id = item.id;
     } else {
       cart.push(item);
     }
@@ -1163,8 +1168,9 @@ window.buyNow = function (
   productImage,
   quantity,
   size,
+  productId,
 ) {
-  addToCart(productName, productPrice, productImage, quantity, size);
+  addToCart(productName, productPrice, productImage, quantity, size, productId);
   setTimeout(function () {
     window.location.href = 'checkout.html';
   }, 1500);
@@ -2222,7 +2228,7 @@ document.addEventListener('DOMContentLoaded', () => {
     newAddToCart.addEventListener('click', () => {
       const size = document.getElementById('qvModalSize').value;
       const qty = parseInt(document.getElementById('qvQtyInput').value, 10);
-      addToCart(product.name, product.price, product.img, qty, size);
+      addToCart(product.name, product.price, product.img, qty, size, product.id);
       modal.classList.remove('active');
     });
 
@@ -2230,7 +2236,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const size = document.getElementById('qvModalSize').value;
       const qty = parseInt(document.getElementById('qvQtyInput').value, 10);
       modal.classList.remove('active');
-      window.buyNow(product.name, product.price, product.img, qty, size);
+      window.buyNow(product.name, product.price, product.img, qty, size, product.id);
     });
 
     modal.classList.add('active');

--- a/backend/alembic/versions/e9f0a1b2c3d4_add_product_id_to_order_items.py
+++ b/backend/alembic/versions/e9f0a1b2c3d4_add_product_id_to_order_items.py
@@ -1,0 +1,50 @@
+"""add product_id to order_items
+
+Revision ID: e9f0a1b2c3d4
+Revises: d8e4f1a2b3c4
+Create Date: 2026-08-06 22:10:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "e9f0a1b2c3d4"
+down_revision: Union[str, Sequence[str], None] = "d8e4f1a2b3c4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("order_items", sa.Column("product_id", sa.Integer(), nullable=True))
+    op.create_index(
+        op.f("ix_order_items_product_id"), "order_items", ["product_id"], unique=False
+    )
+    op.create_foreign_key(
+        "fk_order_items_product_id_products",
+        "order_items",
+        "products",
+        ["product_id"],
+        ["id"],
+    )
+    # Best-effort backfill from product name for existing rows.
+    op.execute(
+        """
+        UPDATE order_items
+        SET product_id = (
+            SELECT products.id FROM products
+            WHERE products.name = order_items.product_name
+            ORDER BY products.id
+            LIMIT 1
+        )
+        WHERE product_id IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_order_items_product_id_products", "order_items", type_="foreignkey")
+    op.drop_index(op.f("ix_order_items_product_id"), table_name="order_items")
+    op.drop_column("order_items", "product_id")

--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -53,6 +53,7 @@ def serialize_order(order: models.Order, db: Session, include_items: bool = True
         )
         payload["items"] = [
             {
+                "product_id": item.product_id,
                 "product_name": item.product_name,
                 "quantity": item.quantity,
                 "price": item.price,
@@ -117,31 +118,31 @@ def create_order(
     db_items = []
 
     # --- Fetch all products in a single query to prevent N+1 issue ---
-    product_names = [item.product_name for item in order_data.items]
-    
+    product_ids = [item.product_id for item in order_data.items]
+
     db_products = (
         db.query(models.Product)
-        .filter(models.Product.name.in_(product_names))
-        .with_for_update() # Apply row locks to all matching products simultaneously
+        .filter(models.Product.id.in_(product_ids))
+        .with_for_update()  # Apply row locks to all matching products simultaneously
         .all()
     )
-    
-    # Create a fast lookup map for the fetched products
-    product_map = {product.name: product for product in db_products}
+
+    # Stable lookup by primary key (names are not unique)
+    product_map = {product.id: product for product in db_products}
 
     for item in order_data.items:
-        db_product = product_map.get(item.product_name)
+        db_product = product_map.get(item.product_id)
 
         if not db_product:
             raise HTTPException(
                 status_code=400,
-                detail=f"Product not found: {item.product_name}"
+                detail=f"Product not found: id={item.product_id}",
             )
 
         if db_product.stock < item.quantity:
             raise HTTPException(
                 status_code=400,
-                detail=f"Insufficient stock for product: {item.product_name}"
+                detail=f"Insufficient stock for product: {db_product.name}",
             )
 
         # Deduct stock in memory (will be committed later)
@@ -152,9 +153,10 @@ def create_order(
 
         db_items.append(
             models.OrderItem(
-                product_name=item.product_name,
+                product_id=db_product.id,
+                product_name=db_product.name,
                 quantity=item.quantity,
-                price=real_price
+                price=real_price,
             )
         )
 
@@ -257,17 +259,17 @@ def cancel_order(
         .filter(models.OrderItem.order_id == order.id)
         .all()
     )
-    product_names = [item.product_name for item in items]
-    if product_names:
+    product_ids = [item.product_id for item in items if item.product_id is not None]
+    if product_ids:
         products = (
             db.query(models.Product)
-            .filter(models.Product.name.in_(product_names))
+            .filter(models.Product.id.in_(product_ids))
             .with_for_update()
             .all()
         )
-        product_map = {product.name: product for product in products}
+        product_map = {product.id: product for product in products}
         for item in items:
-            product = product_map.get(item.product_name)
+            product = product_map.get(item.product_id)
             if product is not None:
                 product.stock += item.quantity
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -114,7 +114,10 @@ class OrderItem(Base):
         ForeignKey("orders.id"),
         nullable=False
     )
+    product_id = Column(Integer, ForeignKey("products.id"), nullable=True, index=True)
+    # Denormalized snapshot kept for order history after renames/deletes.
     product_name = Column(String, nullable=False)
     quantity = Column(Integer, nullable=False)
     price = Column(Float, nullable=False)
     order = relationship("Order")
+    product = relationship("Product")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -126,6 +126,7 @@ class Token(BaseModel):
 
 
 class OrderItemResponse(BaseModel):
+    product_id: Optional[int] = None
     product_name: str
     quantity: int
     price: float
@@ -150,8 +151,8 @@ class OrderResponse(BaseModel):
         from_attributes = True
 
 class OrderItemCreate(BaseModel):
-    product_name: str
-    quantity: int = Field(gt=0)
+    product_id: int = Field(gt=0)
+    quantity: int = Field(gt=0, le=99)
 
 class OrderCreate(BaseModel):
     fullName: str

--- a/backend/tests/test_order_cancel.py
+++ b/backend/tests/test_order_cancel.py
@@ -54,7 +54,8 @@ def _seed_product(db, **kwargs) -> Product:
 def test_cancel_order_restores_stock(client):
     headers = _auth_headers(client)
     db = TestingSessionLocal()
-    _seed_product(db, name="Cancel Restock Shirt", stock=10)
+    product = _seed_product(db, name="Cancel Restock Shirt", stock=10)
+    product_id = product.id
     db.close()
 
     create = client.post(
@@ -66,14 +67,14 @@ def test_cancel_order_restores_stock(client):
             "address": "1 Test St",
             "city": "Testville",
             "zip": "12345",
-            "items": [{"product_name": "Cancel Restock Shirt", "quantity": 3}],
+            "items": [{"product_id": product_id, "quantity": 3}],
         },
     )
     assert create.status_code == 201, create.text
     order_id = create.json()["order_id"]
 
     db = TestingSessionLocal()
-    after_create = db.query(Product).filter(Product.name == "Cancel Restock Shirt").first()
+    after_create = db.query(Product).filter(Product.id == product_id).first()
     assert after_create.stock == 7
     db.close()
 
@@ -82,7 +83,7 @@ def test_cancel_order_restores_stock(client):
     assert cancel.json()["status"] == "CANCELLED"
 
     db = TestingSessionLocal()
-    after_cancel = db.query(Product).filter(Product.name == "Cancel Restock Shirt").first()
+    after_cancel = db.query(Product).filter(Product.id == product_id).first()
     assert after_cancel.stock == 10
     order = db.query(Order).filter(Order.id == order_id).first()
     assert order.status == "CANCELLED"
@@ -92,7 +93,8 @@ def test_cancel_order_restores_stock(client):
 def test_cancel_already_cancelled_does_not_double_restock(client):
     headers = _auth_headers(client)
     db = TestingSessionLocal()
-    _seed_product(db, name="Double Cancel Shirt", stock=5)
+    product = _seed_product(db, name="Double Cancel Shirt", stock=5)
+    product_id = product.id
     db.close()
 
     create = client.post(
@@ -104,7 +106,7 @@ def test_cancel_already_cancelled_does_not_double_restock(client):
             "address": "1 Test St",
             "city": "Testville",
             "zip": "12345",
-            "items": [{"product_name": "Double Cancel Shirt", "quantity": 2}],
+            "items": [{"product_id": product_id, "quantity": 2}],
         },
     )
     assert create.status_code == 201, create.text
@@ -117,6 +119,44 @@ def test_cancel_already_cancelled_does_not_double_restock(client):
     assert second.status_code == 400
 
     db = TestingSessionLocal()
-    product = db.query(Product).filter(Product.name == "Double Cancel Shirt").first()
+    product = db.query(Product).filter(Product.id == product_id).first()
     assert product.stock == 5
+    db.close()
+
+
+def test_order_uses_product_id_when_duplicate_names_exist(client):
+    """Duplicate product names must resolve by id, not the first matching name."""
+    headers = _auth_headers(client, username="dupuser", email="dup@example.com")
+    db = TestingSessionLocal()
+    cheap = _seed_product(db, name="Same Name Tee", price=10.0, stock=5)
+    expensive = _seed_product(db, name="Same Name Tee", price=999.0, stock=5)
+    cheap_id, expensive_id = cheap.id, expensive.id
+    db.close()
+
+    create = client.post(
+        ORDERS_URL,
+        headers=headers,
+        json={
+            "fullName": "Dup User",
+            "email": "dup@example.com",
+            "address": "1 Test St",
+            "city": "Testville",
+            "zip": "12345",
+            "items": [{"product_id": expensive_id, "quantity": 1}],
+        },
+    )
+    assert create.status_code == 201, create.text
+    order_id = create.json()["order_id"]
+
+    db = TestingSessionLocal()
+    cheap_after = db.query(Product).filter(Product.id == cheap_id).first()
+    expensive_after = db.query(Product).filter(Product.id == expensive_id).first()
+    assert cheap_after.stock == 5
+    assert expensive_after.stock == 4
+
+    from app.models import OrderItem
+
+    item = db.query(OrderItem).filter(OrderItem.order_id == order_id).one()
+    assert item.product_id == expensive_id
+    assert item.price == 999.0
     db.close()

--- a/backend/tests/test_order_detail.py
+++ b/backend/tests/test_order_detail.py
@@ -29,7 +29,7 @@ def _auth_headers(client, *, username="detailuser", email="detail@example.com"):
     return {"Authorization": f"Bearer {response.json()['access_token']}"}
 
 
-def _seed_order(*, email: str, product_name: str = "Detail Shirt") -> Order:
+def _seed_order(*, email: str, product_name: str = "Detail Shirt", product_id: int | None = None) -> Order:
     db = TestingSessionLocal()
     order = Order(
         full_name="Detail User",
@@ -45,6 +45,7 @@ def _seed_order(*, email: str, product_name: str = "Detail Shirt") -> Order:
     db.add(
         OrderItem(
             order_id=order.id,
+            product_id=product_id,
             product_name=product_name,
             quantity=2,
             price=60.0,
@@ -59,7 +60,7 @@ def _seed_order(*, email: str, product_name: str = "Detail Shirt") -> Order:
 
 def test_get_order_detail_returns_items_for_owner(client):
     headers = _auth_headers(client)
-    order_id = _seed_order(email="detail@example.com")
+    order_id = _seed_order(email="detail@example.com", product_id=42)
 
     response = client.get(f"{ORDERS_URL}{order_id}", headers=headers)
     assert response.status_code == 200, response.text
@@ -68,6 +69,7 @@ def test_get_order_detail_returns_items_for_owner(client):
     assert data["email"] == "detail@example.com"
     assert len(data["items"]) == 1
     assert data["items"][0]["product_name"] == "Detail Shirt"
+    assert data["items"][0]["product_id"] == 42
     assert data["items"][0]["quantity"] == 2
 
 

--- a/backend/tests/test_order_idempotency.py
+++ b/backend/tests/test_order_idempotency.py
@@ -46,22 +46,22 @@ def _seed_product(name="Idempotency Tee", stock=20):
     return product_id
 
 
-def _order_payload(key, product_name="Idempotency Tee", email="idem1@example.com"):
+def _order_payload(key, product_id, email="idem1@example.com"):
     return {
         "fullName": "Buyer One",
         "email": email,
         "address": "1 Test St",
         "city": "Testville",
         "zip": "10001",
-        "items": [{"product_name": product_name, "quantity": 1}],
+        "items": [{"product_id": product_id, "quantity": 1}],
         "idempotency_key": key,
     }
 
 
 def test_duplicate_idempotency_key_returns_existing(client):
-    _seed_product()
+    product_id = _seed_product()
     headers = _login_headers(client, "idem1@example.com", "Secure123@", "idem1")
-    payload = _order_payload("key-same-user-1")
+    payload = _order_payload("key-same-user-1", product_id)
 
     first = client.post("/api/orders/", json=payload, headers=headers)
     assert first.status_code == 201
@@ -74,7 +74,7 @@ def test_duplicate_idempotency_key_returns_existing(client):
 
 
 def test_same_key_allowed_for_different_buyers(client):
-    _seed_product(name="Shared Key Tee")
+    product_id = _seed_product(name="Shared Key Tee")
     headers_a = _login_headers(client, "idem-a@example.com", "Secure123@", "idema")
     headers_b = _login_headers(client, "idem-b@example.com", "Secure123@", "idemb")
 
@@ -82,7 +82,7 @@ def test_same_key_allowed_for_different_buyers(client):
         "/api/orders/",
         json=_order_payload(
             "shared-key-across-users",
-            product_name="Shared Key Tee",
+            product_id,
             email="idem-a@example.com",
         ),
         headers=headers_a,
@@ -92,7 +92,7 @@ def test_same_key_allowed_for_different_buyers(client):
         json={
             **_order_payload(
                 "shared-key-across-users",
-                product_name="Shared Key Tee",
+                product_id,
                 email="idem-b@example.com",
             ),
             "fullName": "Buyer Two",
@@ -106,7 +106,7 @@ def test_same_key_allowed_for_different_buyers(client):
 
 
 def test_integrity_error_race_returns_existing_order(client, monkeypatch):
-    _seed_product(name="Race Tee")
+    product_id = _seed_product(name="Race Tee")
     headers = _login_headers(client, "idem-race@example.com", "Secure123@", "idemrace")
     key = "race-key-1"
 
@@ -149,7 +149,7 @@ def test_integrity_error_race_returns_existing_order(client, monkeypatch):
 
     response = client.post(
         "/api/orders/",
-        json=_order_payload(key, product_name="Race Tee", email="idem-race@example.com"),
+        json=_order_payload(key, product_id, email="idem-race@example.com"),
         headers=headers,
     )
     assert response.status_code == 200

--- a/checkout.js
+++ b/checkout.js
@@ -60,6 +60,33 @@ function buildAuthHeaders(extraHeaders = {}) {
   return { ...extraHeaders };
 }
 
+async function resolveCartProductIds(cart) {
+  const res = await fetch(`${API_BASE_URL}/api/products/`, {
+    credentials: 'include',
+  });
+  if (!res.ok) {
+    throw new Error('Failed to load products for checkout');
+  }
+  const products = await res.json();
+  const byId = new Map(products.map((p) => [p.id, p]));
+  const byName = new Map();
+  for (const p of products) {
+    if (!byName.has(p.name)) byName.set(p.name, p.id);
+  }
+
+  return cart.map((item) => {
+    const candidate = Number(item.id);
+    if (item.id != null && item.id !== '' && !Number.isNaN(candidate) && byId.has(candidate)) {
+      return { ...item, id: candidate };
+    }
+    const resolved = byName.get(item.name);
+    if (resolved == null) {
+      throw new Error(`Product not found for cart item: ${item.name}`);
+    }
+    return { ...item, id: resolved };
+  });
+}
+
 const paymentMethod = document.getElementById('paymentMethod');
 const cardDetails = document.getElementById('cardDetails');
 
@@ -358,31 +385,34 @@ function submitCheckoutForm() {
     checkoutIdempotencyKey = crypto.randomUUID();
   }
 
-  // Prepare order data
-  const orderData = {
-    fullName: document.getElementById('fullName').value.trim(),
-    email: document.getElementById('email').value.trim(),
-    address: document.getElementById('address').value.trim(),
-    city: document.getElementById('city').value.trim(),
-    zip: document.getElementById('zip').value.trim(),
-    coupon: window.appliedCoupon,
-    idempotency_key: checkoutIdempotencyKey,
-    items: cart.map((item) => ({
-      product_name: item.name,
-      quantity: parseInt(item.quantity, 10) || 1,
-      price: item.price,
-    })),
-  };
+  resolveCartProductIds(cart)
+    .then((resolvedCart) => {
+      cart = resolvedCart;
+      // Prepare order data — server looks up price/name by product_id
+      const orderData = {
+        fullName: document.getElementById('fullName').value.trim(),
+        email: document.getElementById('email').value.trim(),
+        address: document.getElementById('address').value.trim(),
+        city: document.getElementById('city').value.trim(),
+        zip: document.getElementById('zip').value.trim(),
+        coupon: window.appliedCoupon,
+        idempotency_key: checkoutIdempotencyKey,
+        items: cart.map((item) => ({
+          product_id: Number(item.id),
+          quantity: parseInt(item.quantity, 10) || 1,
+        })),
+      };
 
-  fetch(`${API_BASE_URL}/api/orders/`, {
-    method: 'POST',
-    headers: buildAuthHeaders({
-      'Content-Type': 'application/json',
-      'Idempotency-Key': checkoutIdempotencyKey,
-    }),
-    credentials: 'include',
-    body: JSON.stringify(orderData),
-  })
+      return fetch(`${API_BASE_URL}/api/orders/`, {
+        method: 'POST',
+        headers: buildAuthHeaders({
+          'Content-Type': 'application/json',
+          'Idempotency-Key': checkoutIdempotencyKey,
+        }),
+        credentials: 'include',
+        body: JSON.stringify(orderData),
+      });
+    })
     .then((res) =>
       res
         .json()

--- a/products.js
+++ b/products.js
@@ -706,7 +706,7 @@ function renderProducts(containerId, list, query = '') {
     cartBtn.addEventListener('click', (e) => {
       e.stopPropagation();
       e.preventDefault();
-      addToCart(p.name, '₹' + p.price, p.img, 1, 'M');
+      addToCart(p.name, '₹' + p.price, p.img, 1, 'M', p.id);
     });
     const cartIcon = document.createElement('i');
     cartIcon.className = 'ri-shopping-cart-2-line';
@@ -904,9 +904,29 @@ function attachSearchListeners() {
  * Resolves #1691
  * Adds an item to the cart and persists it to localStorage.
  */
-function addToCart(name, price, img, quantity, size) {
+function addToCart(name, price, img, quantity, size, productId) {
   const cart = safeParseJSON('productsInCart');
-  cart.push({ name, price, img, quantity, size, id: Date.now() });
+  const parsedQty = parseInt(quantity, 10) || 1;
+  const item = {
+    id: productId != null && productId !== '' ? Number(productId) : undefined,
+    name,
+    price,
+    image: img,
+    img,
+    quantity: parsedQty,
+    size,
+  };
+  const existing = cart.find(
+    (p) =>
+      (item.id != null && p.id != null ? Number(p.id) === item.id : p.name === name) &&
+      p.size === size,
+  );
+  if (existing) {
+    existing.quantity = (parseInt(existing.quantity, 10) || 0) + parsedQty;
+    if (existing.id == null && item.id != null) existing.id = item.id;
+  } else {
+    cart.push(item);
+  }
   try {
     localStorage.setItem('productsInCart', JSON.stringify(cart));
     if (typeof showToast === 'function') {
@@ -920,16 +940,14 @@ function addToCart(name, price, img, quantity, size) {
   }
 }
 
-function buyNow(name, price, img, quantity, size) {
-  const cart = safeParseJSON('productsInCart');
-  cart.push({ name, price, img, quantity, size, id: Date.now() });
+function buyNow(name, price, img, quantity, size, productId) {
+  addToCart(name, price, img, quantity, size, productId);
   try {
-    localStorage.setItem('productsInCart', JSON.stringify(cart));
     window.location.href = 'checkout.html';
   } catch (e) {
-    window.logError('Failed to save cart:', e);
+    window.logError('Failed to navigate to checkout:', e);
     if (typeof showToast === 'function') {
-      showToast('Storage limit reached! Cannot proceed to checkout.', 'error');
+      showToast('Could not proceed to checkout.', 'error');
     }
   }
 }


### PR DESCRIPTION
## 📄 Description

Order create/cancel looked up products by name. Names are not unique, so duplicate catalog rows could charge or restock the wrong product. Orders now key off product_id.

## 🔗 Related Issues

Closes #4921

## 🧩 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## 🛠️ What Was Changed

- OrderItem stores product_id FK; create/cancel look up by id
- OrderItemCreate requires product_id; name/price snapshotted from DB
- Checkout/cart persist real product ids
- Alembic migration + duplicate-name regression test

## why this needed

Same-name products made stock and pricing ambiguous on order create and cancel.

## 🧪 How Has This Been Tested?

pytest tests/test_order_cancel.py tests/test_order_idempotency.py tests/test_order_detail.py — 9 passed

## ✅ Checklist

- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #IssueNumber`)
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue