### PR TITLE
fix: validated address vault storage shape in checkout-vault

### DIFF
--- a/js/checkout-vault.js
+++ b/js/checkout-vault.js
@@ -5,19 +5,23 @@ class AddressVault {
     getAddresses() {
         try {
             const raw = localStorage.getItem('cara_saved_addresses');
-            return JSON.parse(raw || '[]');
+            const parsed = JSON.parse(raw || '[]');
+            return Array.isArray(parsed) ? parsed : [];
         } catch (err) {
             return [];
         }
     }
 
     saveAddress(addr) {
+        if (!addr || typeof addr !== 'object') return false;
         try {
             const list = this.getAddresses();
             list.push(addr);
             localStorage.setItem('cara_saved_addresses', JSON.stringify(list));
+            return true;
         } catch (err) {
             // Silently fail if localStorage is unavailable or full
+            return false;
         }
     }
 }

--- a/tests/unit/checkout-vault.test.js
+++ b/tests/unit/checkout-vault.test.js
@@ -13,19 +13,23 @@ class TestAddressVault {
   getAddresses() {
     try {
       const raw = localStorage.getItem(this.storageKey);
-      return JSON.parse(raw || '[]');
+      const parsed = JSON.parse(raw || '[]');
+      return Array.isArray(parsed) ? parsed : [];
     } catch (err) {
       return [];
     }
   }
 
   saveAddress(addr) {
+    if (!addr || typeof addr !== 'object') return false;
     try {
       const list = this.getAddresses();
       list.push(addr);
       localStorage.setItem(this.storageKey, JSON.stringify(list));
+      return true;
     } catch (err) {
       // Silently fail
+      return false;
     }
   }
 
@@ -104,5 +108,21 @@ describe('AddressVault saveAddress', () => {
     localStorage.setItem = originalSetItem;
   });
 
-  it('should mask credit card numbers for PCI compliance display', () => { expect(true).toBe(true); });
+  it('returns an empty array when stored value is not an array', () => {
+    localStorage.setItem(vault.storageKey, JSON.stringify({ street: 'Legacy object' }));
+    expect(vault.getAddresses()).toEqual([]);
+  });
+
+  it('recovers and overwrites a corrupt non-array store on next save', () => {
+    localStorage.setItem(vault.storageKey, JSON.stringify({ not: 'an array' }));
+    vault.saveAddress({ street: 'Recovered St', city: 'Goa' });
+    const addresses = JSON.parse(localStorage.getItem(vault.storageKey));
+    expect(addresses).toEqual([{ street: 'Recovered St', city: 'Goa' }]);
+  });
+
+  it('rejects invalid address payloads without touching storage', () => {
+    expect(vault.saveAddress(null)).toBe(false);
+    expect(vault.saveAddress('not-an-object')).toBe(false);
+    expect(localStorage.getItem(vault.storageKey)).toBeNull();
+  });
 });


### PR DESCRIPTION
## 📄 Description
Fixed getAddresses in js/checkout-vault.js to validate that the parsed localStorage value is an array, so a legacy object shape can no longer break subsequent saves. saveAddress now rejects non-object payloads and returns a success boolean. Added unit tests covering non-array storage recovery and invalid address rejection.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5240

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.