### PR TITLE
fix: removed duplicate backToTop button on the shop page

### DIFF
--- a/shop.html
+++ b/shop.html
@@ -547,7 +547,6 @@
         });
       }
     </script>
-    <button id="backToTop">↑</button>
     <script type="module" src="js/shimmer-loader.js" defer></script>
     <script type="module" src="js/recently-viewed.js"></script>
     <script type="module" src="compare.js" defer></script>


### PR DESCRIPTION
## 📄 Description
Fixed shop.html which had two button elements with id=backToTop. The scroll-to-top script uses getElementById, which only returns the first match. Removed the duplicate button so the styled functional one is the single target.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5314

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.