### PR TITLE
fix: handled corrupt view history in recommendations engine

### DIFF
--- a/js/recommendations.js
+++ b/js/recommendations.js
@@ -7,7 +7,15 @@ export class RecommendationEngine {
     }
 
     getRecommendations() {
-        const history = JSON.parse(localStorage.getItem(this.historyKey) || '[]');
+        let history = [];
+        try {
+            const raw = localStorage.getItem(this.historyKey);
+            const parsed = raw ? JSON.parse(raw) : [];
+            history = Array.isArray(parsed) ? parsed : [];
+        } catch (e) {
+            // Corrupt or legacy storage falls back to defaults.
+            history = [];
+        }
         if (history.length === 0) return this.getDefaultRecommendations();
         return history.slice(0, 4);
     }

--- a/tests/unit/recommendations.test.js
+++ b/tests/unit/recommendations.test.js
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import '../../js/recommendations.js';
+
+const RecommendationEngine = window.recommendationEngine.constructor;
 
 describe('recommendations.js unit tests', function () {
   var storage = {};
@@ -73,5 +76,34 @@ describe('recommendations.js unit tests', function () {
     var result = history.slice(0, 4);
     expect(result.length).toBe(4);
     expect(result[3].id).toBe(3);
+  });
+});
+
+describe('recommendations.js module', function () {
+  it('returns defaults when localStorage contains corrupt JSON', function () {
+    // The real module must not throw on corrupt storage.
+    localStorage.setItem('cara_view_history', '{not-json');
+    var engine = new RecommendationEngine();
+    var result = engine.getRecommendations();
+    expect(result.length).toBe(3);
+    expect(result[0].name).toBe('Cartoon Astronaut T-Shirt');
+  });
+
+  it('returns defaults when history is a non-array value', function () {
+    localStorage.setItem('cara_view_history', JSON.stringify({ bad: true }));
+    var engine = new RecommendationEngine();
+    expect(engine.getRecommendations().length).toBe(3);
+  });
+
+  it('returns up to 4 recent history items', function () {
+    var items = [];
+    for (var i = 0; i < 6; i++) {
+      items.push({ id: i, name: 'Item ' + i, price: i });
+    }
+    localStorage.setItem('cara_view_history', JSON.stringify(items));
+    var engine = new RecommendationEngine();
+    var result = engine.getRecommendations();
+    expect(result.length).toBe(4);
+    expect(result[0].id).toBe(0);
   });
 });


### PR DESCRIPTION
## 📄 Description
Fixed getRecommendations in js/recommendations.js to wrap the view-history read in a try/catch and validate the parsed value is an array. Corrupt or legacy storage now falls back to the default recommendations instead of throwing an uncaught SyntaxError. Added unit tests exercising the real module with corrupt and non-array storage.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5310

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.