### PR TITLE
test: add static asset classification coverage to service-worker unit tests

### DIFF
--- a/tests/unit/service-worker.test.js
+++ b/tests/unit/service-worker.test.js
@@ -51,4 +51,53 @@ describe('service-worker cache strategy', () => {
     expect(isStaticAsset(new URL('https://cara.example/style.css'))).toBe(true);
     expect(isStaticAsset(new URL('https://cara.example/api/orders'))).toBe(false);
   });
+
+  describe('isStaticAsset classification', () => {
+    it('classifies all supported static extensions as assets', () => {
+      const extensions = [
+        '.css',
+        '.js',
+        '.png',
+        '.jpg',
+        '.jpeg',
+        '.webp',
+        '.gif',
+        '.svg',
+        '.ico',
+        '.woff',
+        '.woff2',
+      ];
+      extensions.forEach((ext) => {
+        expect(
+          isStaticAsset(new URL('https://cara.example/bundle' + ext)),
+        ).toBe(true);
+      });
+    });
+
+    it('classifies dynamic paths as non-assets', () => {
+      expect(isStaticAsset(new URL('https://cara.example/api/orders'))).toBe(
+        false,
+      );
+      expect(
+        isStaticAsset(new URL('https://cara.example/admin/dashboard')),
+      ).toBe(false);
+      expect(isStaticAsset(new URL('https://cara.example/shop'))).toBe(false);
+      expect(
+        isStaticAsset(new URL('https://cara.example/index.html')),
+      ).toBe(false);
+    });
+
+    it('handles URLs with query strings on static assets', () => {
+      expect(
+        isStaticAsset(
+          new URL('https://cara.example/bundle.js?v=1.2.3'),
+        ),
+      ).toBe(true);
+      expect(
+        isStaticAsset(
+          new URL('https://cara.example/image.png?width=300&height=200'),
+        ),
+      ).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## 📄 Description
service-worker.js exports isStaticAsset which classifies URLs as static or dynamic for the cache strategy. The existing test only had a basic smoke test. This change adds a dedicated describe block with tests covering all supported extensions (.css, .js, .png, .jpg, etc.), dynamic paths (/api, /admin), and query string variants.

## 🔗 Related Issues
Closes #5333

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.