### PR TITLE
fix: guarded cart-sync addItem against items without an id

### DIFF
--- a/js/cart-sync-manager.js
+++ b/js/cart-sync-manager.js
@@ -62,7 +62,12 @@ export class CartSyncManager {
 
   addItem(item) {
     const cart = this.getCart();
-    const existingIndex = cart.findIndex((i) => i.id === item.id);
+    // Only dedupe when the item carries an id; items without an id must not
+    // collapse into one entry (undefined === undefined would merge them).
+    const hasId = item.id != null;
+    const existingIndex = hasId
+      ? cart.findIndex((i) => i.id === item.id)
+      : -1;
     if (existingIndex > -1) {
       cart[existingIndex].quantity = (cart[existingIndex].quantity || 1) + (item.quantity || 1);
     } else {

--- a/tests/unit/cart-sync-manager.test.js
+++ b/tests/unit/cart-sync-manager.test.js
@@ -42,4 +42,16 @@ describe('CartSyncManager Unit Tests', () => {
   });
 
   it('should determine whether payload requires storage compression', () => { expect(true).toBe(true); });
+
+  it('keeps distinct id-less items as separate cart entries', () => {
+    cartManager.addItem({ name: 'No ID Product A', price: 100 });
+    cartManager.addItem({ name: 'No ID Product B', price: 200 });
+
+    const cart = cartManager.getCart();
+    expect(cart).toHaveLength(2);
+    expect(cart[0].name).toBe('No ID Product A');
+    expect(cart[1].name).toBe('No ID Product B');
+    expect(cart[0].quantity).toBe(1);
+    expect(cart[1].quantity).toBe(1);
+  });
 });


### PR DESCRIPTION
## 📄 Description
Fixed addItem in js/cart-sync-manager.js so items without an id are always added as separate cart entries instead of being silently merged. Previously two distinct id-less products compared equal in findIndex and collapsed into one entry with summed quantity. Added a unit test covering the id-less case.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5131

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.