### PR TITLE
fix: escape HTML in product comparator matrix rendering

### DIFF
--- a/js/product-comparator-matrix.js
+++ b/js/product-comparator-matrix.js
@@ -3,6 +3,15 @@
  * Renders side-by-side spec comparison tables and calculates value differences.
  */
 
+function _escape(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 export class ProductComparatorMatrix {
   constructor(maxProducts = 4) {
     this.maxProducts = maxProducts;
@@ -49,11 +58,11 @@ export class ProductComparatorMatrix {
       return container;
     }
 
-    const headersHtml = data.products.map(p => `<th>${p.name} <button data-id="${p.id}" class="remove-comp-btn">×</button></th>`).join('');
+    const headersHtml = data.products.map(p => `<th>${_escape(p.name)} <button data-id="${_escape(p.id)}" class="remove-comp-btn">×</button></th>`).join('');
     const rowsHtml = Object.entries(data.fields).map(([field, values]) => `
       <tr>
-        <td class="spec-label">${field.toUpperCase()}</td>
-        ${values.map(v => `<td>${v}</td>`).join('')}
+        <td class="spec-label">${_escape(field.toUpperCase())}</td>
+        ${values.map(v => `<td>${_escape(v)}</td>`).join('')}
       </tr>
     `).join('');
 


### PR DESCRIPTION
## 📄 Description
renderMatrixTable in js/product-comparator-matrix.js used innerHTML with raw template literal interpolation for product names and field values, creating a reflected XSS vector. This change adds an _escape helper function and applies it to all dynamic content (product names, IDs, field labels, and cell values) before inserting into the DOM.

## 🔗 Related Issues
Closes #5335

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.