### PR TITLE
fix: add try/catch guards for custom mock orders parsing in track-order.js

### DIFF
--- a/track-order.js
+++ b/track-order.js
@@ -137,9 +137,13 @@ if (form) {
     setTimeout(function () {
       setLoading(false);
       // Check localStorage for custom mock orders first
-      const customOrders = JSON.parse(
-        localStorage.getItem('cara_custom_mock_orders') || '{}',
-      );
+      let customOrders = {};
+      try {
+        const stored = localStorage.getItem('cara_custom_mock_orders');
+        customOrders = stored ? JSON.parse(stored) : {};
+      } catch (e) {
+        customOrders = {};
+      }
       const order = customOrders[orderIdRaw] || MOCK_ORDERS[orderIdRaw];
 
       // For demo purposes any email works for the demo order
@@ -447,9 +451,13 @@ document.addEventListener('DOMContentLoaded', () => {
       };
 
       // Retrieve existing custom mock orders
-      const customOrders = JSON.parse(
-        localStorage.getItem('cara_custom_mock_orders') || '{}',
-      );
+      let customOrders = {};
+      try {
+        const stored = localStorage.getItem('cara_custom_mock_orders');
+        customOrders = stored ? JSON.parse(stored) : {};
+      } catch (e) {
+        customOrders = {};
+      }
       customOrders[orderId] = customMockOrder;
       localStorage.setItem(
         'cara_custom_mock_orders',


### PR DESCRIPTION
## 📄 Description
track-order.js reads custom mock orders from localStorage using JSON.parse without error handling. If the stored JSON is corrupt (e.g., from a failed write or storage quota issue), this throws an uncaught exception and breaks the track-order form. This change wraps both parse sites in try/catch, defaulting to an empty object on error, matching the existing pattern used in js/loyalty-rewards-engine.js.

## 🔗 Related Issues
Closes #5328

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.