### PR TITLE
security: fixed HTML escaping in toast-queue messages

### DIFF
--- a/js/toast-queue.js
+++ b/js/toast-queue.js
@@ -1,5 +1,19 @@
 // Reusable Toast Notification Queue Manager
 
+function escapeHtml(value) {
+  return String(value).replace(
+    /[&<>"']/g,
+    (char) =>
+      ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;',
+      })[char],
+  );
+}
+
 export class ToastQueueManager {
   constructor(maxToasts = 5) {
     this.maxToasts = maxToasts;
@@ -45,7 +59,7 @@ export class ToastQueueManager {
       el.innerHTML = `
         <div class="toast-content">
           <span class="toast-icon">${type === 'success' ? '✓' : type === 'error' ? '✕' : 'ℹ'}</span>
-          <span class="toast-message">${message}</span>
+          <span class="toast-message">${escapeHtml(message)}</span>
         </div>
         <button class="toast-close" aria-label="Close notification">&times;</button>
       `;

--- a/tests/unit/toast-queue.test.js
+++ b/tests/unit/toast-queue.test.js
@@ -59,4 +59,15 @@ describe('Toast Queue Manager Unit Tests', () => {
     expect(manager.queue.length).toBe(0);
     vi.useRealTimers();
   });
+
+  it('should escape HTML in toast messages to prevent injection', () => {
+    const id = manager.show('<img src=x onerror=alert(1)>', 'warning', 0);
+    const toastCard = document.getElementById(id);
+    // No real <img> element may be created from the message.
+    expect(toastCard.querySelector('img')).toBeNull();
+    // The raw message is preserved as text, with angle brackets escaped.
+    expect(toastCard.textContent).toContain('<img src=x onerror=alert(1)>');
+    expect(toastCard.querySelector('.toast-message').innerHTML).toContain('&lt;img');
+    expect(toastCard.querySelector('.toast-message').innerHTML).not.toContain('<img');
+  });
 });


### PR DESCRIPTION
## 📄 Description
Fixed a client-side XSS vector in js/toast-queue.js where the ToastQueueManager.show method injected the toast message into innerHTML without escaping. Added an escapeHtml helper applied to the message, matching the escaping already used in js/toast.js, and added a unit test verifying an HTML payload renders as escaped text.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5191

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.