### PR TITLE
fix(coupons): drop FLAT15/FREESHIP so client matches backend (#5082)

### DIFF
--- a/js/promo-discount-calculator.js
+++ b/js/promo-discount-calculator.js
@@ -7,9 +7,7 @@ class PromoDiscountCalculator {
   constructor() {
     this.coupons = {
       'WELCOME10': { type: 'percent', value: 10, minSpend: 20 },
-      'CARA20': { type: 'percent', value: 20, minSpend: 50 },
-      'FLAT15': { type: 'flat', value: 15, minSpend: 40 },
-      'FREESHIP': { type: 'freeship', value: 0, minSpend: 30 }
+      'CARA20': { type: 'percent', value: 20, minSpend: 50 }
     };
     this.freeShippingThreshold = 75;
   }

--- a/tests/unit/promo-discount-calculator.test.js
+++ b/tests/unit/promo-discount-calculator.test.js
@@ -28,12 +28,9 @@ describe('PromoDiscountCalculator Unit Tests', () => {
     expect(summary.grandTotal).toBe(90);
   });
 
-  it('should calculate flat discount correctly', () => {
-    const summary = calc.calculateTotal(50, 'FLAT15', 10);
-    expect(summary.subtotal).toBe(50);
-    expect(summary.discount).toBe(15);
-    expect(summary.shipping).toBe(10);
-    expect(summary.grandTotal).toBe(45);
+  it('should reject coupon codes the backend does not support', () => {
+    expect(calc.validateCoupon('FLAT15', 50).valid).toBe(false);
+    expect(calc.validateCoupon('FREESHIP', 50).valid).toBe(false);
   });
 
   it('should cap discount to maxCap threshold', () => {


### PR DESCRIPTION
## Problem

The client-side `promo-discount-calculator.js` hard-coded coupon codes `FLAT15` and `FREESHIP`, while the backend (`COUPONS = {"CARA20": 20, "WELCOME10": 10}`) does not define them. The client accepted codes the backend would never honor, so the coupon system was inconsistent between client and server.

## Fix

- Removed `FLAT15` and `FREESHIP` from `js/promo-discount-calculator.js`.
- Updated the unit test so these codes are now asserted to be rejected.
- The backend `COUPONS` map is now the single source of truth for valid coupon codes.

## Files changed

- `js/promo-discount-calculator.js`
- `tests/unit/promo-discount-calculator.test.js`

## Testing

- `npm test` unit tests updated to assert `FLAT15`/`FREESHIP` are rejected; `CARA20`/`WELCOME10` still pass.

Closes #5082
