### PR TITLE
fix(cart): unify cart persistence on productsInCart

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,6 +16,60 @@ window.CARA_COUPONS = {
   'CARA20': 20,
   'WELCOME10': 10
 };
+
+// Unify legacy cart keys onto productsInCart (see js/cart-store.js).
+(function migrateLegacyCartKeys() {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    const canonical = localStorage.getItem('productsInCart');
+    const hasCanonical =
+      canonical &&
+      (() => {
+        try {
+          const parsed = JSON.parse(canonical);
+          return Array.isArray(parsed) && parsed.length > 0;
+        } catch (e) {
+          return false;
+        }
+      })();
+    if (hasCanonical) {
+      localStorage.removeItem('cara_shopping_cart');
+      localStorage.removeItem('cara_cart');
+      return;
+    }
+    for (const key of ['cara_shopping_cart', 'cara_cart']) {
+      const raw = localStorage.getItem(key);
+      if (!raw) continue;
+      let items = [];
+      try {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) items = parsed;
+        else if (parsed && Array.isArray(parsed.items)) items = parsed.items;
+        else if (parsed && typeof parsed === 'object') {
+          items = Object.keys(parsed)
+            .filter((k) => k !== 'subtotal' && k !== 'version' && k !== 'timestamp')
+            .map((id) => {
+              const entry = parsed[id];
+              return typeof entry === 'object'
+                ? { id, ...entry }
+                : { id, quantity: Number(entry) || 1 };
+            });
+        }
+      } catch (e) {
+        continue;
+      }
+      if (items.length) {
+        localStorage.setItem('productsInCart', JSON.stringify(items));
+        localStorage.removeItem('cara_shopping_cart');
+        localStorage.removeItem('cara_cart');
+        break;
+      }
+    }
+  } catch (err) {
+    // ignore storage access errors
+  }
+})();
+
 // i18n.js - Multi-language support
 
 // Global error logger

--- a/cara.html
+++ b/cara.html
@@ -659,7 +659,15 @@
 
     // state
     let products = [...sampleProducts];
-    let cart = JSON.parse(localStorage.getItem('cara_cart') || '{}');
+    let cart = JSON.parse(localStorage.getItem('productsInCart') || '{}');
+    if (Array.isArray(cart)) {
+      // Canonical store is an array; convert to id->item map for this demo page.
+      cart = cart.reduce((acc, item) => {
+        const id = item.id || item.name;
+        if (id != null) acc[id] = item;
+        return acc;
+      }, {});
+    }
 
     // DOM refs
     const grid = document.getElementById('grid');
@@ -686,7 +694,15 @@
 
     // helpers
     function formatPrice(v) { return '$' + v.toFixed(2) }
