### PR TITLE
fix: exported orphaned createTimeoutSignalHelper from fetch-timeout

### DIFF
--- a/js/fetch-timeout.js
+++ b/js/fetch-timeout.js
@@ -21,7 +21,7 @@ function fetchWithTimeout(url, options = {}, ms = 10000) {
 
 // Allow import in test / Node environments
 if (typeof module !== 'undefined') {
-  module.exports = { fetchWithTimeout };
+  module.exports = { fetchWithTimeout, createTimeoutSignalHelper };
 }
 
 

--- a/tests/unit/fetch-timeout.test.js
+++ b/tests/unit/fetch-timeout.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
-const { fetchWithTimeout } = require('../../js/fetch-timeout.js');
+const { fetchWithTimeout, createTimeoutSignalHelper } = require('../../js/fetch-timeout.js');
 
 describe('fetchWithTimeout', () => {
   beforeEach(() => {
@@ -71,4 +71,27 @@ describe('fetchWithTimeout', () => {
   });
 
   it('should handle fetchWithTimeout correctly', () => { expect(true).toBe(true); });
+
+  describe('createTimeoutSignalHelper', () => {
+    it('returns an AbortSignal and a cleanup function', () => {
+      const helper = createTimeoutSignalHelper(10000);
+      expect(helper.signal).toBeInstanceOf(AbortSignal);
+      expect(typeof helper.cleanup).toBe('function');
+      helper.cleanup();
+    });
+
+    it('aborts the signal after the timeout elapses', () => {
+      const helper = createTimeoutSignalHelper(5000);
+      expect(helper.signal.aborted).toBe(false);
+      vi.advanceTimersByTime(5001);
+      expect(helper.signal.aborted).toBe(true);
+    });
+
+    it('cleanup clears the timer so the signal never aborts', () => {
+      const helper = createTimeoutSignalHelper(5000);
+      helper.cleanup();
+      vi.advanceTimersByTime(6000);
+      expect(helper.signal.aborted).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## 📄 Description
Exported createTimeoutSignalHelper from js/fetch-timeout.js so other modules can reuse an abortable timeout signal without duplicating AbortController logic. Added unit tests covering signal creation, abort after the timeout elapses, and cleanup clearing the timer.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5129

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.