### PR TITLE
fix(products): expose catalog on window.products for live-sales toasts (#5083)

### DIFF
--- a/products.js
+++ b/products.js
@@ -999,6 +999,10 @@ function showToast(message, type = 'success') {
 }
 
 // Skeleton UI integration added
+if (typeof window !== 'undefined') {
+  window.products = products;
+}
+
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = { products };
 }


### PR DESCRIPTION
## Problem

`js/live-sales-toast.js` reads product data from `window.products`, but the products page (`products.js`) never assigned the loaded catalog to `window.products`. As a result the live-sales toasts fail to resolve product names/images (undefined references) whenever a toast fires on the products page.

## Fix

- In `products.js`, after loading the catalog, expose it as `window.products = products` so live-sales toasts (and any other consumers) can read the catalog.

## Files changed

- `products.js`

## Testing

- Manually triggered a live-sales toast on the products page and confirmed it now resolves the product name/image from `window.products` instead of an undefined reference.

Closes #5083
