### PR TITLE
fix: remove broken loyalty.js script reference from cart.html

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -244,7 +244,6 @@
   </main>
 
   <script src="js/shipping-calc.js" defer></script>
-  <script src="js/loyalty.js" defer></script>
   <script src="js/coupon-config.js" defer></script>
   <script src="js/cart-coupon.js" defer></script>
 


### PR DESCRIPTION
## 📄 Description
cart.html line 247 loads js/loyalty.js which does not exist in the repository, causing a 404 error on every cart page load. The actual loyalty module is js/loyalty-rewards-engine.js which is loaded separately. This change removes the broken script tag.

## 🔗 Related Issues
Closes #5330

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.