### PR TITLE
fix: skipped corrupt ratings in product review summary

### DIFF
--- a/js/product-reviews.js
+++ b/js/product-reviews.js
@@ -95,14 +95,19 @@ export class ProductReviewManager {
 
     const distribution = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
     let sum = 0;
+    let ratedCount = 0;
 
     productReviews.forEach((rev) => {
-      const r = Math.min(5, Math.max(1, rev.rating));
-      distribution[r] = (distribution[r] || 0) + 1;
+      const raw = Number(rev.rating);
+      if (!Number.isFinite(raw)) return; // Skip corrupt legacy entries
+      const r = Math.min(5, Math.max(1, raw));
+      distribution[Math.round(r)] = (distribution[Math.round(r)] || 0) + 1;
       sum += r;
+      ratedCount += 1;
     });
 
-    const averageRating = parseFloat((sum / productReviews.length).toFixed(1));
+    const averageRating =
+      ratedCount > 0 ? parseFloat((sum / ratedCount).toFixed(1)) : 0;
 
     return {
       totalReviews: productReviews.length,

--- a/tests/unit/product-reviews.test.js
+++ b/tests/unit/product-reviews.test.js
@@ -70,4 +70,25 @@ describe('ProductReviewManager Unit Tests', () => {
     expect(manager.sanitizeReviewAuthorName(null)).toBe('');
     expect(manager.sanitizeReviewAuthorName(undefined)).toBe('');
   });
+
+  it('should skip corrupt ratings when computing the summary', () => {
+    // Seed the store directly with a legacy corrupt rating.
+    localStorage.setItem(
+      'cara_test_reviews',
+      JSON.stringify({
+        'prod-x': [
+          { id: 'r1', rating: 5, authorName: 'Alice' },
+          { id: 'r2', rating: 'not-a-number', authorName: 'Bob' },
+          { id: 'r3', rating: 3, authorName: 'Carol' },
+        ],
+      }),
+    );
+    const manager2 = new ProductReviewManager('cara_test_reviews');
+    const summary = manager2.getProductRatingSummary('prod-x');
+    expect(summary.totalReviews).toBe(3);
+    expect(summary.averageRating).toBe(4.0);
+    expect(summary.distribution[5]).toBe(1);
+    expect(summary.distribution[3]).toBe(1);
+    expect(Number.isNaN(summary.averageRating)).toBe(false);
+  });
 });


### PR DESCRIPTION
## 📄 Description
Fixed getProductRatingSummary in js/product-reviews.js to skip non-finite stored ratings when computing the distribution and average. Corrupt legacy entries can no longer inflate the denominator or introduce NaN into the summary. The average now divides by the count of valid ratings only. Added a unit test seeding a corrupt rating.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5250

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.