### PR TITLE
fix(orders): enforce coupon, loyalty, and gift wrap on the server

### DIFF
--- a/backend/alembic/versions/f1a2b3c4d5e6_add_loyalty_points_to_users.py
+++ b/backend/alembic/versions/f1a2b3c4d5e6_add_loyalty_points_to_users.py
@@ -1,0 +1,28 @@
+"""add loyalty_points to users
+
+Revision ID: f1a2b3c4d5e6
+Revises: d8e4f1a2b3c4
+Create Date: 2026-08-06 22:30:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "f1a2b3c4d5e6"
+down_revision: Union[str, Sequence[str], None] = "d8e4f1a2b3c4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("loyalty_points", sa.Integer(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "loyalty_points")

--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -160,28 +160,56 @@ def create_order(
 
     shipping = 0.0 if subtotal >= 3000 else 150.0
     tax = round(subtotal * 0.18, 2)
-    discount = 0.0
+    coupon_discount = 0.0
+    loyalty_discount = 0.0
+    gift_wrap_charge = 0.0
 
-    # --- Coupon Validation ---
-    # Coupons are percentage-off codes defined in a static map that mirrors
-    # the client-side `CARA_COUPONS` config (app.js). There is no Coupon table
-    # in the database, so validating here keeps the backend consistent with
-    # the frontend and avoids a runtime AttributeError on models.Coupon.
+    # Server-owned pricing constants (must match frontend display helpers)
     COUPONS = {"CARA20": 20, "WELCOME10": 10}
+    POINTS_PER_RUPEE = 10
+    GIFT_WRAP_CHARGE = 99.0
 
     if order_data.coupon:
         coupon_code = order_data.coupon.strip().upper()
-
         discount_percentage = COUPONS.get(coupon_code)
         if discount_percentage is None:
             raise HTTPException(
                 status_code=400,
-                detail="Invalid or inactive coupon code"
+                detail="Invalid or inactive coupon code",
             )
+        coupon_discount = round(subtotal * discount_percentage / 100, 2)
 
-        discount = round(subtotal * discount_percentage / 100, 2)
+    # Lock the buyer row so loyalty balance cannot be double-spent.
+    buyer = (
+        db.query(models.User)
+        .filter(models.User.id == current_user.id)
+        .with_for_update()
+        .first()
+    )
+    if not buyer:
+        raise HTTPException(status_code=401, detail="User not found")
 
-    grand_total = max(0, subtotal + tax + shipping - discount)
+    requested_points = int(order_data.loyalty_points or 0)
+    if requested_points > buyer.loyalty_points:
+        raise HTTPException(
+            status_code=400,
+            detail="Insufficient loyalty points",
+        )
+    redeemed_points = requested_points
+    loyalty_discount = round(redeemed_points / POINTS_PER_RUPEE, 2)
+
+    if order_data.gift_wrap:
+        gift_wrap_charge = GIFT_WRAP_CHARGE
+
+    # Urgency / client-only promos are intentionally not applied here.
+    grand_total = max(
+        0,
+        round(subtotal + tax + shipping + gift_wrap_charge - coupon_discount - loyalty_discount, 2),
+    )
+
+    # Redeem then earn on the paid merchandise subtotal (before discounts).
+    earned_points = max(0, int(subtotal * (POINTS_PER_RUPEE / 100)))
+    buyer.loyalty_points = buyer.loyalty_points - redeemed_points + earned_points
 
     new_order = models.Order(
         full_name=order_data.fullName,
@@ -216,10 +244,24 @@ def create_order(
         )
 
     db.refresh(new_order)
+    db.refresh(buyer)
 
     return {
         "message": "Order created successfully",
-        "order_id": new_order.id
+        "order_id": new_order.id,
+        "total_amount": grand_total,
+        "pricing": {
+            "subtotal": subtotal,
+            "tax": tax,
+            "shipping": shipping,
+            "gift_wrap": gift_wrap_charge,
+            "coupon_discount": coupon_discount,
+            "loyalty_discount": loyalty_discount,
+            "loyalty_points_redeemed": redeemed_points,
+            "loyalty_points_earned": earned_points,
+            "loyalty_points_balance": buyer.loyalty_points,
+            "grand_total": grand_total,
+        },
     }
 
 CANCELLABLE_WINDOW_HOURS = 24

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -61,6 +61,7 @@ class User(Base):
     hashed_password = Column(String, nullable=False)
     role            = Column(String, default="USER", nullable=False) 
     is_active = Column(Boolean, default=True)
+    loyalty_points = Column(Integer, default=0, nullable=False)
     created_at = Column(DateTime,  default=lambda: datetime.now(timezone.utc))
     full_name = Column(String, nullable=True)
     phone = Column(String, nullable=True)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -89,6 +89,7 @@ class UserOut(BaseModel):
     email:     str
     role:      str
     is_active: bool
+    loyalty_points: int = 0
 
     class Config:
         from_attributes = True
@@ -161,6 +162,8 @@ class OrderCreate(BaseModel):
     zip: str
     items: list[OrderItemCreate]
     coupon: Optional[str] = None
+    loyalty_points: int = Field(default=0, ge=0)
+    gift_wrap: bool = False
     idempotency_key: Optional[str] = None
 
 

--- a/backend/tests/test_order_pricing.py
+++ b/backend/tests/test_order_pricing.py
@@ -1,0 +1,144 @@
+"""Server-side coupon/loyalty/gift_wrap pricing on order create."""
+from passlib.context import CryptContext
+
+from app.models import Product, User
+from tests.conftest import TestingSessionLocal
+
+ORDERS_URL = "/api/orders/"
+pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def _auth_headers(client, *, email="pricing@example.com", username="pricinguser", points=0):
+    db = TestingSessionLocal()
+    user = db.query(User).filter(User.email == email).first()
+    if user is None:
+        user = User(
+            username=username,
+            email=email,
+            hashed_password=pwd.hash("Test@1234"),
+            loyalty_points=points,
+        )
+        db.add(user)
+    else:
+        user.loyalty_points = points
+    db.commit()
+    db.close()
+
+    response = client.post(
+        "/api/auth/login",
+        json={"email": email, "password": "Test@1234"},
+    )
+    assert response.status_code == 200, response.text
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+def _seed_product(name="Pricing Tee", price=1000.0, stock=10):
+    db = TestingSessionLocal()
+    product = Product(
+        brand="Cara",
+        name=name,
+        price=price,
+        img="tee.jpg",
+        rating=4,
+        category="street",
+        stock=stock,
+    )
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+    product_name = product.name
+    db.close()
+    return product_name
+
+
+def _payload(product_name, **extra):
+    body = {
+        "fullName": "Pricing User",
+        "email": "pricing@example.com",
+        "address": "1 Test St",
+        "city": "Testville",
+        "zip": "12345",
+        "items": [{"product_name": product_name, "quantity": 1}],
+    }
+    body.update(extra)
+    return body
+
+
+def test_coupon_discount_applied_server_side(client):
+    name = _seed_product(price=1000.0)
+    headers = _auth_headers(client)
+    response = client.post(
+        ORDERS_URL,
+        headers=headers,
+        json=_payload(name, coupon="CARA20"),
+    )
+    assert response.status_code == 201, response.text
+    pricing = response.json()["pricing"]
+    assert pricing["coupon_discount"] == 200.0
+    # subtotal 1000 + tax 180 + shipping 150 - 200 = 1130
+    assert pricing["grand_total"] == 1130.0
+    assert response.json()["total_amount"] == 1130.0
+
+
+def test_loyalty_points_validated_and_persisted(client):
+    name = _seed_product(name="Loyalty Tee", price=1000.0)
+    headers = _auth_headers(
+        client, email="loyal@example.com", username="loyaluser", points=100
+    )
+    response = client.post(
+        ORDERS_URL,
+        headers=headers,
+        json={
+            **_payload(name),
+            "email": "loyal@example.com",
+            "loyalty_points": 100,
+        },
+    )
+    assert response.status_code == 201, response.text
+    pricing = response.json()["pricing"]
+    assert pricing["loyalty_discount"] == 10.0
+    assert pricing["loyalty_points_redeemed"] == 100
+    assert pricing["loyalty_points_earned"] == 100  # floor(1000 * 0.1)
+    assert pricing["loyalty_points_balance"] == 100  # 100 - 100 + 100
+
+    db = TestingSessionLocal()
+    user = db.query(User).filter(User.email == "loyal@example.com").one()
+    assert user.loyalty_points == 100
+    db.close()
+
+
+def test_loyalty_overdraft_rejected(client):
+    name = _seed_product(name="Overdraft Tee", price=100.0)
+    headers = _auth_headers(
+        client, email="broke@example.com", username="brokeuser", points=5
+    )
+    response = client.post(
+        ORDERS_URL,
+        headers=headers,
+        json={
+            **_payload(name),
+            "email": "broke@example.com",
+            "loyalty_points": 50,
+        },
+    )
+    assert response.status_code == 400
+    assert "Insufficient loyalty points" in response.json()["detail"]
+
+
+def test_gift_wrap_added_to_total(client):
+    name = _seed_product(name="Gift Tee", price=1000.0)
+    headers = _auth_headers(client, email="gift@example.com", username="giftuser")
+    response = client.post(
+        ORDERS_URL,
+        headers=headers,
+        json={
+            **_payload(name),
+            "email": "gift@example.com",
+            "gift_wrap": True,
+        },
+    )
+    assert response.status_code == 201, response.text
+    pricing = response.json()["pricing"]
+    assert pricing["gift_wrap"] == 99.0
+    # 1000 + 180 + 150 + 99 = 1429
+    assert pricing["grand_total"] == 1429.0

--- a/checkout.js
+++ b/checkout.js
@@ -358,7 +358,7 @@ function submitCheckoutForm() {
     checkoutIdempotencyKey = crypto.randomUUID();
   }
 
-  // Prepare order data
+  // Prepare order data — discounts enforced server-side
   const orderData = {
     fullName: document.getElementById('fullName').value.trim(),
     email: document.getElementById('email').value.trim(),
@@ -366,11 +366,13 @@ function submitCheckoutForm() {
     city: document.getElementById('city').value.trim(),
     zip: document.getElementById('zip').value.trim(),
     coupon: window.appliedCoupon,
+    loyalty_points:
+      parseInt(localStorage.getItem('cara_applied_loyalty_points'), 10) || 0,
+    gift_wrap: !!document.getElementById('gift-wrap-opt')?.checked,
     idempotency_key: checkoutIdempotencyKey,
     items: cart.map((item) => ({
       product_name: item.name,
       quantity: parseInt(item.quantity, 10) || 1,
-      price: item.price,
     })),
   };
 
@@ -394,25 +396,20 @@ function submitCheckoutForm() {
     )
     .then((res) => {
       if (!res.ok) {
-        throw new Error(res.body.detail || 'Failed to place order');
+        const detail = res.body && res.body.detail;
+        throw new Error(
+          typeof detail === 'string' ? detail : 'Failed to place order',
+        );
       }
 
-      // DEDUCT & ADD LOYALTY POINTS ON SUCCESSFUL ORDER
-      const appliedPoints =
-        parseInt(localStorage.getItem('cara_applied_loyalty_points'), 10) || 0;
-      const currentBalance =
-        parseInt(localStorage.getItem('cara_loyalty_balance'), 10) || (window.CARA_CONFIG ? window.CARA_CONFIG.LOYALTY.DEFAULT_BALANCE : 150);
-      const subtotal = cart.reduce(
-        (sum, item) =>
-          sum + parsePriceString(item.price) * (parseInt(item.quantity, 10) || 1),
-        0,
-      );
-      const earnedPoints = Math.floor(subtotal * (window.CARA_CONFIG ? window.CARA_CONFIG.LOYALTY.POINTS_PER_RUPEE / 100 : 0.1));
-      const newBalance = Math.max(
-        0,
-        currentBalance - appliedPoints + earnedPoints,
-      );
-      localStorage.setItem('cara_loyalty_balance', newBalance);
+      // Sync loyalty from server response (source of truth)
+      const pricing = res.body.pricing || {};
+      if (typeof pricing.loyalty_points_balance === 'number') {
+        localStorage.setItem(
+          'cara_loyalty_balance',
+          String(pricing.loyalty_points_balance),
+        );
+      }
       localStorage.removeItem('cara_applied_loyalty_points');
 
       // CLEAR CART AFTER SUCCESSFUL ORDER
@@ -535,18 +532,15 @@ window.updateCheckoutSummary = function () {
   const couponPct = COUPONS[couponCode] || 0;
   const couponDiscountCents = Math.round(subtotalCents * couponPct / 100);
 
-  // Check urgency discount if the timer is running
+  // Urgency banner is marketing-only — it must not change the charged total.
+  // Server is the source of truth for discounts (coupon + loyalty + gift wrap).
   const hasUrgency =
     !window.urgencyTimerExpired &&
     document.getElementById('checkout-promo-alert-bar');
-  const urgencyDiscount = hasUrgency ? subtotal * (window.CARA_CONFIG ? window.CARA_CONFIG.URGENCY_DISCOUNT_PCT : 0.05) : 0;
 
   // Check gift wrap
   const hasGiftWrap = document.getElementById('gift-wrap-opt')?.checked;
   const giftCharge = hasGiftWrap ? (window.CARA_CONFIG ? window.CARA_CONFIG.GIFT_WRAP_CHARGE : 99) : 0;
-
-  // Calculate tax
-  const tax = subtotal * (window.CARA_CONFIG ? window.CARA_CONFIG.TAX_RATE : 0.18);
 
   // Check loyalty points discount
   const loyaltyPoints =
@@ -555,17 +549,19 @@ window.updateCheckoutSummary = function () {
 
   const taxCents = Math.round(subtotalCents * (window.CARA_CONFIG ? window.CARA_CONFIG.TAX_RATE : 0.18));
   const giftChargeCents = Math.round(giftCharge * 100);
-  const urgencyDiscountCents = Math.round(urgencyDiscount * 100);
   const loyaltyDiscountCents = Math.round(loyaltyDiscount * 100);
+  const shippingFee = window.CARA_CONFIG ? window.CARA_CONFIG.SHIPPING.FEE : 150;
+  const freeShipAt = window.CARA_CONFIG ? window.CARA_CONFIG.SHIPPING.FREE_THRESHOLD : 3000;
+  const shippingCents = subtotal >= freeShipAt ? 0 : Math.round(shippingFee * 100);
 
-  // Grand Total in cents (integer, safe for Stripe)
+  // Grand Total mirrors server: subtotal + tax + shipping + gift - coupon - loyalty
   const grandTotalCents = Math.max(
     0,
     subtotalCents +
       taxCents +
+      shippingCents +
       giftChargeCents -
       couponDiscountCents -
-      urgencyDiscountCents -
       loyaltyDiscountCents,
   );
 
@@ -617,9 +613,9 @@ window.updateCheckoutSummary = function () {
     if (couponRow) couponRow.remove();
   }
 
-  // Update Urgency Row
+  // Urgency timer is display-only; do not imply it reduces the charged total.
   let urgencyRow = document.getElementById('urgency-discount-row');
-  if (urgencyDiscountCents > 0) {
+  if (hasUrgency) {
     if (!urgencyRow) {
       urgencyRow = document.createElement('div');
       urgencyRow.id = 'urgency-discount-row';
@@ -629,9 +625,10 @@ window.updateCheckoutSummary = function () {
       const divider = document.querySelector('.summary-divider');
       if (divider) divider.parentNode.insertBefore(urgencyRow, divider);
     }
-    urgencyRow.innerHTML = `<span>Urgency Promo (${window.CARA_CONFIG ? window.CARA_CONFIG.URGENCY_DISCOUNT_PCT * 100 : 5}%)</span><span id='urgency-discount-val'>-${formatCurrency(urgencyDiscountCents)}</span>`;
-  } else {
-    if (urgencyRow) urgencyRow.remove();
+    urgencyRow.innerHTML =
+      '<span>Limited-time checkout</span><span style="font-weight:500;font-size:12px;">Coupon &amp; loyalty applied at payment</span>';
+  } else if (urgencyRow) {
+    urgencyRow.remove();
   }
 
   // Update Gift Wrap Row


### PR DESCRIPTION
## 📄 Description

Checkout UI applied loyalty/urgency discounts that the API ignored, so charged totals diverged. Loyalty is now stored on the user and all paid discounts are computed server-side.

## 🔗 Related Issues

Closes #4922

## 🧩 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## 🛠️ What Was Changed

- users.loyalty_points + order create accepts loyalty_points / gift_wrap
- Server validates balance, applies coupon/loyalty/gift wrap, returns pricing breakdown
- Checkout stops subtracting urgency from the payable total; syncs balance from API

## why this needed

Displayed checkout totals were editable via localStorage and did not match what orders charged.

## 🧪 How Has This Been Tested?

pytest tests/test_order_pricing.py tests/test_order_idempotency.py tests/test_order_cancel.py — 9 passed

## ✅ Checklist

- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #IssueNumber`)
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue