### PR TITLE
feat: implement Compute Pressure API to dynamically throttle heavy an…

### DIFF
--- a/app.js
+++ b/app.js
@@ -1641,7 +1641,13 @@ function initHeroSlider() {
   }
   function resetAutoPlay() {
     clearInterval(autoPlayInterval);
-    autoPlayInterval = setInterval(nextSlide, intervalTime);
+    autoPlayInterval = setInterval(() => {
+      if (document.documentElement.getAttribute('data-compute-pressure') === 'high') {
+        // Defer next slide to save compute
+        return;
+      }
+      nextSlide();
+    }, intervalTime);
   }
 
   if (nextBtn)
@@ -2428,4 +2434,21 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 });
+
+// Compute Pressure API Implementation
+if ('PressureObserver' in globalThis) {
+  try {
+    const observer = new PressureObserver((records) => {
+      const lastRecord = records[records.length - 1];
+      if (lastRecord.state === 'serious' || lastRecord.state === 'critical') {
+        document.documentElement.setAttribute('data-compute-pressure', 'high');
+      } else {
+        document.documentElement.removeAttribute('data-compute-pressure');
+      }
+    });
+    observer.observe('cpu');
+  } catch (error) {
+    window.logError('Compute Pressure API is supported but failed to observe CPU:', error);
+  }
+}
 })();

--- a/global.css
+++ b/global.css
@@ -3517,3 +3517,19 @@ footer .copyright {
 .autocomplete-spinner {
   animation: spin 0.6s linear infinite;
 }
+
+
+/* Compute Pressure API: gracefully degrade animations */
+html[data-compute-pressure="high"] *,
+html[data-compute-pressure="high"] *::before,
+html[data-compute-pressure="high"] *::after {
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.01ms !important;
+  scroll-behavior: auto !important;
+}
+
+html[data-compute-pressure="high"] .slide.active {
+  animation: none !important;
+}
+


### PR DESCRIPTION
# 📋 Summary
Implemented the modern Compute Pressure API using `PressureObserver` to detect CPU thermal-throttling. It dynamically throttles heavy CSS animations, transitions, and auto-playing carousels when the CPU pressure is 'serious' or 'critical' to save battery and significantly reduce frame drops and jank on low-end devices.

---

## 🔗 Related Issue
Closes #5121

---

## 🔄 Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Style / UI improvement (Performance & UX)
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

---

## 🛠️ What Was Changed
- Integrated `PressureObserver` in `app.js` to subscribe to the 'cpu' state.
- Added logic to dynamically toggle a `data-compute-pressure="high"` attribute on the `<html>` tag based on real-time pressure reports.
- Paused the hero-slider's auto-play interval dynamically in `app.js` when compute pressure is high.
- Added CSS rules in `global.css` that use the `html[data-compute-pressure="high"]` selector to instantly degrade `animation-duration` and `transition-duration` to `0.01ms` site-wide, gracefully pausing heavy visual effects until the device cools down.

---

## why this needed
- When users on low-end mobile devices visit our site during hot weather or while running heavy background apps, their CPU often thermal-throttles. 
- Relying strictly on `requestAnimationFrame` metrics is too reactive (the device is already struggling by the time we detect frame drops). 
- Pausing heavy animations proactively ensures that we prevent severe jank, rapid battery drain, and unresponsiveness, greatly improving the overall user experience.

---

## 🧪 How Has This Been Tested?

- [ ] Tested backend API endpoints manually
- [x] Ran frontend locally with `npm run dev`
- [x] Ran `npm run lint` — no errors
- [x] Ran `npm run build` — no errors
- [ ] Uploaded a test document and verified output
- [x] Tested on mobile view

*(Note: Unit tests were verified and passed successfully via `vitest` during the git commit hooks)*

---

## ✅ Self-Review Checklist

- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #5121`)
- [x] I have tested my changes locally
- [ ] I have added screenshots for UI changes
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue

---

## 📋 Additional Notes

The fallback is robust: if a browser doesn't support the Compute Pressure API, the `PressureObserver` check is safely bypassed and users will experience the normal baseline behavior.