### PR TITLE
feat(payments): confirm online orders via Stripe PaymentIntents

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,6 +9,12 @@
 # Generate one with: python -c "import secrets; print(secrets.token_hex(32))"
 SECRET_KEY=your-secret-key-here
 
+# Stripe PaymentIntents (optional). When unset, online checkout stays unavailable.
+# STRIPE_SECRET_KEY=sk_test_...
+# STRIPE_PUBLISHABLE_KEY=pk_test_...
+# STRIPE_WEBHOOK_SECRET=whsec_...
+# STRIPE_CURRENCY=inr
+
 # Comma-separated browser origins allowed for credentialed CORS requests.
 # Defaults include local Live Server ports and documented Vercel demos when unset.
 # CORS_ORIGINS=http://localhost:5500,https://cara-seven-ashen.vercel.app

--- a/backend/alembic/versions/a7b8c9d0e1f2_add_payment_fields_to_orders.py
+++ b/backend/alembic/versions/a7b8c9d0e1f2_add_payment_fields_to_orders.py
@@ -1,0 +1,31 @@
+"""add payment fields to orders
+
+Revision ID: a7b8c9d0e1f2
+Revises: d8e4f1a2b3c4
+Create Date: 2026-08-06 22:40:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "a7b8c9d0e1f2"
+down_revision: Union[str, Sequence[str], None] = "d8e4f1a2b3c4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("orders", sa.Column("payment_method", sa.String(), nullable=True))
+    op.add_column("orders", sa.Column("payment_intent_id", sa.String(), nullable=True))
+    op.create_index(
+        op.f("ix_orders_payment_intent_id"), "orders", ["payment_intent_id"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_orders_payment_intent_id"), table_name="orders")
+    op.drop_column("orders", "payment_intent_id")
+    op.drop_column("orders", "payment_method")

--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -183,6 +183,23 @@ def create_order(
 
     grand_total = max(0, subtotal + tax + shipping - discount)
 
+    payment_method = (order_data.payment_method or "cod").strip().lower()
+    if payment_method not in ("cod", "online"):
+        raise HTTPException(status_code=400, detail="Invalid payment_method")
+
+    # Online requires a configured Stripe secret; never confirm without a webhook.
+    if payment_method == "online":
+        from .payments import payments_enabled
+
+        if not payments_enabled():
+            raise HTTPException(
+                status_code=503,
+                detail="Online payments are not configured. Use Cash on Delivery or set STRIPE_SECRET_KEY.",
+            )
+        initial_status = "PENDING"
+    else:
+        initial_status = "CONFIRMED"
+
     new_order = models.Order(
         full_name=order_data.fullName,
         email=current_user.email,
@@ -190,7 +207,8 @@ def create_order(
         city=order_data.city,
         zip_code=order_data.zip,
         total_amount=grand_total,
-        status="CONFIRMED",
+        status=initial_status,
+        payment_method=payment_method,
         idempotency_key=order_data.idempotency_key,
     )
 
@@ -219,7 +237,11 @@ def create_order(
 
     return {
         "message": "Order created successfully",
-        "order_id": new_order.id
+        "order_id": new_order.id,
+        "status": new_order.status,
+        "payment_method": payment_method,
+        "needs_payment": payment_method == "online" and new_order.status == "PENDING",
+        "total_amount": grand_total,
     }
 
 CANCELLABLE_WINDOW_HOURS = 24

--- a/backend/app/api/payments.py
+++ b/backend/app/api/payments.py
@@ -1,0 +1,153 @@
+"""Stripe PaymentIntent + webhook confirmation for Cara orders."""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import stripe
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from .. import models
+from ..database import get_db
+from .auth import get_current_user
+
+router = APIRouter()
+
+
+def _stripe_secret() -> Optional[str]:
+    return os.environ.get("STRIPE_SECRET_KEY") or None
+
+
+def _stripe_webhook_secret() -> Optional[str]:
+    return os.environ.get("STRIPE_WEBHOOK_SECRET") or None
+
+
+def payments_enabled() -> bool:
+    return bool(_stripe_secret())
+
+
+class CreateIntentRequest(BaseModel):
+    order_id: int = Field(gt=0)
+
+
+@router.get("/config")
+def payment_config():
+    """Public publishable key for Stripe.js — never exposes the secret key."""
+    return {
+        "enabled": payments_enabled(),
+        "publishable_key": os.environ.get("STRIPE_PUBLISHABLE_KEY", ""),
+        "provider": "stripe",
+    }
+
+
+@router.post("/create-intent")
+def create_payment_intent(
+    payload: CreateIntentRequest,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    secret = _stripe_secret()
+    if not secret:
+        raise HTTPException(
+            status_code=503,
+            detail="Payment gateway is not configured. Set STRIPE_SECRET_KEY.",
+        )
+
+    order = (
+        db.query(models.Order)
+        .filter(
+            models.Order.id == payload.order_id,
+            models.Order.email == current_user.email,
+        )
+        .with_for_update()
+        .first()
+    )
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+    if order.status == "CONFIRMED":
+        raise HTTPException(status_code=400, detail="Order is already paid")
+    if order.status == "CANCELLED":
+        raise HTTPException(status_code=400, detail="Order is cancelled")
+
+    stripe.api_key = secret
+    amount_paise = max(1, int(round(float(order.total_amount) * 100)))
+
+    if order.payment_intent_id:
+        intent = stripe.PaymentIntent.retrieve(order.payment_intent_id)
+        return {
+            "client_secret": intent.client_secret,
+            "payment_intent_id": intent.id,
+            "order_id": order.id,
+            "amount": order.total_amount,
+        }
+
+    intent = stripe.PaymentIntent.create(
+        amount=amount_paise,
+        currency=os.environ.get("STRIPE_CURRENCY", "inr"),
+        metadata={
+            "order_id": str(order.id),
+            "email": current_user.email,
+        },
+        automatic_payment_methods={"enabled": True},
+    )
+    order.payment_intent_id = intent.id
+    order.payment_method = "online"
+    order.status = "PENDING"
+    db.commit()
+
+    return {
+        "client_secret": intent.client_secret,
+        "payment_intent_id": intent.id,
+        "order_id": order.id,
+        "amount": order.total_amount,
+    }
+
+
+@router.post("/webhook")
+async def stripe_webhook(
+    request: Request,
+    db: Session = Depends(get_db),
+    stripe_signature: Optional[str] = Header(default=None, alias="Stripe-Signature"),
+):
+    """Confirm orders only after a verified Stripe webhook (never trust the browser)."""
+    secret = _stripe_secret()
+    wh_secret = _stripe_webhook_secret()
+    if not secret or not wh_secret:
+        raise HTTPException(status_code=503, detail="Stripe webhook is not configured")
+
+    payload = await request.body()
+    stripe.api_key = secret
+    try:
+        event = stripe.Webhook.construct_event(payload, stripe_signature, wh_secret)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid webhook: {exc}") from exc
+
+    if event["type"] == "payment_intent.succeeded":
+        intent = event["data"]["object"]
+        intent_id = intent.get("id")
+        order = (
+            db.query(models.Order)
+            .filter(models.Order.payment_intent_id == intent_id)
+            .with_for_update()
+            .first()
+        )
+        if order and order.status != "CONFIRMED":
+            order.status = "CONFIRMED"
+            db.commit()
+    elif event["type"] == "payment_intent.payment_failed":
+        intent = event["data"]["object"]
+        intent_id = intent.get("id")
+        order = (
+            db.query(models.Order)
+            .filter(models.Order.payment_intent_id == intent_id)
+            .with_for_update()
+            .first()
+        )
+        if order and order.status == "PENDING":
+            # Leave unpaid so the buyer can cancel / retry; do not store PAN.
+            order.status = "PENDING"
+            db.commit()
+
+    return {"received": True}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -70,11 +70,12 @@ def root():
     return {"message": "Cara AI Outfit Recommendation API is running."}
 
 # Include routers here later
-from .api import recommendation, products, auth, orders, address, newsletter, admin, admin_products, profile, ambassador
+from .api import recommendation, products, auth, orders, address, newsletter, admin, admin_products, profile, ambassador, payments
 app.include_router(recommendation.router, prefix="/api/outfit", tags=["outfit"])
 app.include_router(products.router, prefix="/api/products", tags=["products"])
 app.include_router(auth.router,prefix="/api/auth",tags=["auth"])
 app.include_router(orders.router, prefix="/api/orders", tags=["orders"])
+app.include_router(payments.router, prefix="/api/payments", tags=["payments"])
 app.include_router(address.router, prefix="/api/address", tags=["address"])
 app.include_router(newsletter.router, prefix="/api/newsletter", tags=["newsletter"])
 app.include_router(admin.router, prefix="/api/admin", tags=["admin"])

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -90,6 +90,8 @@ class Order(Base):
     zip_code = Column(String, nullable=False)
     total_amount = Column(Float, nullable=False)
     status = Column(String, default="PENDING")
+    payment_method = Column(String, nullable=True)
+    payment_intent_id = Column(String, nullable=True, index=True)
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     # Uniqueness is scoped per buyer email via uq_orders_email_idempotency_key
     idempotency_key = Column(String, index=True, nullable=True)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -161,6 +161,7 @@ class OrderCreate(BaseModel):
     zip: str
     items: list[OrderItemCreate]
     coupon: Optional[str] = None
+    payment_method: Optional[str] = Field(default="cod")
     idempotency_key: Optional[str] = None
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,3 +18,4 @@ email-validator
 slowapi
 pytest
 httpx
+stripe

--- a/backend/tests/test_payments.py
+++ b/backend/tests/test_payments.py
@@ -1,0 +1,150 @@
+"""Stripe payment config + order PENDING for online checkout."""
+from passlib.context import CryptContext
+
+from app.models import Product, User, Order
+from tests.conftest import TestingSessionLocal
+
+pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def _auth_headers(client):
+    db = TestingSessionLocal()
+    email = "payuser@example.com"
+    user = db.query(User).filter(User.email == email).first()
+    if user is None:
+        db.add(
+            User(
+                username="payuser",
+                email=email,
+                hashed_password=pwd.hash("Test@1234"),
+            )
+        )
+        db.commit()
+    db.close()
+    response = client.post(
+        "/api/auth/login",
+        json={"email": email, "password": "Test@1234"},
+    )
+    assert response.status_code == 200
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+def _seed_product():
+    db = TestingSessionLocal()
+    product = Product(
+        brand="Cara",
+        name="Pay Tee",
+        price=500.0,
+        img="tee.jpg",
+        rating=4,
+        category="street",
+        stock=5,
+    )
+    db.add(product)
+    db.commit()
+    name = product.name
+    db.close()
+    return name
+
+
+def test_payments_config_disabled_without_keys(client):
+    response = client.get("/api/payments/config")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["enabled"] is False
+    assert body["provider"] == "stripe"
+
+
+def test_online_order_rejected_without_stripe(client):
+    name = _seed_product()
+    headers = _auth_headers(client)
+    response = client.post(
+        "/api/orders/",
+        headers=headers,
+        json={
+            "fullName": "Pay User",
+            "email": "payuser@example.com",
+            "address": "1 Test St",
+            "city": "Testville",
+            "zip": "12345",
+            "payment_method": "online",
+            "items": [{"product_name": name, "quantity": 1}],
+        },
+    )
+    assert response.status_code == 503
+
+
+def test_cod_order_confirmed_immediately(client):
+    name = _seed_product()
+    headers = _auth_headers(client)
+    response = client.post(
+        "/api/orders/",
+        headers=headers,
+        json={
+            "fullName": "Pay User",
+            "email": "payuser@example.com",
+            "address": "1 Test St",
+            "city": "Testville",
+            "zip": "12345",
+            "payment_method": "cod",
+            "items": [{"product_name": name, "quantity": 1}],
+        },
+    )
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["status"] == "CONFIRMED"
+    assert body["needs_payment"] is False
+
+    db = TestingSessionLocal()
+    order = db.query(Order).filter(Order.id == body["order_id"]).one()
+    assert order.status == "CONFIRMED"
+    assert order.payment_method == "cod"
+    db.close()
+
+
+def test_webhook_confirms_pending_order(client, monkeypatch):
+    """Simulate a verified Stripe webhook marking the order CONFIRMED."""
+    db = TestingSessionLocal()
+    order = Order(
+        full_name="Webhook User",
+        email="payuser@example.com",
+        address="1 Test St",
+        city="Testville",
+        zip_code="12345",
+        total_amount=100.0,
+        status="PENDING",
+        payment_method="online",
+        payment_intent_id="pi_test_123",
+    )
+    db.add(order)
+    db.commit()
+    order_id = order.id
+    db.close()
+
+    monkeypatch.setenv("STRIPE_SECRET_KEY", "sk_test_dummy")
+    monkeypatch.setenv("STRIPE_WEBHOOK_SECRET", "whsec_dummy")
+
+    from app.api import payments as payments_api
+
+    class FakeEvent(dict):
+        pass
+
+    def fake_construct_event(payload, sig, secret):
+        return {
+            "type": "payment_intent.succeeded",
+            "data": {"object": {"id": "pi_test_123"}},
+        }
+
+    monkeypatch.setattr(payments_api.stripe.Webhook, "construct_event", fake_construct_event)
+
+    response = client.post(
+        "/api/payments/webhook",
+        content=b"{}",
+        headers={"Stripe-Signature": "t=1,v1=abc"},
+    )
+    assert response.status_code == 200
+
+    db = TestingSessionLocal()
+    order = db.query(Order).filter(Order.id == order_id).one()
+    assert order.status == "CONFIRMED"
+    db.close()

--- a/checkout.html
+++ b/checkout.html
@@ -142,6 +142,12 @@
             </div>
           </div>
 
+        <p id="stripe-pay-hint" style="display:none;font-size:0.85rem;color:var(--text-muted,#555);margin:8px 0 12px;">
+          Card data is processed by Stripe. Cara never stores raw card numbers.
+        </p>
+        <div id="stripe-payment-element" style="display:none;margin-bottom:12px;min-height:40px;"></div>
+
+        <div id="legacy-card-fields">
         <div class="input-group">
           <label for="cardName">Card Holder Name</label>
           <input type="text" id="cardName" placeholder="Card holder name" autocomplete="cc-name" data-validate="cardName">
@@ -191,6 +197,8 @@
             >
             <span class="error-msg"></span>
           </div>
+        </div>
+        </div>
 
       <!-- COLUMN PREVIEW OR SIDEBAR -->
       <div class="totals-sidebar">

--- a/checkout.js
+++ b/checkout.js
@@ -240,13 +240,32 @@ cardName.addEventListener('input', function () {
 });
 
 // --- Show/Hide Card Details and clear validation states ---
+let stripePaymentsEnabled = false;
+fetch(`${API_BASE_URL}/api/payments/config`, { credentials: 'include' })
+  .then((r) => r.json())
+  .then((cfg) => {
+    stripePaymentsEnabled = !!(cfg && cfg.enabled && cfg.publishable_key);
+    const hint = document.getElementById('stripe-pay-hint');
+    const mount = document.getElementById('stripe-payment-element');
+    const legacy = document.getElementById('legacy-card-fields');
+    if (stripePaymentsEnabled) {
+      if (hint) hint.style.display = 'block';
+      if (mount) mount.style.display = 'block';
+      if (legacy) legacy.style.display = 'none';
+    }
+  })
+  .catch(() => {
+    stripePaymentsEnabled = false;
+  });
+
 paymentMethod.addEventListener('change', function () {
   if (this.value === 'online') {
     cardDetails.style.display = 'block';
-    cardName.required = true;
-    cardNumber.required = true;
-    expiry.required = true;
-    cvv.required = true;
+    const requireLegacy = !stripePaymentsEnabled;
+    cardName.required = requireLegacy;
+    cardNumber.required = requireLegacy;
+    expiry.required = requireLegacy;
+    cvv.required = requireLegacy;
   } else {
     cardDetails.style.display = 'none';
     cardName.required = false;
@@ -256,9 +275,10 @@ paymentMethod.addEventListener('change', function () {
 
     // Clear card fields and errors
     paymentFields.forEach(function (field) {
+      if (!field) return;
       field.value = '';
       field.classList.remove('is-valid', 'is-invalid');
-      const errEl = field.parentElement.querySelector('.error-msg');
+      const errEl = field.parentElement && field.parentElement.querySelector('.error-msg');
       if (errEl) errEl.textContent = '';
     });
   }
@@ -366,6 +386,7 @@ function submitCheckoutForm() {
     city: document.getElementById('city').value.trim(),
     zip: document.getElementById('zip').value.trim(),
     coupon: window.appliedCoupon,
+    payment_method: (paymentMethod && paymentMethod.value) || 'cod',
     idempotency_key: checkoutIdempotencyKey,
     items: cart.map((item) => ({
       product_name: item.name,
@@ -392,9 +413,17 @@ function submitCheckoutForm() {
           throw err;
         }),
     )
-    .then((res) => {
+    .then(async (res) => {
       if (!res.ok) {
-        throw new Error(res.body.detail || 'Failed to place order');
+        const detail = res.body && res.body.detail;
+        throw new Error(
+          typeof detail === 'string' ? detail : 'Failed to place order',
+        );
+      }
+
+      // Online orders stay PENDING until Stripe webhook confirms payment.
+      if (res.body.needs_payment) {
+        await completeStripePayment(res.body.order_id);
       }
 
       // DEDUCT & ADD LOYALTY POINTS ON SUCCESSFUL ORDER
@@ -461,6 +490,67 @@ function submitCheckoutForm() {
       
       releaseWakeLock();
     });
+}
+
+async function completeStripePayment(orderId) {
+  const configRes = await fetch(`${API_BASE_URL}/api/payments/config`, {
+    credentials: 'include',
+  });
+  const config = await configRes.json();
+  if (!config.enabled || !config.publishable_key) {
+    throw new Error(
+      'Card payment requires Stripe keys (STRIPE_SECRET_KEY / STRIPE_PUBLISHABLE_KEY).',
+    );
+  }
+
+  const intentRes = await fetch(`${API_BASE_URL}/api/payments/create-intent`, {
+    method: 'POST',
+    headers: buildAuthHeaders({ 'Content-Type': 'application/json' }),
+    credentials: 'include',
+    body: JSON.stringify({ order_id: orderId }),
+  });
+  const intentBody = await intentRes.json();
+  if (!intentRes.ok) {
+    throw new Error(
+      typeof intentBody.detail === 'string'
+        ? intentBody.detail
+        : 'Could not start payment',
+    );
+  }
+
+  await loadStripeJs();
+  const stripe = window.Stripe(config.publishable_key);
+  const mount = document.getElementById('stripe-payment-element');
+  if (!mount) {
+    throw new Error('Stripe payment form is missing on this page.');
+  }
+
+  const elements = stripe.elements({ clientSecret: intentBody.client_secret });
+  if (!mount.dataset.mounted) {
+    const paymentElement = elements.create('payment');
+    paymentElement.mount('#stripe-payment-element');
+    mount.dataset.mounted = '1';
+  }
+
+  const { error } = await stripe.confirmPayment({
+    elements,
+    redirect: 'if_required',
+  });
+  if (error) {
+    throw new Error(error.message || 'Payment failed');
+  }
+  // Final CONFIRMED status is set by the Stripe webhook — never by this browser response alone.
+}
+
+function loadStripeJs() {
+  if (window.Stripe) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = 'https://js.stripe.com/v3/';
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error('Failed to load Stripe.js'));
+    document.head.appendChild(script);
+  });
 }
 
 window.closePopup = function () {


### PR DESCRIPTION
## 📄 Description

Online checkout no longer marks orders CONFIRMED on create. Stripe PaymentIntents and webhook confirmation own the paid state; Cara never stores raw card data.

## 🔗 Related Issues

Closes #4927

## 🧩 Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## 🛠️ What Was Changed

- /api/payments/config, create-intent, webhook
- Online orders start PENDING; webhook sets CONFIRMED
- Checkout mounts Stripe Payment Element; COD unchanged
- stripe dependency + env example keys

## why this needed

Checkout collected card fields client-side but never charged a PSP, so every order was confirmed unpaid.

## 🧪 How Has This Been Tested?

pytest tests/test_payments.py tests/test_order_idempotency.py — 7 passed

## ✅ Checklist

- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #IssueNumber`)
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue