### PR TITLE
fix: removed duplicate upload-success id on the community page

### DIFF
--- a/community.html
+++ b/community.html
@@ -351,7 +351,6 @@
             <p class="cara-text">PNG, JPG up to 5MB</p>
         </div>
         <input type="file" id="community-upload" accept="image/*">
-    <div id="upload-success" style="display:none; color: green; margin-top: 15px; font-weight: bold; text-align: center;">Photo uploaded successfully!</div>
     </label>
     <div id="upload-success" style="display: none; color: #088178; font-weight: 600; margin-top: 15px; text-align: center;">
         <i class="ri-checkbox-circle-fill"></i> Upload Successful! Your look is being reviewed.


### PR DESCRIPTION
## 📄 Description
Fixed community.html which had two divs with id=upload-success. getElementById only returns the first match, so the upload-success script toggled the stale duplicate instead of the intended visible message. Removed the leftover duplicate so the success message displays correctly.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5308

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.