### PR TITLE
feat(wishlist): GSSoC_2026 add shareable encoded wishlist URL exporter engine

### DIFF
--- a/docs/architecture/wishlist-share-exporter.md
+++ b/docs/architecture/wishlist-share-exporter.md
@@ -1,0 +1,10 @@
+# Shareable Wishlist Link Exporter Architecture
+
+## Overview
+Serializes wishlist item arrays into portable URL query parameters for cross-user sharing.
+
+## Usage
+```javascript
+import { WishlistShareExporter } from './js/wishlist-share-exporter.js';
+const link = WishlistShareExporter.exportToShareableLink(items);
+```

--- a/js/wishlist-share-exporter.js
+++ b/js/wishlist-share-exporter.js
@@ -1,0 +1,24 @@
+/**
+ * Shareable Wishlist Link Exporter Engine
+ * Serializes wishlist item IDs into a base64 encoded share link and decodes on receive.
+ */
+export class WishlistShareExporter {
+  static exportToShareableLink(items = [], baseUrl = 'https://cara.store/wishlist.html') {
+    if (!Array.isArray(items) || items.length === 0) return baseUrl;
+    const ids = items.map(item => typeof item === 'object' ? item.id : item).filter(Boolean);
+    const encoded = btoa(JSON.stringify(ids));
+    return `${baseUrl}?share=${encodeURIComponent(encoded)}`;
+  }
+
+  static parseShareableLink(urlQueryString = '') {
+    const params = new URLSearchParams(urlQueryString);
+    const shareData = params.get('share');
+    if (!shareData) return [];
+    try {
+      const decoded = atob(shareData);
+      return JSON.parse(decoded);
+    } catch {
+      return [];
+    }
+  }
+}

--- a/tests/unit/wishlist-share-exporter.test.js
+++ b/tests/unit/wishlist-share-exporter.test.js
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { WishlistShareExporter } from '../../js/wishlist-share-exporter.js';
+
+describe('WishlistShareExporter', () => {
+  it('encodes wishlist product ids to shareable url', () => {
+    const items = [{ id: 'p1' }, { id: 'p2' }];
+    const url = WishlistShareExporter.exportToShareableLink(items, 'http://localhost/wishlist.html');
+    expect(url).toContain('?share=');
+    
+    const query = url.substring(url.indexOf('?'));
+    const parsed = WishlistShareExporter.parseShareableLink(query);
+    expect(parsed).toEqual(['p1', 'p2']);
+  });
+});


### PR DESCRIPTION
# Related Issue
Closes #5506

# Summary
Serializes wishlist item arrays into portable shareable URLs and decodes incoming shared links.

# Changes Made
- `js/wishlist-share-exporter.js` [NEW]: Base64 URL serializer and decoder.
- `tests/unit/wishlist-share-exporter.test.js` [NEW]: Unit tests for link encoding and decoding.
- `docs/architecture/wishlist-share-exporter.md` [NEW]: Module documentation.

# Testing
- Tested encoding and parsing roundtrips in Vitest.
