### PR TITLE
feat: added country postal code validation to checkout-validator

### DIFF
--- a/js/checkout-validator.js
+++ b/js/checkout-validator.js
@@ -37,11 +37,20 @@ export function validateExpiryDate(expiryStr) {
   return true;
 }
 
+const POSTAL_CODE_PATTERNS = {
+  US: /^\d{5}(-\d{4})?$/,
+  IN: /^\d{6}$/,
+  UK: /^[A-Z]{1,2}\d[A-Z\d]? ?\d[A-Z]{2}$/i,
+  CA: /^[A-Z]\d[A-Z] ?\d[A-Z]\d$/i,
+  AU: /^\d{4}$/,
+};
+
 export function validatePostalCode(postalCode, country = 'US') {
   if (!postalCode) return false;
   const clean = postalCode.trim();
-  if (country === 'US') {
-    return /^\d{5}(-\d{4})?$/.test(clean);
+  const pattern = POSTAL_CODE_PATTERNS[country.toUpperCase()];
+  if (pattern) {
+    return pattern.test(clean);
   }
   return clean.length >= 3 && clean.length <= 10;
 }

--- a/tests/unit/checkout-validator.test.js
+++ b/tests/unit/checkout-validator.test.js
@@ -27,6 +27,35 @@ describe('Checkout Form Validator Unit Tests', () => {
     expect(validatePostalCode('abc', 'US')).toBe(false);
   });
 
+  it('should validate Indian postal codes', () => {
+    expect(validatePostalCode('110001', 'IN')).toBe(true);
+    expect(validatePostalCode('12345', 'IN')).toBe(false);
+    expect(validatePostalCode('1100012', 'IN')).toBe(false);
+  });
+
+  it('should validate UK postal codes', () => {
+    expect(validatePostalCode('SW1A 1AA', 'UK')).toBe(true);
+    expect(validatePostalCode('M1 1AE', 'UK')).toBe(true);
+    expect(validatePostalCode('12345', 'UK')).toBe(false);
+  });
+
+  it('should validate Canadian postal codes', () => {
+    expect(validatePostalCode('K1A 0B1', 'CA')).toBe(true);
+    expect(validatePostalCode('K1A0B1', 'CA')).toBe(true);
+    expect(validatePostalCode('12345', 'CA')).toBe(false);
+  });
+
+  it('should validate Australian postal codes', () => {
+    expect(validatePostalCode('2000', 'AU')).toBe(true);
+    expect(validatePostalCode('20001', 'AU')).toBe(false);
+    expect(validatePostalCode('abc', 'AU')).toBe(false);
+  });
+
+  it('should fall back to length check for unknown countries', () => {
+    expect(validatePostalCode('ABC-123', 'XX')).toBe(true);
+    expect(validatePostalCode('ab', 'XX')).toBe(false);
+  });
+
   it('should validate email addresses', () => {
     expect(validateEmail('customer@example.com')).toBe(true);
     expect(validateEmail('invalid-email')).toBe(false);


### PR DESCRIPTION
## 📄 Description
Extended validatePostalCode in js/checkout-validator.js with country-specific regex patterns for India, the UK, Canada, and Australia, mirroring the patterns already used in js/address-validation-service.js. Unknown countries keep the generic length fallback. Added unit tests for each new format.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5132

## 🧩 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.