### PR TITLE
fix: scoped metro-zone delivery heuristic to Indian pincodes

### DIFF
--- a/js/pincode-validation-engine.js
+++ b/js/pincode-validation-engine.js
@@ -45,11 +45,18 @@ export class PincodeValidationEngine {
     const check = this.validatePostalCode(code, countryCode);
     if (!check.valid) return null;
 
-    const numericVal = parseInt(code.replace(/\D/g, '').substring(0, 2), 10) || 0;
-    // Simulating metro vs non-metro zones
-    if (numericVal >= 11 && numericVal <= 40) {
-      return { minDays: 1, maxDays: 3, tier: 'Express Zone' };
+    const country = countryCode.toUpperCase();
+    // The metro-zone heuristic below uses Indian PIN ranges (11-40),
+    // so only apply it to Indian pincodes.
+    if (country === 'IN') {
+      const numericVal = parseInt(code.replace(/\D/g, '').substring(0, 2), 10) || 0;
+      if (numericVal >= 11 && numericVal <= 40) {
+        return { minDays: 1, maxDays: 3, tier: 'Express Zone' };
+      }
+      return { minDays: 3, maxDays: 5, tier: 'Standard Zone' };
     }
-    return { minDays: 3, maxDays: 5, tier: 'Standard Zone' };
+
+    // Non-Indian pincodes: use a country-agnostic default estimate.
+    return { minDays: 3, maxDays: 7, tier: 'Standard Zone' };
   }
 }

--- a/tests/unit/pincode-validation-engine.test.js
+++ b/tests/unit/pincode-validation-engine.test.js
@@ -38,4 +38,23 @@ describe('PincodeValidationEngine', () => {
     });
   });
 
+  it('should not apply the Indian metro heuristic to foreign pincodes', () => {
+    // 10001 (US) would be "Express" under the old IN-only heuristic.
+    const est = engine.estimateDeliveryDays('10001', 'US');
+    expect(est).not.toBeNull();
+    expect(est.tier).toBe('Standard Zone');
+    expect(est.minDays).toBe(3);
+  });
+
+  it('should return the standard zone for non-metro Indian pincodes', () => {
+    const est = engine.estimateDeliveryDays('700001', 'IN');
+    expect(est.tier).toBe('Standard Zone');
+    expect(est.minDays).toBe(3);
+  });
+
+  it('should validate UK and Canadian postal codes', () => {
+    expect(engine.validatePostalCode('SW1A 1AA', 'UK').valid).toBe(true);
+    expect(engine.validatePostalCode('K1A 0B1', 'CA').valid).toBe(true);
+    expect(engine.validatePostalCode('BAD', 'UK').valid).toBe(false);
+  });
 });


### PR DESCRIPTION
## 📄 Description
Fixed estimateDeliveryDays in js/pincode-validation-engine.js so the Indian metro-zone heuristic (PIN prefix 11-40) is only applied to Indian pincodes. Foreign postal codes such as US ZIP 10001 previously got misclassified as Indian metro Express Zone; they now receive a country-agnostic standard estimate. Added unit tests for foreign pincodes and UK/Canadian validation.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5233

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.