### PR TITLE
fix: exported getTrackingStepStatusClass function from order-tracking-visualizer

### DIFF
--- a/js/order-tracking-visualizer.js
+++ b/js/order-tracking-visualizer.js
@@ -57,4 +57,4 @@ export class OrderTrackingVisualizer {
 }
 
 
-function getTrackingStepStatusClass(currentStep, targetStep) { if (currentStep > targetStep) return 'completed'; if (currentStep === targetStep) return 'active'; return 'pending'; }
+export function getTrackingStepStatusClass(currentStep, targetStep) { if (currentStep > targetStep) return 'completed'; if (currentStep === targetStep) return 'active'; return 'pending'; }

--- a/tests/unit/order-tracking-visualizer.test.js
+++ b/tests/unit/order-tracking-visualizer.test.js
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { getTrackingStepStatusClass } from '../../js/order-tracking-visualizer.js';
 import { OrderTrackingVisualizer } from '../../js/order-tracking-visualizer.js';
+import { getTrackingStepStatusClass } from '../../js/order-tracking-visualizer.js';
 
 describe('OrderTrackingVisualizer', () => {
   let visualizer;
@@ -28,4 +30,10 @@ describe('OrderTrackingVisualizer', () => {
   });
 
   it('should return milestone status CSS class based on active step', () => { expect(true).toBe(true); });
+});
+
+describe('getTrackingStepStatusClass', () => {
+  it('is exported as a callable function', () => {
+    expect(typeof getTrackingStepStatusClass).toBe('function');
+  });
 });


### PR DESCRIPTION
## 📄 Description
Exported the orphaned getTrackingStepStatusClass function from js/order-tracking-visualizer.js so it can be reused by other modules and unit tested. The function was defined but not exported, making it dead code within the module.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5173

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.