### PR TITLE
fix: corrected checkout tax label to match the 18% tax rate

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -252,7 +252,7 @@
               <span id="summary-shipping">Free</span>
             </div>
             <div class="total-row summary-row">
-              <span>Tax (5%)</span>
+              <span>Tax (18%)</span>
               <span id="summary-tax">₹0.00</span>
             </div>
             <hr class="summary-divider" style="border: 0; border-top: 1px solid var(--border); margin: 10px 0;">


### PR DESCRIPTION
## 📄 Description
Fixed the checkout summary in checkout.html where the Tax label read 5% while the configured TAX_RATE in js/config.js is 0.18 (18%). The label now correctly discloses the applied 18% tax rate.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5302

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.