### PR TITLE
fix: guarded custom mock orders parsing in track-order form

### DIFF
--- a/track-order.js
+++ b/track-order.js
@@ -137,9 +137,14 @@ if (form) {
     setTimeout(function () {
       setLoading(false);
       // Check localStorage for custom mock orders first
-      const customOrders = JSON.parse(
-        localStorage.getItem('cara_custom_mock_orders') || '{}',
-      );
+      let customOrders = {};
+      try {
+        const raw = localStorage.getItem('cara_custom_mock_orders');
+        const parsed = raw ? JSON.parse(raw) : {};
+        customOrders = parsed && typeof parsed === 'object' ? parsed : {};
+      } catch (e) {
+        customOrders = {};
+      }
       const order = customOrders[orderIdRaw] || MOCK_ORDERS[orderIdRaw];
 
       // For demo purposes any email works for the demo order


### PR DESCRIPTION
## 📄 Description
Fixed the track-order form in track-order.js to wrap the cara_custom_mock_orders localStorage read in a try/catch and validate the parsed value is an object. Corrupt storage now falls back to an empty object instead of crashing the form.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5326

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.