### PR TITLE
fix: guarded non-finite transform values in virtual-tryon-engine

### DIFF
--- a/js/virtual-tryon-engine.js
+++ b/js/virtual-tryon-engine.js
@@ -22,10 +22,13 @@ class VirtualTryOnEngine {
   }
 
   updateTransform({ scale, rotation, offsetX, offsetY }) {
-    if (typeof scale === 'number') this.state.scale = Math.max(0.2, Math.min(3.0, scale));
-    if (typeof rotation === 'number') this.state.rotation = rotation % 360;
-    if (typeof offsetX === 'number') this.state.position.x = offsetX;
-    if (typeof offsetY === 'number') this.state.position.y = offsetY;
+    if (typeof scale === 'number' && isFinite(scale)) this.state.scale = Math.max(0.2, Math.min(3.0, scale));
+    if (typeof rotation === 'number' && isFinite(rotation)) {
+      // Normalize to a positive angle in [0, 360).
+      this.state.rotation = ((rotation % 360) + 360) % 360;
+    }
+    if (typeof offsetX === 'number' && isFinite(offsetX)) this.state.position.x = offsetX;
+    if (typeof offsetY === 'number' && isFinite(offsetY)) this.state.position.y = offsetY;
 
     return { ...this.state };
   }

--- a/tests/unit/virtual-tryon-engine.test.js
+++ b/tests/unit/virtual-tryon-engine.test.js
@@ -31,4 +31,20 @@ describe('VirtualTryOnEngine Unit Tests', () => {
     expect(bounds.centerX).toBe(210);
     expect(bounds.centerY).toBe(320);
   });
+
+  it('should ignore non-finite offsets and scale values', () => {
+    const res = engine.updateTransform({
+      scale: NaN,
+      offsetX: NaN,
+      offsetY: Infinity,
+    });
+    expect(res.scale).toBe(1.0);
+    expect(res.position.x).toBe(0);
+    expect(res.position.y).toBe(0);
+  });
+
+  it('should normalize negative rotations to a positive angle', () => {
+    const res = engine.updateTransform({ rotation: -90 });
+    expect(res.rotation).toBe(270);
+  });
 });


### PR DESCRIPTION
## 📄 Description
Fixed updateTransform in js/virtual-tryon-engine.js to ignore non-finite values (NaN and Infinity) for scale, rotation, and offsets, preventing NaN corruption in the garment bounds calculations. Rotation is now normalized to a positive angle in [0, 360). Added unit tests covering the non-finite input handling and rotation normalization.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5215

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.