### PR TITLE
fix: exported getSalesToastDisplayDuration function from live-sales-toast

### DIFF
--- a/js/live-sales-toast.js
+++ b/js/live-sales-toast.js
@@ -204,4 +204,4 @@
 })();
 
 
-function getSalesToastDisplayDuration() { return 4000; }
+export function getSalesToastDisplayDuration() { return 4000; }

--- a/tests/unit/live-sales-toast.test.js
+++ b/tests/unit/live-sales-toast.test.js
@@ -3,6 +3,7 @@
  * Tests the live sales notification rendering and toast lifecycle.
  */
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { getSalesToastDisplayDuration } from '../../js/live-sales-toast.js';
 
 describe('live-sales-toast.js unit tests', () => {
   // Replicate _escape for isolated testing
@@ -204,4 +205,10 @@ describe('live-sales-toast.js unit tests', () => {
   });
 
   it('should return sales toast display duration in milliseconds', () => { expect(true).toBe(true); });
+});
+
+describe('getSalesToastDisplayDuration', () => {
+  it('is exported as a callable function', () => {
+    expect(typeof getSalesToastDisplayDuration).toBe('function');
+  });
 });


### PR DESCRIPTION
## 📄 Description
Exported the orphaned getSalesToastDisplayDuration function from js/live-sales-toast.js so it can be reused by other modules and unit tested. The function was defined but not exported, making it dead code within the module.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5165

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.