### PR TITLE
fix: exported orphaned getErrorFallbackHTML function from error-boundary.js

### DIFF
--- a/js/error-boundary.js
+++ b/js/error-boundary.js
@@ -75,3 +75,6 @@ function getErrorFallbackHTML(message) {
   }
   return '<div class="error-fallback-box"><p>' + message + '</p></div>';
 }
+
+// Expose utility function globally for external use
+window.getErrorFallbackHTML = getErrorFallbackHTML;


### PR DESCRIPTION
## 📄 Description
Export the orphaned getErrorFallbackHTML function from error-boundary.js so it can be reused by other modules and unit tested. The function was defined but not exported, making it dead code within the module.

## 🔗 Related Issues
Closes #5109

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.