### PR TITLE
fix: skipped corrupt ratings in product review aggregator stats

### DIFF
--- a/js/product-review-aggregator.js
+++ b/js/product-review-aggregator.js
@@ -62,15 +62,21 @@ class ProductReviewAggregator {
 
     const distribution = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
     let total = 0;
+    let ratedCount = 0;
 
     productReviews.forEach((review) => {
-      total += review.rating;
-      distribution[review.rating] = (distribution[review.rating] || 0) + 1;
+      const raw = Number(review.rating);
+      if (!Number.isFinite(raw)) return; // Skip corrupt legacy entries
+      const r = Math.min(5, Math.max(1, Math.round(raw)));
+      distribution[r] = (distribution[r] || 0) + 1;
+      total += r;
+      ratedCount += 1;
     });
 
     return {
       count: productReviews.length,
-      average: parseFloat((total / productReviews.length).toFixed(1)),
+      average:
+        ratedCount > 0 ? parseFloat((total / ratedCount).toFixed(1)) : 0,
       distribution
     };
   }

--- a/tests/unit/product-review-aggregator.test.js
+++ b/tests/unit/product-review-aggregator.test.js
@@ -54,4 +54,30 @@ describe('ProductReviewAggregator Unit Tests', () => {
     const breakdown = aggregator.calculateReviewRatingBreakdown('nonexistent');
     expect(breakdown).toEqual({ 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 });
   });
+
+  it('should skip corrupt ratings in stats and breakdown', () => {
+    localStorage.setItem(
+      'cara_reviews_v2',
+      JSON.stringify({
+        'prod-bad': [
+          { id: 'r1', rating: 5, date: new Date().toISOString() },
+          { id: 'r2', rating: 'corrupt', date: new Date().toISOString() },
+          { id: 'r3', rating: 3, date: new Date().toISOString() },
+        ],
+      }),
+    );
+    const aggregator2 = new ProductReviewAggregator();
+    const stats = aggregator2.getStats('prod-bad');
+    expect(stats.count).toBe(3);
+    expect(stats.average).toBe(4.0);
+    expect(Number.isNaN(stats.average)).toBe(false);
+    expect(stats.distribution[5]).toBe(1);
+    expect(stats.distribution[3]).toBe(1);
+    expect(stats.distribution.corrupt).toBeUndefined();
+  });
+
+  it('should reject a review with a non-integer out-of-range rating', () => {
+    const res = aggregator.submitReview('prod-z', { rating: '5.5', body: 'x' });
+    expect(res.success).toBe(false);
+  });
 });


### PR DESCRIPTION
## 📄 Description
Fixed getStats in js/product-review-aggregator.js to skip non-finite stored ratings when computing the distribution and average. Corrupt legacy entries can no longer introduce NaN into the total or pollute the distribution map with out-of-range keys. Added unit tests seeding a corrupt rating.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5264

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.