### PR TITLE
a11y: skipped hidden elements in accessibility focus manager trap

### DIFF
--- a/js/accessibility-focus-manager.js
+++ b/js/accessibility-focus-manager.js
@@ -18,7 +18,14 @@ export class AccessibilityFocusManager {
     this.previousActiveElement = document.activeElement;
 
     const selector = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable]';
-    this.focusableElements = Array.from(modalElement.querySelectorAll(selector));
+    this.focusableElements = Array.from(modalElement.querySelectorAll(selector)).filter(
+      (el) =>
+        el.style.display !== 'none' &&
+        el.style.visibility !== 'hidden' &&
+        !el.hasAttribute('hidden') &&
+        el.getAttribute('aria-hidden') !== 'true' &&
+        !(el.tagName === 'INPUT' && el.type === 'hidden'),
+    );
 
     if (this.focusableElements.length === 0) return false;
 

--- a/tests/unit/accessibility-focus-manager.test.js
+++ b/tests/unit/accessibility-focus-manager.test.js
@@ -45,4 +45,36 @@ describe('AccessibilityFocusManager', () => {
     expect(() => manager.restoreFocus()).not.toThrow();
   });
 
+  it('should skip hidden elements when trapping focus', () => {
+    document.body.innerHTML = `
+      <button id="trigger-btn">Open Modal</button>
+      <div id="test-modal">
+        <input id="input-1" type="text" />
+        <input id="hidden-input" type="hidden" />
+        <button id="hidden-btn" hidden>Hidden</button>
+        <button id="btn-close">Close</button>
+      </div>
+    `;
+    const manager = new AccessibilityFocusManager();
+    const modal = document.getElementById('test-modal');
+    const trapped = manager.trapFocus(modal);
+    expect(trapped).toBe(true);
+    expect(document.activeElement.id).toBe('input-1');
+    expect(manager.focusableElements.length).toBe(2);
+  });
+
+  it('should return false when a modal has no focusable elements', () => {
+    document.body.innerHTML = `
+      <button id="trigger-btn">Open Modal</button>
+      <div id="test-modal"><p>No controls here</p></div>
+    `;
+    const manager = new AccessibilityFocusManager();
+    expect(manager.trapFocus(document.getElementById('test-modal'))).toBe(false);
+  });
+
+  it('should not trap focus when no modal is active', () => {
+    const manager = new AccessibilityFocusManager();
+    const event = new KeyboardEvent('keydown', { key: 'Tab' });
+    expect(() => manager.handleKeyDown(event)).not.toThrow();
+  });
 });


### PR DESCRIPTION
## 📄 Description
Fixed trapFocus in js/accessibility-focus-manager.js to filter hidden inputs, hidden-attribute elements, and aria-hidden elements out of the focusable list, so focus trapping lands only on visible controls. Added unit tests covering hidden-element skipping, empty-modal handling, and inactive-modal key handling.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5274

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.