### PR TITLE
fix: expired zero-duration stock reservation timers immediately

### DIFF
--- a/js/stock-simulator.js
+++ b/js/stock-simulator.js
@@ -15,6 +15,10 @@ export function getStockInfo(size) {
 }
 
 export function startStockReservationTimer(durationSeconds, onTick, onExpire) {
+  if (durationSeconds <= 0) {
+    if (onExpire) onExpire();
+    return null;
+  }
   let remaining = durationSeconds;
   const interval = setInterval(() => {
     remaining -= 1;

--- a/tests/unit/stock-simulator.test.js
+++ b/tests/unit/stock-simulator.test.js
@@ -48,4 +48,16 @@ describe('Stock Simulator Unit Tests', () => {
     expect(infoEmpty).toEqual({ count: 0, status: 'unknown' });
   });
 
+  it('should expire immediately for a zero or negative duration', () => {
+    const onTick = vi.fn();
+    const onExpire = vi.fn();
+    const intervalZero = startStockReservationTimer(0, onTick, onExpire);
+    expect(onExpire).toHaveBeenCalledTimes(1);
+    expect(onTick).not.toHaveBeenCalled();
+    expect(intervalZero).toBeNull();
+
+    const intervalNegative = startStockReservationTimer(-5, onTick, onExpire);
+    expect(onExpire).toHaveBeenCalledTimes(2);
+    expect(intervalNegative).toBeNull();
+  });
 });


### PR DESCRIPTION
## 📄 Description
Fixed startStockReservationTimer in js/stock-simulator.js to expire immediately and return null for durations less than or equal to zero, instead of starting an interval that counts into negative territory before firing onExpire. Added a unit test covering zero and negative durations.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5258

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.