### PR TITLE
fix: read cart subtotal from productsInCart in cart-coupon validation

### DIFF
--- a/js/cart-coupon.js
+++ b/js/cart-coupon.js
@@ -52,11 +52,24 @@
     // Use PromoDiscountCalculator if available, otherwise fall back to simple lookup
     if (typeof PromoDiscountCalculator !== 'undefined') {
       const calculator = new PromoDiscountCalculator();
-      // Get cart subtotal from localStorage or default to 0
+      // Get cart subtotal from the actual cart storage key used by the app
+      // ('productsInCart'), falling back to 'cara_cart' for legacy pages.
       let subtotal = 0;
       try {
-        const cart = JSON.parse(localStorage.getItem('cara_cart') || '{}');
-        subtotal = parseFloat(cart.subtotal) || 0;
+        const rawCart = JSON.parse(
+          localStorage.getItem('productsInCart') ||
+            localStorage.getItem('cara_cart') ||
+            '[]',
+        );
+        if (Array.isArray(rawCart)) {
+          subtotal = rawCart.reduce((sum, item) => {
+            const price = parseFloat(item.price) || 0;
+            const qty = parseInt(item.quantity, 10) || 1;
+            return sum + price * qty;
+          }, 0);
+        } else {
+          subtotal = parseFloat(rawCart.subtotal) || 0;
+        }
       } catch (err) {
         // ignore parse errors
       }

--- a/tests/unit/cart-coupon.test.js
+++ b/tests/unit/cart-coupon.test.js
@@ -61,4 +61,30 @@ describe('cart-coupon', () => {
     expect(window.appliedCoupon).toBe('');
     expect(localStorage.getItem('appliedCoupon')).toBeNull();
   });
+
+  it('reads the cart subtotal from productsInCart for coupon validation', async () => {
+    const validateCoupon = vi.fn(() => ({
+      valid: true,
+      code: 'CARA20',
+      discountPct: 20,
+    }));
+    window.PromoDiscountCalculator = class {
+      validateCoupon(...args) {
+        return validateCoupon(...args);
+      }
+    };
+    localStorage.setItem(
+      'productsInCart',
+      JSON.stringify([
+        { name: 'T-Shirt', price: '500', quantity: 2 },
+        { name: 'Jeans', price: '1000', quantity: 1 },
+      ]),
+    );
+    document.getElementById('coupon-code-input').value = 'CARA20';
+
+    await import('../../js/cart-coupon.js');
+    apply();
+
+    expect(validateCoupon).toHaveBeenCalledWith('CARA20', 2000);
+  });
 });


### PR DESCRIPTION
## 📄 Description
Fixed applyCoupon in js/cart-coupon.js which read the cart subtotal from the legacy cara_cart key (never populated by the app), making minimum-spend coupon validation always fail with a 0 subtotal. It now reads productsInCart and sums price x quantity for array carts, with cara_cart kept as a legacy fallback. Added a unit test verifying the subtotal is passed to PromoDiscountCalculator.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5236

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.