### PR TITLE
fix: expire zero-duration stock reservation timers immediately

### DIFF
--- a/js/stock-simulator.js
+++ b/js/stock-simulator.js
@@ -15,6 +15,10 @@ export function getStockInfo(size) {
 }
 
 export function startStockReservationTimer(durationSeconds, onTick, onExpire) {
+  if (durationSeconds <= 0) {
+    if (onExpire) onExpire();
+    return null;
+  }
   let remaining = durationSeconds;
   const interval = setInterval(() => {
     remaining -= 1;


### PR DESCRIPTION
## 📄 Description
startStockReservationTimer in js/stock-simulator.js started a setInterval even when durationSeconds was 0, delaying the onExpire callback by 1 second instead of calling it immediately. This change adds an early guard: if durationSeconds <= 0, onExpire is called synchronously and null is returned.

## 🔗 Related Issues
Closes #5337

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.