### PR TITLE
feat(cart): GSSoC_2026 add idle session abandoned cart recovery notifier

### DIFF
--- a/docs/architecture/abandoned-cart-notifier.md
+++ b/docs/architecture/abandoned-cart-notifier.md
@@ -1,0 +1,11 @@
+# Abandoned Cart Recovery Notifier Architecture
+
+## Overview
+Monitors idle cart sessions and prompts desktop/browser recovery notifications to reduce bounce rates.
+
+## Usage
+```javascript
+import { AbandonedCartNotifier } from './js/abandoned-cart-notifier.js';
+const notifier = new AbandonedCartNotifier();
+notifier.startTracking(cart.length);
+```

--- a/js/abandoned-cart-notifier.js
+++ b/js/abandoned-cart-notifier.js
@@ -1,0 +1,36 @@
+/**
+ * Abandoned Cart Recovery Notifier
+ * Detects idle cart sessions and prompts desktop/browser recovery notifications.
+ */
+export class AbandonedCartNotifier {
+  constructor(options = {}) {
+    this.idleThresholdMs = options.idleThresholdMs || 300000; // 5 mins
+    this.timer = null;
+    this.onNotify = options.onNotify || (() => {});
+  }
+
+  startTracking(cartItemsCount) {
+    this.stopTracking();
+    if (!cartItemsCount || cartItemsCount <= 0) return;
+
+    this.timer = setTimeout(() => {
+      this.triggerNotification();
+    }, this.idleThresholdMs);
+  }
+
+  stopTracking() {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  triggerNotification() {
+    const payload = {
+      title: 'Items waiting in your cart!',
+      body: 'Complete your purchase now before items sell out.',
+      timestamp: Date.now()
+    };
+    this.onNotify(payload);
+  }
+}

--- a/tests/unit/abandoned-cart-notifier.test.js
+++ b/tests/unit/abandoned-cart-notifier.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AbandonedCartNotifier } from '../../js/abandoned-cart-notifier.js';
+
+describe('AbandonedCartNotifier', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('triggers notification after idle threshold', () => {
+    const spy = vi.fn();
+    const notifier = new AbandonedCartNotifier({ idleThresholdMs: 1000, onNotify: spy });
+    notifier.startTracking(3);
+    
+    vi.advanceTimersByTime(1000);
+    expect(spy).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
# Related Issue
Closes #5492

# Summary
Monitors idle browsing sessions with active items and triggers recovery prompts.

# Changes Made
- `js/abandoned-cart-notifier.js` [NEW]: Idle timer and callback trigger.
- `tests/unit/abandoned-cart-notifier.test.js` [NEW]: Unit tests using fake timers.
- `docs/architecture/abandoned-cart-notifier.md` [NEW]: Architecture documentation.

# Testing
- Verified fake timer triggers in Vitest.
