### PR TITLE
fix: fixed ReferenceError from document default parameter in grid-cls-optimizer

### DIFF
--- a/js/grid-cls-optimizer.js
+++ b/js/grid-cls-optimizer.js
@@ -10,9 +10,10 @@ export class GridClsOptimizer {
   }
 
 
-  cleanupReservedDimensions(container = document) {
+  cleanupReservedDimensions(container = null) {
     if (typeof document === 'undefined') return { cleaned: 0 };
-    const images = container.querySelectorAll ? container.querySelectorAll(this.targetSelector) : [];
+    const root = container || document;
+    const images = root.querySelectorAll ? root.querySelectorAll(this.targetSelector) : [];
     let cleaned = 0;
     images.forEach((img) => {
       if (img.classList.contains('cls-optimized') && img.complete) {
@@ -23,10 +24,11 @@ export class GridClsOptimizer {
     return { cleaned };
   }
 
-  optimizeGridImages(container = document) {
+  optimizeGridImages(container = null) {
     if (typeof document === 'undefined') return { count: 0 };
 
-    const images = container.querySelectorAll ? container.querySelectorAll(this.targetSelector) : [];
+    const root = container || document;
+    const images = root.querySelectorAll ? root.querySelectorAll(this.targetSelector) : [];
     let count = 0;
 
     images.forEach((img) => {

--- a/tests/unit/grid-cls-optimizer.test.js
+++ b/tests/unit/grid-cls-optimizer.test.js
@@ -47,4 +47,18 @@ describe('GridClsOptimizer Unit Tests', () => {
     expect(img.classList.contains('cls-optimized')).toBe(false);
   });
 
+  it('should not throw when document is undefined (non-DOM environment)', async () => {
+    // Temporarily hide the global document to simulate a non-DOM environment.
+    const originalDocument = globalThis.document;
+    Object.defineProperty(globalThis, 'document', { value: undefined, writable: true, configurable: true });
+    try {
+      const res = optimizer.cleanupReservedDimensions();
+      expect(res.cleaned).toBe(0);
+      const optRes = optimizer.optimizeGridImages();
+      expect(optRes.count).toBe(0);
+    } finally {
+      Object.defineProperty(globalThis, 'document', { value: originalDocument, writable: true, configurable: true });
+    }
+  });
+
 });


### PR DESCRIPTION
## 📄 Description
Fixed a ReferenceError in js/grid-cls-optimizer.js where cleanupReservedDimensions and optimizeGridImages used the global document as a default parameter. The default was evaluated before the typeof document guard could protect the call, so the methods crashed in non-DOM environments such as Node.js or unit tests. The document reference is now resolved lazily inside the method body, and a unit test verifies the non-DOM path returns an empty result instead of throwing.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5124

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.