### PR TITLE
fix(orders): bound OrderItemCreate.quantity to 1..99

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -151,7 +151,7 @@ class OrderResponse(BaseModel):
 
 class OrderItemCreate(BaseModel):
     product_name: str
-    quantity: int = Field(gt=0)
+    quantity: int = Field(gt=0, le=99)
 
 class OrderCreate(BaseModel):
     fullName: str

--- a/backend/tests/test_order_quantity_bounds.py
+++ b/backend/tests/test_order_quantity_bounds.py
@@ -1,0 +1,96 @@
+"""Quantity bounds for order line items (replaces removed CheckoutItem schema)."""
+from passlib.context import CryptContext
+
+from app.models import Product, User
+from tests.conftest import TestingSessionLocal
+
+ORDERS_URL = "/api/orders/"
+pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def _auth_headers(client):
+    db = TestingSessionLocal()
+    email = "qtybounds@example.com"
+    user = db.query(User).filter(User.email == email).first()
+    if user is None:
+        user = User(
+            username="qtybounds",
+            email=email,
+            hashed_password=pwd.hash("Test@1234"),
+        )
+        db.add(user)
+        db.commit()
+    db.close()
+    response = client.post(
+        "/api/auth/login",
+        json={"email": email, "password": "Test@1234"},
+    )
+    assert response.status_code == 200, response.text
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+def _seed_product(stock=100):
+    db = TestingSessionLocal()
+    product = Product(
+        brand="Cara",
+        name="Qty Bound Tee",
+        price=50.0,
+        img="tee.jpg",
+        rating=4,
+        category="street",
+        stock=stock,
+    )
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+    name = product.name
+    db.close()
+    return name
+
+
+def _payload(quantity, product_name="Qty Bound Tee"):
+    return {
+        "fullName": "Qty User",
+        "email": "qtybounds@example.com",
+        "address": "1 Test St",
+        "city": "Testville",
+        "zip": "12345",
+        "items": [{"product_name": product_name, "quantity": quantity}],
+    }
+
+
+def test_quantity_zero_rejected(client):
+    _seed_product()
+    headers = _auth_headers(client)
+    response = client.post(ORDERS_URL, json=_payload(0), headers=headers)
+    assert response.status_code == 422
+
+
+def test_quantity_negative_rejected(client):
+    _seed_product()
+    headers = _auth_headers(client)
+    response = client.post(ORDERS_URL, json=_payload(-1), headers=headers)
+    assert response.status_code == 422
+
+
+def test_quantity_above_max_rejected(client):
+    _seed_product()
+    headers = _auth_headers(client)
+    response = client.post(ORDERS_URL, json=_payload(100), headers=headers)
+    assert response.status_code == 422
+
+
+def test_quantity_at_max_accepted(client):
+    _seed_product(stock=100)
+    headers = _auth_headers(client)
+    response = client.post(ORDERS_URL, json=_payload(99), headers=headers)
+    assert response.status_code == 201, response.text
+
+
+def test_products_checkout_schema_gone(client):
+    """Legacy unauthenticated CheckoutItem endpoint must stay removed."""
+    response = client.post(
+        "/api/products/checkout",
+        json={"items": [{"name": "Anything", "quantity": -5}]},
+    )
+    assert response.status_code in (404, 405, 422)


### PR DESCRIPTION
## 📄 Description

CheckoutItem /api/products/checkout is already removed. The surviving order line schema only had gt=0, so huge quantities were still accepted. Cap at 99 and reject 0/negatives.

## 🔗 Related Issues

Closes #4931

## 🧩 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## 🛠️ What Was Changed

- OrderItemCreate.quantity is now Field(gt=0, le=99)
- Added tests/test_order_quantity_bounds.py

## why this needed

Unbounded quantities could still corrupt stock math on authenticated order create.

## 🧪 How Has This Been Tested?

pytest tests/test_order_quantity_bounds.py — 5 passed

## ✅ Checklist

- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #IssueNumber`)
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue