### PR TITLE
fix: fixed excludeId and excludeName logic in recently-viewed render

### DIFF
--- a/js/recently-viewed.js
+++ b/js/recently-viewed.js
@@ -144,8 +144,12 @@
       : null;
 
     const list = getRecentlyViewed().filter((item) => {
-      if (options.excludeId != null) return item.id !== options.excludeId;
-      if (options.excludeName) return item.name !== options.excludeName;
+      if (options.excludeId != null && item.id === options.excludeId) {
+        return false;
+      }
+      if (options.excludeName && item.name === options.excludeName) {
+        return false;
+      }
       return true;
     });
 

--- a/tests/unit/recently-viewed.test.js
+++ b/tests/unit/recently-viewed.test.js
@@ -187,6 +187,26 @@ describe('renderRecentlyViewed', () => {
     );
   });
 
+  it('applies both excludeId and excludeName when both are provided', () => {
+    setUpDom();
+    RecentlyViewed.addRecentlyViewed(product({ id: 1, name: 'A' }));
+    RecentlyViewed.addRecentlyViewed(product({ id: 2, name: 'B' }));
+    RecentlyViewed.addRecentlyViewed(product({ id: 3, name: 'C' }));
+
+    const list = RecentlyViewed.renderRecentlyViewed({
+      containerId: 'recently-viewed-container',
+      sectionId: 'recently-viewed-section',
+      excludeId: 2,
+      excludeName: 'A',
+    });
+
+    expect(list).toHaveLength(1);
+    expect(list[0].name).toBe('C');
+    expect(
+      document.getElementById('recently-viewed-container').children,
+    ).toHaveLength(1);
+  });
+
   it('does nothing when the container is missing from the DOM', () => {
     document.body.innerHTML = '';
     expect(() =>


### PR DESCRIPTION
## 📄 Description
Fixed renderRecentlyViewed in js/recently-viewed.js so excludeId and excludeName are applied as independent filters. Previously the if/else chain meant the name exclusion was silently ignored whenever an id exclusion was also supplied. Added a unit test covering the both-exclusions case.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5127

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.