### PR TITLE
fix: exported getAbandonedCartGuard function from cart-recovery-engine

### DIFF
--- a/js/cart-recovery-engine.js
+++ b/js/cart-recovery-engine.js
@@ -117,4 +117,4 @@ export class CartRecoveryEngine {
 }
 
 
-function getAbandonedCartGuard(items) { return Array.isArray(items) ? items : []; }
+export function getAbandonedCartGuard(items) { return Array.isArray(items) ? items : []; }

--- a/tests/unit/cart-recovery-engine.test.js
+++ b/tests/unit/cart-recovery-engine.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { CartRecoveryEngine } from '../../js/cart-recovery-engine.js';
+import { CartRecoveryEngine, getAbandonedCartGuard } from '../../js/cart-recovery-engine.js';
 
 describe('CartRecoveryEngine', () => {
   let engine;
@@ -54,4 +54,21 @@ describe('CartRecoveryEngine', () => {
   });
 
   it('should return empty list when storage is unavailable', () => { expect(true).toBe(true); });
+});
+
+describe('getAbandonedCartGuard', () => {
+  it('returns the array unchanged for valid item arrays', () => {
+    const items = [{ id: 'p1' }, { id: 'p2' }];
+    expect(getAbandonedCartGuard(items)).toBe(items);
+  });
+
+  it('returns an empty array for null or undefined input', () => {
+    expect(getAbandonedCartGuard(null)).toEqual([]);
+    expect(getAbandonedCartGuard(undefined)).toEqual([]);
+  });
+
+  it('returns an empty array for non-array input', () => {
+    expect(getAbandonedCartGuard('items')).toEqual([]);
+    expect(getAbandonedCartGuard({ length: 2 })).toEqual([]);
+  });
 });


### PR DESCRIPTION
## 📄 Description
Exported the orphaned getAbandonedCartGuard function from js/cart-recovery-engine.js so it can be reused by other modules and unit tested. The function was defined but not exported, making it dead code within the module.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5145

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.