### PR TITLE
fix: guarded malformed category sales data in admin-analytics rendering

### DIFF
--- a/js/admin-analytics.js
+++ b/js/admin-analytics.js
@@ -63,8 +63,8 @@
       .map(
         (r) => `
       <tr>
-        <td><strong>${_escape(r.category.toUpperCase())}</strong></td>
-        <td class="text-right">${r.units_sold.toLocaleString()} units</td>
+        <td><strong>${_escape(String(r.category || '').toUpperCase())}</strong></td>
+        <td class="text-right">${(Number(r.units_sold) || 0).toLocaleString()} units</td>
         <td class="text-right font-weight-bold text-teal">${_fmtRev(r.revenue)}</td>
       </tr>`,
       )

--- a/tests/unit/admin-analytics.test.js
+++ b/tests/unit/admin-analytics.test.js
@@ -123,4 +123,15 @@ describe('admin-analytics.js unit tests', () => {
     expect(typeof window.AdminDashboard).toBe('object');
   });
 
+  it('exposes refresh that calls all three analytics endpoints with credentials', async () => {
+    fetchSpy.mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve({}) });
+    await window.AdminDashboard.refresh();
+    const urls = fetchSpy.mock.calls.map((c) => String(c[0]));
+    expect(urls.some((u) => u.includes('/api/admin/analytics/summary'))).toBe(true);
+    expect(urls.some((u) => u.includes('/api/admin/analytics/category-sales'))).toBe(true);
+    expect(urls.some((u) => u.includes('/api/admin/analytics/order-status-distribution'))).toBe(true);
+    fetchSpy.mock.calls.forEach(([, opts]) => {
+      expect(opts.credentials).toBe('include');
+    });
+  });
 });


### PR DESCRIPTION
## 📄 Description
Fixed renderCategorySales in js/admin-analytics.js to coerce units_sold with Number and String() the category before uppercasing, so malformed category sales entries can no longer crash the dashboard render. Added a unit test verifying the refresh flow calls all three analytics endpoints with credentials.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5279

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.