### PR TITLE
test: added clearing and empty message coverage to a11y-announcer unit tests

### DIFF
--- a/tests/unit/a11y-announcer.test.js
+++ b/tests/unit/a11y-announcer.test.js
@@ -82,4 +82,17 @@ describe('a11y-announcer Unit Tests', () => {
     expect(polite.textContent).toBe('');
   });
 
+  it('should clear the assertive region too when clearing announcements', () => {
+    initAnnouncer();
+    const assertive = document.getElementById('a11y-announcer-assertive');
+    assertive.textContent = 'Stale alert';
+    clearAnnouncements();
+    expect(assertive.textContent).toBe('');
+  });
+
+  it('should announce an empty message without throwing', () => {
+    initAnnouncer();
+    expect(() => announce('')).not.toThrow();
+    expect(() => announce(null)).not.toThrow();
+  });
 });


### PR DESCRIPTION
## 📄 Description
Added tests to tests/unit/a11y-announcer.test.js covering assertive-region clearing and empty/null message handling.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5276

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.