### PR TITLE
test: added sanitizeDOMNode and non-string coverage to sanitize unit tests

### DIFF
--- a/tests/unit/sanitize.test.js
+++ b/tests/unit/sanitize.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { sanitizeHTML, sanitizeDOMNode } from '../../js/utils/sanitize.js';
 
 describe('js/utils/sanitize.js — sanitizeHTML', () => {
   beforeEach(async () => {
@@ -62,5 +63,28 @@ describe('js/utils/sanitize.js — sanitizeHTML', () => {
   it('sanitizeHTML is exposed on window', async () => {
     await import('../../js/utils/sanitize.js');
     expect(typeof window.sanitizeHTML).toBe('function');
+  });
+
+  it('should return non-string input unchanged', () => {
+    expect(sanitizeHTML(null)).toBeNull();
+    expect(sanitizeHTML(undefined)).toBeUndefined();
+    expect(sanitizeHTML(42)).toBe(42);
+  });
+
+  it('should remove script, iframe, object and embed tags via sanitizeDOMNode', () => {
+    const container = document.createElement('div');
+    container.innerHTML =
+      '<p>safe</p><script>alert(1)</script><iframe src="x"></iframe><object></object><embed>';
+    sanitizeDOMNode(container);
+    expect(container.querySelector('script')).toBeNull();
+    expect(container.querySelector('iframe')).toBeNull();
+    expect(container.querySelector('object')).toBeNull();
+    expect(container.querySelector('embed')).toBeNull();
+    expect(container.querySelector('p')).not.toBeNull();
+  });
+
+  it('should no-op when sanitizeDOMNode receives a non-element', () => {
+    expect(() => sanitizeDOMNode(null)).not.toThrow();
+    expect(() => sanitizeDOMNode({})).not.toThrow();
   });
 });


### PR DESCRIPTION
## 📄 Description
Added tests to tests/unit/sanitize.test.js covering non-string input being returned unchanged, sanitizeDOMNode removing script/iframe/object/embed tags, and sanitizeDOMNode no-oping on non-element input.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5238

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.