### PR TITLE
test: added international and edge case coverage to address-validation-service unit tests

### DIFF
--- a/tests/unit/address-validation-service.test.js
+++ b/tests/unit/address-validation-service.test.js
@@ -48,4 +48,38 @@ describe('AddressValidationService Unit Tests', () => {
     expect(result.sanitized.street).toBe('123 Main St alert(1)');
   });
 
+  it('should validate UK and Canadian postal code formats', () => {
+    expect(service.validatePostalCode('SW1A 1AA', 'UK').valid).toBe(true);
+    expect(service.validatePostalCode('K1A 0B1', 'CA').valid).toBe(true);
+    expect(service.validatePostalCode('not-a-postcode', 'UK').valid).toBe(false);
+  });
+
+  it('should report missing address fields as invalid', () => {
+    const result = service.validateAddress({
+      street: '',
+      city: '',
+      state: '',
+      postalCode: '',
+      country: 'US'
+    });
+    expect(result.isValid).toBe(false);
+    expect(result.errors.street).toBeDefined();
+    expect(result.errors.city).toBeDefined();
+    expect(result.errors.state).toBeDefined();
+    expect(result.errors.postalCode).toBeDefined();
+    expect(result.sanitized).toBeNull();
+  });
+
+  it('should uppercase the sanitized state and country fields', () => {
+    const result = service.validateAddress({
+      street: '10 Downing St',
+      city: 'London',
+      state: 'england',
+      postalCode: 'SW1A 2AA',
+      country: 'uk'
+    });
+    expect(result.isValid).toBe(true);
+    expect(result.sanitized.state).toBe('ENGLAND');
+    expect(result.sanitized.country).toBe('UK');
+  });
 });


### PR DESCRIPTION
## 📄 Description
Added tests to tests/unit/address-validation-service.test.js covering UK and Canadian postal formats, missing required fields producing per-field errors, and sanitized state/country uppercasing.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5193

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.