### PR TITLE
test: added aria-labelledby coverage to a11y-validation unit tests

### DIFF
--- a/tests/unit/a11y-validation.test.js
+++ b/tests/unit/a11y-validation.test.js
@@ -145,6 +145,13 @@ describe('A11y Validation Audit', () => {
       expect(warnings.length).toBe(0);
     });
 
+    it('does not flag inputs with aria-labelledby pointing to a label', () => {
+      document.body.innerHTML =
+        '<span id="search-title">Search</span><input type="text" aria-labelledby="search-title" />';
+      const { warnings } = runA11yAudit(document);
+      expect(warnings.length).toBe(0);
+    });
+
     it('skips hidden inputs', () => {
       document.body.innerHTML = '<input type="hidden" name="token" value="abc" />';
       const { warnings } = runA11yAudit(document);


### PR DESCRIPTION
## 📄 Description
Added a test to tests/unit/a11y-validation.test.js verifying that inputs with an aria-labelledby attribute pointing to a label are not flagged as warnings.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5296

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.