### PR TITLE
fix(checkout): move scripts inside closing body tag (#5089)

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -293,9 +293,8 @@
   <script type="module" src="js/checkout-validator.js"></script>
   <script type="module" src="js/address-validation-service.js" defer></script>
   <script type="module" src="js/address-autocomplete.js" defer></script>
+  <script src="js/checkout-vault.js"></script>
+  <script src="js/checkout-wizard.js"></script>
+  <script type="module" src="js/pincode-validation-engine.js"></script>
 </body>
 </html>
-
-<script src="js/checkout-vault.js"></script>
-<script src="js/checkout-wizard.js"></script>
-<script type="module" src="js/pincode-validation-engine.js"></script>


### PR DESCRIPTION
## Problem

`checkout.html` loaded `checkout-vault.js`, `checkout-wizard.js`, and `pincode-validation-engine.js` outside the body (after `</html>`), producing invalid markup and risking undefined `document` references when scripts execute too early.

## Fix

- Moved all three scripts inside `</body>`, before `</html>`, so they load in a valid document position after the DOM is available.

## Files changed

- `checkout.html`

## Testing

- Loaded the checkout page and confirmed all scripts run with `document` available; no errors in the console.

Closes #5089
