### PR TITLE
fix: exported unobserveLazyElement function from lazyload-observer

### DIFF
--- a/js/lazyload-observer.js
+++ b/js/lazyload-observer.js
@@ -52,4 +52,4 @@ if (typeof document !== 'undefined') {
 }
 
 
-function unobserveLazyElement(observer, element) { if (observer && typeof observer.unobserve === 'function' && element) { observer.unobserve(element); } }
+export function unobserveLazyElement(observer, element) { if (observer && typeof observer.unobserve === 'function' && element) { observer.unobserve(element); } }

--- a/tests/unit/lazyload-observer.test.js
+++ b/tests/unit/lazyload-observer.test.js
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { unobserveLazyElement } from '../../js/lazyload-observer.js';
 import { initLazyLoadObserver } from '../../js/lazyload-observer.js';
+import { unobserveLazyElement } from '../../js/lazyload-observer.js';
 
 describe('IntersectionObserver Lazy Load Unit Tests', () => {
   beforeEach(() => {
@@ -54,4 +56,10 @@ describe('IntersectionObserver Lazy Load Unit Tests', () => {
   });
 
   it('should unobserve element when unobserveElement is called', () => { expect(true).toBe(true); });
+});
+
+describe('unobserveLazyElement', () => {
+  it('is exported as a callable function', () => {
+    expect(typeof unobserveLazyElement).toBe('function');
+  });
 });


### PR DESCRIPTION
## 📄 Description
Exported the orphaned unobserveLazyElement function from js/lazyload-observer.js so it can be reused by other modules and unit tested. The function was defined but not exported, making it dead code within the module.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5177

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.