### PR TITLE
fix: handled empty category params in product-facet-filter

### DIFF
--- a/js/product-facet-filter.js
+++ b/js/product-facet-filter.js
@@ -66,8 +66,9 @@ export class ProductFacetFilter {
 
   parseQueryParams(queryString) {
     const params = new URLSearchParams(queryString);
+    const rawCategories = params.get('categories');
     const filters = {
-      category: params.get('categories') ? params.get('categories').split(',') : [],
+      category: rawCategories ? rawCategories.split(',').filter((c) => c.length > 0) : [],
       minPrice: parseFloat(params.get('minPrice')) || 0,
       maxPrice: parseFloat(params.get('maxPrice')) || Infinity,
       minRating: parseFloat(params.get('minRating')) || 0,

--- a/tests/unit/product-facet-filter.test.js
+++ b/tests/unit/product-facet-filter.test.js
@@ -62,4 +62,16 @@ describe('ProductFacetFilter', () => {
     expect(filter.isPriceInFacetRange(NaN, 0, 100)).toBe(false);
   });
 
+  it('should treat an empty categories param as no category filter', () => {
+    const newEngine = new ProductFacetFilter(sampleProducts);
+    newEngine.parseQueryParams('categories=&minPrice=10');
+    expect(newEngine.activeFilters.category).toEqual([]);
+    expect(newEngine.applyFilters()).toHaveLength(4);
+  });
+
+  it('should drop empty entries when splitting category params', () => {
+    const newEngine = new ProductFacetFilter(sampleProducts);
+    const filters = newEngine.parseQueryParams('categories=tshirts,,shirts');
+    expect(filters.category).toEqual(['tshirts', 'shirts']);
+  });
 });


### PR DESCRIPTION
## 📄 Description
Fixed parseQueryParams in js/product-facet-filter.js to drop empty entries when splitting the categories query parameter. An empty or trailing categories value no longer produces a match-nothing category filter that silently empties the results. Added unit tests covering empty and mixed-empty category params.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5256

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.