### PR TITLE
a11y: excluded hidden elements from focus trap tabbables

### DIFF
--- a/js/a11y-focus-trap.js
+++ b/js/a11y-focus-trap.js
@@ -6,7 +6,12 @@ export const TABBABLE_SELECTOR =
 export function getTabbableElements(container) {
   if (!container || typeof container.querySelectorAll !== 'function') return [];
   return Array.from(container.querySelectorAll(TABBABLE_SELECTOR)).filter(
-    (el) => el.style.display !== 'none' && el.style.visibility !== 'hidden'
+    (el) =>
+      el.style.display !== 'none' &&
+      el.style.visibility !== 'hidden' &&
+      !el.hasAttribute('hidden') &&
+      el.getAttribute('aria-hidden') !== 'true' &&
+      !(el.tagName === 'INPUT' && el.type === 'hidden'),
   );
 }
 

--- a/tests/unit/a11y-focus-trap.test.js
+++ b/tests/unit/a11y-focus-trap.test.js
@@ -66,4 +66,30 @@ describe('Accessibility Focus Trap & Announcer Unit Tests', () => {
     expect(trapFocus(null, null)).toBeNull();
   });
 
+  it('should exclude hidden, aria-hidden, and type=hidden elements from tabbables', () => {
+    container.innerHTML = `
+      <button id="btn1">Button 1</button>
+      <button id="hiddenBtn" hidden>Hidden</button>
+      <button id="ariaHiddenBtn" aria-hidden="true">Aria Hidden</button>
+      <input id="hiddenInput" type="hidden" />
+      <input id="textInput" type="text" />
+    `;
+    const tabbables = getTabbableElements(container);
+    const ids = tabbables.map((el) => el.id);
+    expect(ids).toContain('btn1');
+    expect(ids).toContain('textInput');
+    expect(ids).not.toContain('hiddenBtn');
+    expect(ids).not.toContain('ariaHiddenBtn');
+    expect(ids).not.toContain('hiddenInput');
+  });
+
+  it('should return an empty array for a container without tabbables', () => {
+    container.innerHTML = '<button disabled>Disabled</button>';
+    expect(getTabbableElements(container)).toEqual([]);
+  });
+
+  it('should return an empty array for null or non-element input', () => {
+    expect(getTabbableElements(null)).toEqual([]);
+    expect(getTabbableElements({})).toEqual([]);
+  });
 });


### PR DESCRIPTION
## 📄 Description
Fixed getTabbableElements in js/a11y-focus-trap.js to exclude elements hidden with the hidden attribute, marked aria-hidden=true, and inputs of type hidden. The focus trap now skips non-visible controls so keyboard navigation stays correct in modals that contain them. Added unit tests covering the new exclusions and empty-container handling.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5242

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.