### PR TITLE
chore: remove NFC payload debug log from authenticity.js

### DIFF
--- a/authenticity.js
+++ b/authenticity.js
@@ -80,7 +80,6 @@ document.addEventListener('DOMContentLoaded', () => {
     // Hide scanning UI
     nfcStatus.classList.add('hidden');
     startScanBtn.classList.add('hidden');
-    console.log('NFC Payload:', payload);
 
     // Populate data
     // Fallback to random if serial is missing, simulating a tag


### PR DESCRIPTION
## 📄 Description
authenticity.js had a console.log statement logging NFC tag payload data to the browser console. This leaks potentially sensitive data and is a leftover debug statement. This change removes it.

## 🔗 Related Issues
Closes #5331

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.