### PR TITLE
fix: fixed CSV quote escaping in wishlist export

### DIFF
--- a/js/wishlist-export-share.js
+++ b/js/wishlist-export-share.js
@@ -39,7 +39,17 @@ export class WishlistExportShare {
   exportToCSV(items = []) {
     if (!Array.isArray(items) || items.length === 0) return '';
     const headers = ['ID', 'Name', 'Price'];
-    const rows = items.map(item => `"${item.id || ''}","${item.name || ''}","${item.price || ''}"`);
+    const escapeCsv = (value) => {
+      const str = value == null ? '' : String(value);
+      // Standard CSV escaping: double up embedded quotes, then wrap in quotes.
+      return `"${str.replace(/"/g, '""')}"`;
+    };
+    const rows = items.map(
+      (item) =>
+        [escapeCsv(item.id), escapeCsv(item.name), escapeCsv(item.price)].join(
+          ',',
+        ),
+    );
     return [headers.join(','), ...rows].join('\n');
   }
 

--- a/tests/unit/wishlist-export-share.test.js
+++ b/tests/unit/wishlist-export-share.test.js
@@ -31,4 +31,16 @@ describe('WishlistExportShare', () => {
     expect(csv).toContain('ID,Name,Price');
     expect(csv).toContain('"p1","Cotton Shirt","29.99"');
   });
+
+  it('should escape embedded quotes in CSV fields', () => {
+    const items = [
+      { id: 'p3', name: 'T-Shirt "Classic" Edition', price: 19.99 }
+    ];
+    const csv = exporter.exportToCSV(items);
+    expect(csv).toContain('"p3","T-Shirt ""Classic"" Edition","19.99"');
+    // The quoted field must remain a single parseable column.
+    const nameField = csv.split('\n')[1].split(',')[1];
+    expect(nameField.startsWith('"')).toBe(true);
+    expect(nameField.endsWith('"')).toBe(true);
+  });
 });


### PR DESCRIPTION
## 📄 Description
Fixed exportToCSV in js/wishlist-export-share.js to escape embedded double quotes in CSV fields using the standard double-quote doubling. Product names containing quotes now export as a single parseable column instead of malformed CSV. Added a unit test covering names with embedded quotes.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5126

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.