-    function saveCart() { localStorage.setItem('cara_cart', JSON.stringify(cart)); }
+    function saveCart() {
+      const items = Object.keys(cart).map((id) => {
+        const entry = cart[id];
+        return typeof entry === 'object' ? { id, ...entry } : { id, quantity: entry };
+      });
+      localStorage.setItem('productsInCart', JSON.stringify(items));
+      localStorage.removeItem('cara_cart');
+      localStorage.removeItem('cara_shopping_cart');
+    }
 
     function renderGrid(items) {
       grid.innerHTML = '';

--- a/cart.html
+++ b/cart.html
@@ -243,6 +243,7 @@
   </div>
   </main>
 
+  <script src="js/cart-store.js" defer></script>
   <script src="js/shipping-calc.js" defer></script>
   <script src="js/loyalty.js" defer></script>
   <script src="js/coupon-config.js" defer></script>

--- a/checkout.html
+++ b/checkout.html
@@ -33,6 +33,7 @@
   </script>
   <meta name="description" content="Cara - The best ecommerce store for modern fashion and clothing.">
     <script type="module" src="js/config.js"></script>
+    <script src="js/cart-store.js"></script>
   <script src="assets/js/skip-link.js" defer></script>
 </head>
 <body>

--- a/js/cart-coupon.js
+++ b/js/cart-coupon.js
@@ -55,8 +55,18 @@
       // Get cart subtotal from localStorage or default to 0
       let subtotal = 0;
       try {
-        const cart = JSON.parse(localStorage.getItem('cara_cart') || '{}');
-        subtotal = parseFloat(cart.subtotal) || 0;
+        if (window.CaraCartStore) {
+          subtotal = window.CaraCartStore.cartSubtotal();
+        } else {
+          const cart = JSON.parse(localStorage.getItem('productsInCart') || '[]');
+          if (Array.isArray(cart)) {
+            subtotal = cart.reduce((sum, item) => {
+              const price =
+                Number(String(item.price || 0).toString().replace(/[^\d.]/g, '')) || 0;
+              return sum + price * (parseInt(item.quantity, 10) || 1);
+            }, 0);
+          }
+        }
       } catch (err) {
         // ignore parse errors
       }

--- a/js/cart-store.js
+++ b/js/cart-store.js
@@ -1,0 +1,130 @@
+/**
+ * Canonical cart localStorage store.
+ * One key, schema versioning, and one-time migration from legacy keys.
+ */
+(function (root) {
+  'use strict';
+
+  const CART_KEY = 'productsInCart';
+  const SCHEMA_VERSION = 1;
+  const LEGACY_KEYS = ['cara_shopping_cart', 'cara_cart'];
+
+  function safeParse(raw, fallback) {
+    try {
+      return raw == null ? fallback : JSON.parse(raw);
+    } catch (err) {
+      return fallback;
+    }
+  }
+
+  function normalizeItems(raw) {
+    if (Array.isArray(raw)) return raw;
+    if (raw && Array.isArray(raw.items)) return raw.items;
+    if (raw && typeof raw === 'object') {
+      // cara.html historically stored a map of id -> qty/item
+      return Object.keys(raw)
+        .filter((k) => k !== 'subtotal' && k !== 'version' && k !== 'timestamp')
+        .map((id) => {
+          const entry = raw[id];
+          if (entry && typeof entry === 'object') {
+            return { id, ...entry, quantity: entry.quantity || entry.qty || 1 };
+          }
+          return { id, quantity: Number(entry) || 1 };
+        });
+    }
+    return [];
+  }
+
+  function readLegacyItems() {
+    if (typeof localStorage === 'undefined') return [];
+    for (const key of LEGACY_KEYS) {
+      const raw = localStorage.getItem(key);
+      if (!raw) continue;
+      const parsed = safeParse(raw, null);
+      const items = normalizeItems(parsed);
+      if (items.length) return items;
+    }
+    return [];
+  }
+
+  function migrateIfNeeded() {
+    if (typeof localStorage === 'undefined') return;
+    const existing = localStorage.getItem(CART_KEY);
+    if (existing) {
+      const parsed = safeParse(existing, []);
+      if (Array.isArray(parsed) && parsed.length) return;
+    }
+    const legacyItems = readLegacyItems();
+    if (!legacyItems.length) return;
+    writeCart(legacyItems);
+    for (const key of LEGACY_KEYS) {
+      try {
+        localStorage.removeItem(key);
+      } catch (err) {
+        // ignore
+      }
+    }
+  }
+
+  function readCart() {
+    migrateIfNeeded();
+    if (typeof localStorage === 'undefined') return [];
+    return normalizeItems(safeParse(localStorage.getItem(CART_KEY), []));
+  }
+
+  function writeCart(items) {
+    if (typeof localStorage === 'undefined') return;
+    const list = Array.isArray(items) ? items : [];
+    try {
+      localStorage.setItem(CART_KEY, JSON.stringify(list));
+      // Keep a version marker for future migrations without breaking array readers.
+      localStorage.setItem(
+        'cara_cart_meta',
+        JSON.stringify({ version: SCHEMA_VERSION, updatedAt: Date.now() }),
+      );
+      // Mirror cleared legacy keys so stale writers do not resurrect forks.
+      for (const key of LEGACY_KEYS) {
+        localStorage.removeItem(key);
+      }
+    } catch (err) {
+      console.warn('Failed to persist cart:', err);
+    }
+    if (typeof root !== 'undefined') {
+      root.cachedCartState = list;
+    }
+  }
+
+  function clearCart() {
+    writeCart([]);
+    try {
+      localStorage.removeItem(CART_KEY);
+    } catch (err) {
+      // ignore
+    }
+  }
+
+  function cartSubtotal(items) {
+    const list = items || readCart();
+    return list.reduce((sum, item) => {
+      const price = Number(String(item.price || 0).toString().replace(/[^\d.]/g, '')) || 0;
+      const qty = parseInt(item.quantity, 10) || 1;
+      return sum + price * qty;
+    }, 0);
+  }
+
+  const api = {
+    KEY: CART_KEY,
+    LEGACY_KEYS,
+    SCHEMA_VERSION,
+    readCart,
+    writeCart,
+    clearCart,
+    cartSubtotal,
+    migrateIfNeeded,
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+  root.CaraCartStore = api;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/js/cart-sync-manager.js
+++ b/js/cart-sync-manager.js
@@ -5,9 +5,39 @@
 
 export class CartSyncManager {
   constructor(options = {}) {
-    this.storageKey = options.storageKey || 'cara_shopping_cart';
+    // Canonical key shared with app.js / checkout (migrates legacy keys).
+    this.storageKey = options.storageKey || 'productsInCart';
     this.ttlMs = options.ttlMs || 24 * 60 * 60 * 1000; // 24 hours
+    this._migrateLegacy();
     this.initSync();
+  }
+
+  _migrateLegacy() {
+    if (typeof window !== 'undefined' && window.CaraCartStore) {
+      window.CaraCartStore.migrateIfNeeded();
+      return;
+    }
+    if (typeof localStorage === 'undefined') return;
+    if (localStorage.getItem(this.storageKey)) return;
+    for (const key of ['cara_shopping_cart', 'cara_cart']) {
+      const raw = localStorage.getItem(key);
+      if (!raw) continue;
+      try {
+        const parsed = JSON.parse(raw);
+        const items = Array.isArray(parsed)
+          ? parsed
+          : Array.isArray(parsed.items)
+            ? parsed.items
+            : [];
+        if (items.length) {
+          this.saveCart(items);
+          localStorage.removeItem(key);
+          break;
+        }
+      } catch (e) {
+        // ignore bad legacy payload
+      }
+    }
   }
 
   initSync() {
@@ -28,7 +58,22 @@ export class CartSyncManager {
     if (typeof localStorage === 'undefined') return null;
     try {
       const data = localStorage.getItem(this.storageKey);
-      return data ? JSON.parse(data) : null;
+      if (!data) return null;
+      const parsed = JSON.parse(data);
+      const metaRaw = localStorage.getItem(`${this.storageKey}_meta`);
+      let metaTs = Date.now();
+      if (metaRaw) {
+        try {
+          metaTs = JSON.parse(metaRaw).updatedAt || metaTs;
+        } catch (e) {
+          // ignore
+        }
+      }
+      // Canonical store is a bare array; wrap for TTL helpers.
+      if (Array.isArray(parsed)) {
+        return { items: parsed, timestamp: metaTs };
+      }
+      return parsed;
     } catch (e) {
       return null;
     }
@@ -49,12 +94,15 @@ export class CartSyncManager {
 
   saveCart(items = []) {
     if (typeof localStorage === 'undefined') return;
-    const payload = {
-      items,
-      timestamp: Date.now(),
-    };
     try {
-      localStorage.setItem(this.storageKey, JSON.stringify(payload));
+      // Persist as the canonical array shape used by app.js / checkout.
+      localStorage.setItem(this.storageKey, JSON.stringify(items));
+      localStorage.setItem(
+        `${this.storageKey}_meta`,
+        JSON.stringify({ version: 1, updatedAt: Date.now() }),
+      );
+      localStorage.removeItem('cara_shopping_cart');
+      localStorage.removeItem('cara_cart');
     } catch (e) {
       console.warn('Failed to save cart payload:', e);
     }

--- a/tests/unit/cart-store.test.js
+++ b/tests/unit/cart-store.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+// Load via CommonJS export path used in Node/vitest
+const CaraCartStore = require('../../js/cart-store.js');
+
+describe('CaraCartStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('migrates cara_shopping_cart items into productsInCart', () => {
+    localStorage.setItem(
+      'cara_shopping_cart',
+      JSON.stringify({
+        items: [{ id: 1, name: 'Tee', quantity: 2, price: 10 }],
+        timestamp: Date.now(),
+      }),
+    );
+
+    const items = CaraCartStore.readCart();
+    expect(items).toHaveLength(1);
+    expect(items[0].name).toBe('Tee');
+    expect(localStorage.getItem('productsInCart')).toBeTruthy();
+    expect(localStorage.getItem('cara_shopping_cart')).toBeNull();
+  });
+
+  it('migrates cara_cart map into productsInCart', () => {
+    localStorage.setItem(
+      'cara_cart',
+      JSON.stringify({
+        a1: { name: 'Hoodie', quantity: 1, price: 40 },
+        subtotal: 40,
+      }),
+    );
+
+    const items = CaraCartStore.readCart();
+    expect(items.some((i) => i.name === 'Hoodie')).toBe(true);
+    expect(localStorage.getItem('cara_cart')).toBeNull();
+  });
+
+  it('writes only the canonical key', () => {
+    CaraCartStore.writeCart([{ id: 9, name: 'Cap', quantity: 1, price: 5 }]);
+    expect(JSON.parse(localStorage.getItem('productsInCart'))[0].id).toBe(9);
+    expect(localStorage.getItem('cara_shopping_cart')).toBeNull();
+    expect(localStorage.getItem('cara_cart')).toBeNull();
+  });
+});


### PR DESCRIPTION
## 📄 Description

Cart state lived in three localStorage keys. Everything now reads/writes productsInCart, with a one-time migration from the legacy keys.

## 🔗 Related Issues

Closes #4923

## 🧩 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## 🛠️ What Was Changed

- Added js/cart-store.js (canonical key + migration)
- Pointed CartSyncManager and cart coupon subtotal at productsInCart
- Migrated cara.html demo cart; app boot clears/migrates legacy keys

## why this needed

Coupon/sync paths were operating on different stores than the shop cart.

## 🧪 How Has This Been Tested?

vitest — 476 passed

## ✅ Checklist

- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #IssueNumber`)
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue