### PR TITLE
test: added edge case coverage to virtual-stylist-engine unit tests

### DIFF
--- a/tests/unit/virtual-stylist-engine.test.js
+++ b/tests/unit/virtual-stylist-engine.test.js
@@ -30,4 +30,33 @@ describe('VirtualStylistEngine', () => {
     expect(ranked[0].item.id).toBe('b2');
     expect(ranked[0].score).toBeGreaterThan(ranked[1].score);
   });
+
+  it('should treat color comparison as case-insensitive and trimmed', () => {
+    expect(engine.isColorCompatible('  BLUE ', 'white')).toBe(true);
+    expect(engine.isColorCompatible('Blue', 'WHITE')).toBe(true);
+  });
+
+  it('should return true for identical colors', () => {
+    expect(engine.isColorCompatible('red', 'red')).toBe(true);
+    expect(engine.isColorCompatible('', '')).toBe(true);
+  });
+
+  it('should return 0 when either outfit item is missing', () => {
+    expect(engine.calculateOutfitScore(null, { category: 'jeans' })).toBe(0);
+    expect(engine.calculateOutfitScore({ category: 'shirts' }, null)).toBe(0);
+  });
+
+  it('should cap outfit scores at 100', () => {
+    const top = { category: 'shirts', color: 'blue' };
+    const bottom = { category: 'pants', color: 'white' };
+    // base 50 + 30 category + 20 color = 100 (capped)
+    expect(engine.calculateOutfitScore(top, bottom)).toBe(100);
+  });
+
+  it('should return an empty list for invalid catalog input', () => {
+    const top = { category: 'shirts', color: 'blue' };
+    expect(engine.recommendBottoms(top, null)).toEqual([]);
+    expect(engine.recommendBottoms(top, 'not-an-array')).toEqual([]);
+    expect(engine.recommendBottoms(null, [])).toEqual([]);
+  });
 });


### PR DESCRIPTION
## 📄 Description
Added tests to tests/unit/virtual-stylist-engine.test.js covering case-insensitive color comparison, identical colors, missing item handling, score capping at 100, and invalid catalog input returning an empty list.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5217

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.