### PR TITLE
fix: add guards for malformed category sales data in admin-analytics

### DIFF
--- a/js/admin-analytics.js
+++ b/js/admin-analytics.js
@@ -59,7 +59,20 @@
         '<tr><td colspan="3" class="text-muted text-center">No sales recorded yet.</td></tr>';
       return;
     }
-    catTable.innerHTML = list
+    const validList = list.filter(
+      (r) =>
+        r &&
+        typeof r.category === 'string' &&
+        r.category.trim() !== '' &&
+        typeof r.units_sold === 'number' &&
+        isFinite(r.units_sold),
+    );
+    if (validList.length === 0) {
+      catTable.innerHTML =
+        '<tr><td colspan="3" class="text-muted text-center">No valid sales recorded.</td></tr>';
+      return;
+    }
+    catTable.innerHTML = validList
       .map(
         (r) => `
       <tr>


### PR DESCRIPTION
## 📄 Description
renderCategorySales in js/admin-analytics.js directly accessed r.category and r.units_sold without null/undefined checks. If the /api/admin/analytics/category-sales endpoint returns entries with missing properties, this throws a TypeError and prevents the table from rendering. This change adds a filter to skip entries where category is missing or units_sold is not a finite number, with a fallback empty-state message.

## 🔗 Related Issues
Closes #5334

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.