### PR TITLE
fix(checkout): remove unused feature object instantiations (#5090)

### DIFF
--- a/checkout.js
+++ b/checkout.js
@@ -50,7 +50,6 @@ function safeParseJSON(key, fallback = '[]') {
 }
 
 const API_BASE_URL = window.CARA_API_BASE_URL || '';
-const promoCalcEngine = typeof PromoDiscountCalculator !== 'undefined' ? new PromoDiscountCalculator() : null;
 
 
 function buildAuthHeaders(extraHeaders = {}) {

--- a/js/address-autocomplete.js
+++ b/js/address-autocomplete.js
@@ -11,7 +11,6 @@
 
   const DEBOUNCE_MS = 300;
   const SUGGEST_API = '/api/address/suggest';
-  const addressService = typeof AddressValidationService !== 'undefined' ? new AddressValidationService() : null;
 
   // ── DOM References ─────────────────────────────────────────────────────────
   const addressInput = document.getElementById('address');

--- a/track-order.js
+++ b/track-order.js
@@ -10,9 +10,6 @@ if (copyrightYearEl) {
   copyrightYearEl.textContent = new Date().getFullYear();
 }
 
-const telemetryEngine = typeof OrderTelemetryTracker !== 'undefined' ? new OrderTelemetryTracker() : null;
-// In a real app this would be a backend API call.
-// We use a demo entry so reviewers can test the UI immediately.
 const MOCK_ORDERS = {
   'CARA-20261234': {
     id: 'CARA-20261234',


### PR DESCRIPTION
## Problem

Three feature objects were instantiated but never used, leaving dead code and a misleading impression of half-wired integrations:

- `promoCalcEngine` (`checkout.js`) — instantiated `PromoDiscountCalculator` never referenced; checkout discount is handled by `CARA_COUPONS`.
- `addressService` (`js/address-autocomplete.js`) — instantiated `AddressValidationService` never referenced; suggestions come straight from the fetch call.
- `telemetryEngine` (`track-order.js`) — instantiated `OrderTelemetryTracker` never referenced; the page uses mocked order data.

## Fix

- Removed all three unused instantiations. The underlying classes remain defined and tested (`promo-discount-calculator.js`, `address-validation-service.js`, `order-telemetry-tracker.js`) and are used where appropriate.

## Files changed

- `checkout.js`
- `js/address-autocomplete.js`
- `track-order.js`

## Testing

- `node --check` passes on all three files.
- Grepped the repo to confirm no remaining references to `promoCalcEngine`, `addressService`, or `telemetryEngine`.
- Loaded checkout, address-autocomplete, and track-order pages; behavior unchanged.

Closes #5090
