### PR TITLE
security: escaped HTML in product comparator matrix rendering

### DIFF
--- a/js/product-comparator-matrix.js
+++ b/js/product-comparator-matrix.js
@@ -38,6 +38,15 @@ export class ProductComparatorMatrix {
     };
   }
 
+  escapeHtml(value) {
+    return String(value == null ? '' : value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
   renderMatrixTable(containerId = 'comparator-matrix-container') {
     if (typeof document === 'undefined') return null;
     const container = document.getElementById(containerId);
@@ -49,11 +58,11 @@ export class ProductComparatorMatrix {
       return container;
     }
 
-    const headersHtml = data.products.map(p => `<th>${p.name} <button data-id="${p.id}" class="remove-comp-btn">×</button></th>`).join('');
+    const headersHtml = data.products.map(p => `<th>${this.escapeHtml(p.name)} <button data-id="${this.escapeHtml(p.id)}" class="remove-comp-btn">×</button></th>`).join('');
     const rowsHtml = Object.entries(data.fields).map(([field, values]) => `
       <tr>
         <td class="spec-label">${field.toUpperCase()}</td>
-        ${values.map(v => `<td>${v}</td>`).join('')}
+        ${values.map(v => `<td>${this.escapeHtml(v)}</td>`).join('')}
       </tr>
     `).join('');
 

--- a/tests/unit/product-comparator-matrix.test.js
+++ b/tests/unit/product-comparator-matrix.test.js
@@ -58,4 +58,17 @@ describe('ProductComparatorMatrix', () => {
     expect(diffs).toEqual([]);
   });
 
+  it('should escape HTML in product names and field values when rendering', () => {
+    document.body.innerHTML = '<div id="comparator-matrix-container"></div>';
+    const m = new ProductComparatorMatrix(4);
+    m.addProduct({ id: 'p1', name: '<img src=x onerror=alert(1)>', brand: 'A', price: 20 });
+    m.addProduct({ id: 'p2', name: 'Safe Shirt', brand: 'A', price: 30 });
+    m.renderMatrixTable('comparator-matrix-container');
+
+    const container = document.getElementById('comparator-matrix-container');
+    expect(container.querySelector('img')).toBeNull();
+    const productTh = container.querySelectorAll('thead th')[1];
+    expect(productTh.textContent).toContain('<img src=x onerror=alert(1)>');
+    expect(productTh.innerHTML).toContain('&lt;img');
+  });
 });


### PR DESCRIPTION
## 📄 Description
Fixed renderMatrixTable in js/product-comparator-matrix.js to escape product names, ids, and spec values before injecting them into the comparison table innerHTML. A crafted product name can no longer execute as markup, removing a client-side XSS vector. Added a unit test verifying an HTML payload renders as escaped text.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5266

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.