### PR TITLE
fix: removed duplicate scrollTopBtn button on the about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -900,10 +900,6 @@
   </div>
 </footer>
 
-<button id="scrollTopBtn" title="Go to top" aria-label="Go to top">
-  <i class="ri-arrow-up-line"></i>
-</button>
-
 <!-- Scripts -->
 <script type="module" src="navbar.js"></script>
 <script>


### PR DESCRIPTION
## 📄 Description
Fixed about.html which had two button elements with id=scrollTopBtn. The scroll-to-top script uses getElementById, which only returns the first match. Removed the duplicate button so the styled functional one is the single target.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5316

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.