### PR TITLE
fix: fixed ReferenceError from document default parameter in csrf-protection

### DIFF
--- a/js/csrf-protection.js
+++ b/js/csrf-protection.js
@@ -32,10 +32,11 @@ export function getOrCreateCSRFToken() {
   return token;
 }
 
-export function injectCSRFInputs(formContainer = document) {
-  if (!formContainer || typeof formContainer.querySelectorAll !== 'function') return;
+export function injectCSRFInputs(formContainer = null) {
+  const root = formContainer || (typeof document !== 'undefined' ? document : null);
+  if (!root || typeof root.querySelectorAll !== 'function') return;
   const token = getOrCreateCSRFToken();
-  const forms = formContainer.querySelectorAll('form');
+  const forms = root.querySelectorAll('form');
 
   forms.forEach((form) => {
     let input = form.querySelector('input[name="_csrf"]');

--- a/tests/unit/csrf-protection.test.js
+++ b/tests/unit/csrf-protection.test.js
@@ -47,4 +47,14 @@ describe('CSRF Protection Unit Tests', () => {
   });
 
   it('should generate fallback CSRF token string', () => { expect(true).toBe(true); });
+
+  it('should not throw when document is undefined (non-DOM environment)', () => {
+    const originalDocument = globalThis.document;
+    Object.defineProperty(globalThis, 'document', { value: undefined, writable: true, configurable: true });
+    try {
+      expect(() => injectCSRFInputs()).not.toThrow();
+    } finally {
+      Object.defineProperty(globalThis, 'document', { value: originalDocument, writable: true, configurable: true });
+    }
+  });
 });


### PR DESCRIPTION
## 📄 Description
Fixed injectCSRFInputs in js/csrf-protection.js so the document reference is resolved lazily inside the function body instead of as a default parameter. The function no longer throws a ReferenceError in non-DOM environments and still injects CSRF inputs correctly in the browser. Added a unit test for the non-DOM path.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5133

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.