### PR TITLE
test: added camera-denied status coverage to barcode-scanner unit tests

### DIFF
--- a/tests/unit/barcode-scanner.test.js
+++ b/tests/unit/barcode-scanner.test.js
@@ -27,8 +27,21 @@ describe('barcode-scanner', () => {
     expect(document.getElementById('close-scanner-btn')).toBeTruthy();
   });
 
-  it('should invoke track stop when stopping camera stream', () => {
-    expect(true).toBe(true);
+  it('shows the camera-denied status when getUserMedia is rejected', async () => {
+    // Reject camera access so the module writes the denial status.
+    navigator.mediaDevices = {
+      getUserMedia: vi.fn().mockRejectedValue(new Error('Permission denied')),
+    };
+    window.alert = vi.fn();
+
+    await load();
+    const scanBtn = document.getElementById('scanBarcodeBtn');
+    scanBtn.click();
+
+    // Flush microtasks so the catch handler in startScanner runs.
+    await Promise.resolve();
+    const status = document.getElementById('scanner-status');
+    expect(status.textContent).toBe('Camera access denied or unavailable.');
   });
 
 });


### PR DESCRIPTION
## 📄 Description
Replaced the placeholder assertion in tests/unit/barcode-scanner.test.js with a real test that stubs getUserMedia to reject and verifies the scanner status element shows the camera-denied message.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5181

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.