### PR TITLE
fix(recommend): lazy faiss import + brute-force fallback on real embeddings (#5086)

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 *.pyc
 cara.db
 faiss_index.bin
+faiss_embeddings.npz

--- a/backend/app/vector_search/faiss_index.py
+++ b/backend/app/vector_search/faiss_index.py
@@ -1,39 +1,97 @@
-import faiss
 import os
 import numpy as np
 
 index_path = os.path.join(os.path.dirname(__file__), '..', '..', 'faiss_index.bin')
-index = None
+embeddings_path = os.path.join(os.path.dirname(__file__), '..', '..', 'faiss_embeddings.npz')
 
-if os.path.exists(index_path):
-    index = faiss.read_index(index_path)
-else:
-    print("Warning: FAISS index not found. Please run precompute_embeddings.py")
+
+def _load_faiss():
+    """Import faiss lazily so the API still boots when it is unavailable."""
+    try:
+        import faiss
+        return faiss
+    except Exception:
+        return None
+
+
+def _load_index(faiss):
+    """Load the persisted FAISS index if the library and file are available."""
+    if faiss is None:
+        return None
+    if not os.path.exists(index_path):
+        print("Warning: FAISS index not found. Please run precompute_embeddings.py")
+        return None
+    try:
+        return faiss.read_index(index_path)
+    except Exception as e:
+        print(f"Warning: Failed to load FAISS index: {e}")
+        return None
+
+
+def _load_embeddings():
+    """Load the persisted product embeddings for brute-force search."""
+    if not os.path.exists(embeddings_path):
+        return None, None
+    try:
+        data = np.load(embeddings_path)
+        return data['ids'], data['embeddings']
+    except Exception as e:
+        print(f"Warning: Failed to load persisted embeddings: {e}")
+        return None, None
+
+
+faiss = _load_faiss()
+index = _load_index(faiss)
+embedding_ids, embeddings = _load_embeddings()
+
+
+def _query_embedding(product_id):
+    """Resolve the stored embedding for a product, preferring persisted data."""
+    if embedding_ids is not None and embeddings is not None:
+        match = np.where(embedding_ids == product_id)[0]
+        if match.size:
+            return embeddings[match[0]]
+
+    if faiss is not None and index is not None:
+        try:
+            emb = np.zeros((index.d,), dtype='float32')
+            index.reconstruct(product_id, emb)
+            return emb
+        except Exception:
+            pass
+
+    return None
+
+
+def _brute_force_similar(query, product_id, top_k):
+    """NumPy L2-nearest-neighbour search over persisted embeddings."""
+    if embedding_ids is None or embeddings is None:
+        return []
+    if len(embeddings) == 0:
+        return []
+
+    diffs = embeddings - query
+    distances = np.einsum('ij,ij->i', diffs, diffs)
+    k = min(top_k, len(distances))
+    nearest = np.argpartition(distances, k - 1)[:k]
+    nearest = nearest[np.argsort(distances[nearest])]
+    ids = [int(embedding_ids[i]) for i in nearest]
+    return [i for i in ids if i != product_id]
+
 
 def get_similar_product_ids(product_id: int, top_k: int = 10):
-    if index is None:
+    if top_k <= 0:
         return []
-    
-    # Retrieve embedding for the given product_id
-    try:
-        # We need to map product_id to the embedding vector.
-        # Faiss IndexIDMap allows us to search by vector, but not retrieve vector by ID directly easily in basic FlatL2.
-        # Let's reconstruct the vector if possible, or we could just use a cached embedding dict.
-        # For simplicity, we will reconstruct it if the index supports it. IndexFlatL2 doesn't support reconstruct directly with IDMap.
-        # A simpler way is to just generate the synthetic vector again using the same seed to query.
-        
-        # Fallback synthetic embedding generator based on product ID to match seed_data / precompute
-        d = 512
-        np.random.seed(product_id)
-        emb = np.random.rand(d).astype('float32')
-        emb = emb / np.linalg.norm(emb)
-        
-        # Search
-        distances, indices = index.search(np.array([emb]), top_k)
-        
-        # Filter out self and return
-        return [int(idx) for idx in indices[0] if idx != -1 and idx != product_id]
-        
-    except Exception as e:
-        print(f"Error in vector search: {e}")
+
+    query = _query_embedding(product_id)
+    if query is None:
         return []
+
+    if faiss is not None and index is not None:
+        try:
+            distances, indices = index.search(np.array([query]), top_k)
+            return [int(idx) for idx in indices[0] if idx != -1 and idx != product_id]
+        except Exception as e:
+            print(f"Error in vector search: {e}")
+
+    return _brute_force_similar(query, product_id, top_k)

--- a/backend/scripts/precompute_embeddings.py
+++ b/backend/scripts/precompute_embeddings.py
@@ -65,7 +65,15 @@ def precompute():
         ids.append(p.id)
         
     embeddings_np = np.array(embeddings).astype('float32')
-    
+
+    # Persist embeddings alongside the index so the API can run a NumPy
+    # brute-force search when faiss is unavailable at runtime.
+    np.savez(
+        os.path.join(os.path.dirname(__file__), '..', 'faiss_embeddings.npz'),
+        ids=np.array(ids).astype('int64'),
+        embeddings=embeddings_np,
+    )
+
     # Map faiss ids to product ids
     index_id_map = faiss.IndexIDMap(index)
     index_id_map.add_with_ids(embeddings_np, np.array(ids).astype('int64'))


### PR DESCRIPTION
## Problem

`faiss_index.py` imported `faiss` at module load time, so the backend would fail to boot on environments without FAISS installed. Embeddings were also recomputed from scratch every run, making the module expensive and fragile.

## Fix

- Lazy-imported `faiss` so the backend starts without FAISS.
- When FAISS is unavailable, fall back to brute-force NumPy L2 search over persisted embeddings (`faiss_embeddings.npz`).
- Persisted embeddings to disk (`backend/.gitignore` updated) so they are reused across runs; `get_similar_product_ids` returns `[]` only when no data exists.

## Files changed

- `backend/app/vector_search/faiss_index.py`
- `backend/scripts/precompute_embeddings.py`
- `backend/.gitignore`

## Testing

- Backend boots without FAISS installed and falls back to brute-force search.
- With FAISS present, indexing and similarity search still work.
- `get_similar_product_ids` returns results when embeddings exist and `[]` when none do.

Closes #5086
