### PR TITLE
fix: returned a usable result from lazyload fallback path

### DIFF
--- a/js/lazyload-observer.js
+++ b/js/lazyload-observer.js
@@ -13,14 +13,20 @@ export function initLazyLoadObserver(selector = 'img.lazyload', options = {}) {
   const lazyImages = Array.from(document.querySelectorAll(selector));
 
   if (!('IntersectionObserver' in window)) {
-    // Fallback for browsers without IntersectionObserver
+    // Fallback for browsers without IntersectionObserver: load images immediately.
     lazyImages.forEach((img) => {
       if (img.dataset.src) img.src = img.dataset.src;
       if (img.dataset.srcset) img.srcset = img.dataset.srcset;
       img.classList.remove('lazyload');
       img.classList.add('lazyloaded');
     });
-    return null;
+    // Return a minimal observer-like object so the return contract is consistent.
+    return {
+      observe: () => {},
+      unobserve: () => {},
+      disconnect: () => {},
+      isFallback: true,
+    };
   }
 
   const observer = new IntersectionObserver((entries, obs) => {
@@ -31,7 +37,7 @@ export function initLazyLoadObserver(selector = 'img.lazyload', options = {}) {
         if (img.dataset.srcset) img.srcset = img.dataset.srcset;
         img.classList.remove('lazyload');
         img.classList.add('lazyloaded');
-        obs.unobserve(img);
+        unobserveLazyElement(obs, img);
       }
     });
   }, defaultOptions);

--- a/tests/unit/lazyload-observer.test.js
+++ b/tests/unit/lazyload-observer.test.js
@@ -15,10 +15,15 @@ describe('IntersectionObserver Lazy Load Unit Tests', () => {
     img.dataset.src = 'img/products/f1.jpg';
     document.body.appendChild(img);
 
-    initLazyLoadObserver('img.lazyload');
+    const result = initLazyLoadObserver('img.lazyload');
 
     expect(img.src).toContain('img/products/f1.jpg');
     expect(img.classList.contains('lazyloaded')).toBe(true);
+    // The fallback path returns a usable observer-like object.
+    expect(result).toBeTruthy();
+    expect(result.isFallback).toBe(true);
+    expect(typeof result.unobserve).toBe('function');
+    expect(() => result.unobserve()).not.toThrow();
 
     window.IntersectionObserver = originalObserver;
   });


### PR DESCRIPTION
## 📄 Description
Fixed initLazyLoadObserver in js/lazyload-observer.js so the no-IntersectionObserver fallback returns a minimal observer-like object with unobserve and disconnect no-ops instead of null. The IntersectionObserver callback now reuses the previously orphaned unobserveLazyElement helper. Updated the fallback unit test to verify the returned object.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5128

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.