### PR TITLE
test: added legacy key cleanup coverage to session-lock unit tests

### DIFF
--- a/tests/unit/session-lock.test.js
+++ b/tests/unit/session-lock.test.js
@@ -61,4 +61,39 @@ describe('session-lock', () => {
     vi.advanceTimersByTime(15 * 60 * 1000);
     await vi.waitFor(() => expect(window.location.href).toBe('login.html'));
   });
+
+  it('clears legacy identity keys from localStorage when locking', async () => {
+    const fetchMock = vi.fn(async (url, options = {}) => {
+      if (String(url).includes('/api/auth/me')) {
+        return { ok: true, status: 200, json: async () => ({ email: 'a@b.c' }) };
+      }
+      if (String(url).includes('/api/auth/logout')) {
+        return { ok: true, status: 200, json: async () => ({}) };
+      }
+      return { ok: false, status: 404 };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    localStorage.setItem('cara_user_session', 'legacy');
+    localStorage.setItem('cara_user_token', 'legacy-token');
+    localStorage.setItem('access_token', 'legacy-access');
+
+    await import('../../js/session-lock.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await vi.waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some((call) =>
+          String(call[0]).includes('/api/auth/me'),
+        ),
+      ).toBe(true),
+    );
+    await Promise.resolve();
+
+    vi.advanceTimersByTime(15 * 60 * 1000);
+    await vi.waitFor(() => expect(window.location.href).toBe('login.html'));
+
+    expect(localStorage.getItem('cara_user_session')).toBeNull();
+    expect(localStorage.getItem('cara_user_token')).toBeNull();
+    expect(localStorage.getItem('access_token')).toBeNull();
+  });
 });


### PR DESCRIPTION
## 📄 Description
Added a test to tests/unit/session-lock.test.js that seeds legacy identity keys in localStorage, triggers the inactivity lock, and verifies the keys are removed.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5213

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.