### PR TITLE
fix: skip corrupt ratings in product review statistics

### DIFF
--- a/js/product-review-aggregator.js
+++ b/js/product-review-aggregator.js
@@ -60,17 +60,28 @@ class ProductReviewAggregator {
       return { count: 0, average: 0, distribution: { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 } };
     }
 
+    // Filter out reviews with corrupt ratings before computing stats.
+    const validReviews = productReviews.filter(
+      (r) =>
+        typeof r.rating === 'number' &&
+        Number.isInteger(r.rating) &&
+        r.rating >= 1 &&
+        r.rating <= 5,
+    );
+
     const distribution = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
     let total = 0;
 
-    productReviews.forEach((review) => {
+    validReviews.forEach((review) => {
       total += review.rating;
       distribution[review.rating] = (distribution[review.rating] || 0) + 1;
     });
 
     return {
-      count: productReviews.length,
-      average: parseFloat((total / productReviews.length).toFixed(1)),
+      count: validReviews.length,
+      average: validReviews.length > 0
+        ? parseFloat((total / validReviews.length).toFixed(1))
+        : 0,
       distribution
     };
   }


### PR DESCRIPTION
## 📄 Description
getStats() in js/product-review-aggregator.js iterated over all reviews without validating that rating is a valid integer between 1 and 5. Corrupt storage data (NaN, null, out-of-range numbers) corrupted the distribution object and produced NaN in the average. This change adds a filter to only include valid ratings before computing statistics.

## 🔗 Related Issues
Closes #5336

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.