### PR TITLE
test: added fallback rendering coverage to error-boundary unit tests

### DIFF
--- a/tests/unit/error-boundary.test.js
+++ b/tests/unit/error-boundary.test.js
@@ -72,7 +72,25 @@ describe('error-boundary.js unit tests', () => {
     expect(errorSpy).not.toHaveBeenCalled();
   });
 
-  it('should render fallback box on error', () => {
-    expect(true).toBe(true);
+  it('wrap renders the fallback message when renderFn throws', () => {
+    const renderFn = vi.fn(() => {
+      throw new Error('Custom failure');
+    });
+    CaraErrorBoundary.wrap('#test-target', renderFn);
+    const fallback = container.querySelector('.cara-error-fallback');
+    expect(fallback).not.toBeNull();
+    expect(fallback.querySelector('p').textContent).toContain(
+      'Something went wrong loading this section.',
+    );
+    expect(fallback.querySelector('.cara-error-retry')).not.toBeNull();
+  });
+
+  it('wrap leaves the container untouched when renderFn succeeds', () => {
+    const renderFn = vi.fn(() => {
+      container.innerHTML = '<p class="ok">loaded</p>';
+    });
+    CaraErrorBoundary.wrap('#test-target', renderFn);
+    expect(container.querySelector('.ok')).not.toBeNull();
+    expect(container.querySelector('.cara-error-fallback')).toBeNull();
   });
 });


### PR DESCRIPTION
## 📄 Description
Replaced the placeholder assertion in tests/unit/error-boundary.test.js with real tests that verify the fallback box renders with its retry button when a render function throws, and that a successful render leaves the container untouched.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5185

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.