### PR TITLE
fix: fixed average rating miscount for string ratings in reviews

### DIFF
--- a/js/reviews.js
+++ b/js/reviews.js
@@ -70,15 +70,19 @@
   function _calcStats(reviews) {
     if (!reviews.length) return { avg: 0, total: 0, dist: [0, 0, 0, 0, 0] };
     const dist = [0, 0, 0, 0, 0];
+    let counted = 0;
     const sum = reviews.reduce((acc, r) => {
-      if (typeof r.rating === 'number' && r.rating >= 1 && r.rating <= 5) {
-        dist[r.rating - 1]++;
-        return acc + r.rating;
+      // Normalize numeric-string ratings (e.g. "5") before aggregation.
+      const rating = typeof r.rating === 'string' ? parseInt(r.rating, 10) : r.rating;
+      if (typeof rating === 'number' && rating >= 1 && rating <= 5) {
+        dist[rating - 1]++;
+        counted++;
+        return acc + rating;
       }
       return acc;
     }, 0);
     return {
-      avg: parseFloat((sum / reviews.length).toFixed(1)),
+      avg: counted > 0 ? parseFloat((sum / counted).toFixed(1)) : 0,
       total: reviews.length,
       dist,
     };

--- a/tests/unit/reviews.test.js
+++ b/tests/unit/reviews.test.js
@@ -167,4 +167,42 @@ describe('reviews.js unit tests', function () {
     expect(result.length).toBe(1);
     expect(result[0].rating).toBe(5);
   });
+
+  it('renders a correct aggregate average when ratings arrive as strings', function () {
+    // Seed reviews with a numeric rating and a numeric-string rating.
+    storage['cara_reviews_strpid'] = JSON.stringify([
+      { id: 1, rating: 5, author: 'Alice' },
+      { id: 2, rating: '5', author: 'Bob' },
+      { id: 3, rating: 1, author: 'Carol' }
+    ]);
+
+    document.body.innerHTML =
+      '<div id="productReviews" data-product-id="strpid"></div>';
+
+    // Re-evaluate the real source in the current DOM so _render runs _calcStats.
+    var fs = require('node:fs');
+    var vm = require('node:vm');
+    var src = fs.readFileSync(require.resolve('../../js/reviews.js'), 'utf8');
+    var sandbox = {
+      window: window,
+      document: document,
+      localStorage: localStorage,
+      console: console,
+      ProductReviewAggregator: undefined,
+      CustomEvent: window.CustomEvent,
+      Intl: Intl,
+      Date: Date,
+      setTimeout: setTimeout
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(src, sandbox, { filename: 'reviews.js' });
+
+    // _render runs on DOMContentLoaded/readyState; force a manual invoke by
+    // dispatching the event the module listens for.
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    var aggregateNumber = document.querySelector('.aggregate-number');
+    expect(aggregateNumber).toBeTruthy();
+    expect(aggregateNumber.textContent.trim()).toBe('3.7');
+  });
 });


### PR DESCRIPTION
## 📄 Description
Fixed _calcStats in js/reviews.js so numeric-string ratings (for example "5") are normalized before aggregation. They now contribute to the average and distribution instead of only inflating the review-count denominator, which produced wrong star averages for data arriving with string-typed ratings. Added a unit test that renders the aggregate for a mixed numeric/string dataset.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5125

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.