### PR TITLE
test: added owner id format coverage to order-bola-authorization unit tests

### DIFF
--- a/tests/unit/order-bola-authorization.test.js
+++ b/tests/unit/order-bola-authorization.test.js
@@ -30,4 +30,16 @@ describe('BOLA / Object-Level Authorization Security Defense', () => {
     expect(verifyOrderOwnership({}, 'usr_abc', false)).toBe(false);
     expect(verifyOrderOwnership({ id: 'ord_1' }, null, false)).toBe(false);
   });
+
+  test('recognizes alternate owner id key formats', () => {
+    expect(verifyOrderOwnership({ userId: 'usr_1' }, 'usr_1', false)).toBe(true);
+    expect(verifyOrderOwnership({ user_id: 'usr_2' }, 'usr_2', false)).toBe(true);
+    expect(verifyOrderOwnership({ ownerId: 'usr_3' }, 'usr_3', false)).toBe(true);
+    expect(verifyOrderOwnership({ customerId: 'usr_4' }, 'usr_4', false)).toBe(true);
+  });
+
+  test('compares owner ids as strings to handle mixed types', () => {
+    expect(verifyOrderOwnership({ userId: 12345 }, '12345', false)).toBe(true);
+    expect(verifyOrderOwnership({ userId: 'usr_abc' }, 999, false)).toBe(false);
+  });
 });


### PR DESCRIPTION
## 📄 Description
Added tests to tests/unit/order-bola-authorization.test.js covering the user_id, ownerId, and customerId key formats, and string coercion when comparing owner ids of mixed types.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5228

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.