### PR TITLE
fix(orders): restore stock by product id and guard NULL created_at (#5510)

### DIFF
--- a/backend/alembic/versions/f6e2b7c4d5a0_add_product_id_to_order_items.py
+++ b/backend/alembic/versions/f6e2b7c4d5a0_add_product_id_to_order_items.py
@@ -1,0 +1,47 @@
+"""add product_id to order_items for stable stock restore
+
+Revision ID: f6e2b7c4d5a0
+Revises: d8e4f1a2b3c4
+Create Date: 2026-08-08 11:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f6e2b7c4d5a0"
+down_revision: Union[str, Sequence[str], None] = "d8e4f1a2b3c4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Batch mode is required for SQLite, which cannot ALTER TABLE ADD COLUMN
+    # with an inline FK constraint (uses a copy-and-recreate strategy).
+    with op.batch_alter_table("order_items") as batch_op:
+        batch_op.add_column(sa.Column("product_id", sa.Integer(), nullable=True))
+        batch_op.create_foreign_key(
+            "fk_order_items_product_id", "products", ["product_id"], ["id"]
+        )
+    # Backfill existing rows from the stored product name snapshot.
+    op.execute(
+        """
+        UPDATE order_items
+        SET product_id = (
+            SELECT products.id FROM products WHERE products.name = order_items.product_name
+        )
+        WHERE product_id IS NULL
+        """
+    )
+    op.create_index(op.f("ix_order_items_product_id"), "order_items", ["product_id"], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_order_items_product_id"), table_name="order_items")
+    with op.batch_alter_table("order_items") as batch_op:
+        batch_op.drop_column("product_id")

--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -2,10 +2,13 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
+import logging
 from .. import models, schemas
 from ..database import get_db
 from .auth import get_current_user
 from datetime import datetime, timezone, timedelta
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -152,6 +155,7 @@ def create_order(
 
         db_items.append(
             models.OrderItem(
+                product_id=db_product.id,
                 product_name=item.product_name,
                 quantity=item.quantity,
                 price=real_price
@@ -245,33 +249,62 @@ def cancel_order(
     if order.status == "CANCELLED":
         raise HTTPException(status_code=400, detail="Order is already cancelled")
 
-    order_age = datetime.now(timezone.utc) - order.created_at.replace(tzinfo=timezone.utc)
-    if order_age > timedelta(hours=CANCELLABLE_WINDOW_HOURS):
-        raise HTTPException(
-            status_code=400,
-            detail=f"Orders can only be cancelled within {CANCELLABLE_WINDOW_HOURS} hours of placing them.",
+    # Guard against NULL created_at (legacy/manual rows): log and skip the
+    # window check instead of crashing with a 500.
+    if order.created_at is None:
+        logger.warning(
+            "Order %s has no created_at; skipping cancellable window check",
+            order.id,
         )
+    else:
+        order_age = datetime.now(timezone.utc) - order.created_at.replace(tzinfo=timezone.utc)
+        if order_age > timedelta(hours=CANCELLABLE_WINDOW_HOURS):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Orders can only be cancelled within {CANCELLABLE_WINDOW_HOURS} hours of placing them.",
+            )
 
     items = (
         db.query(models.OrderItem)
         .filter(models.OrderItem.order_id == order.id)
         .all()
     )
-    product_names = [item.product_name for item in items]
-    if product_names:
+
+    # Restore stock by the stable product_id so renamed/deleted products still
+    # get their inventory back (or are reported explicitly when missing).
+    product_ids = [item.product_id for item in items if item.product_id is not None]
+    product_map = {}
+    if product_ids:
         products = (
             db.query(models.Product)
-            .filter(models.Product.name.in_(product_names))
+            .filter(models.Product.id.in_(product_ids))
             .with_for_update()
             .all()
         )
-        product_map = {product.name: product for product in products}
-        for item in items:
-            product = product_map.get(item.product_name)
-            if product is not None:
-                product.stock += item.quantity
+        product_map = {product.id: product for product in products}
+
+    missing_names = []
+    for item in items:
+        product = product_map.get(item.product_id) if item.product_id is not None else None
+        if product is not None:
+            product.stock += item.quantity
+        else:
+            missing_names.append(item.product_name)
+
+    if missing_names:
+        logger.warning(
+            "Order %s cancelled but could not restore stock for missing products: %s",
+            order.id,
+            ", ".join(sorted(set(missing_names))),
+        )
 
     order.status = "CANCELLED"
     db.commit()
 
-    return {"message": "Order cancelled successfully", "status": order.status}
+    response = {"message": "Order cancelled successfully", "status": order.status}
+    if missing_names:
+        response["warning"] = (
+            "Some items could not be restocked because their products were "
+            "removed or renamed."
+        )
+    return response

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -114,7 +114,14 @@ class OrderItem(Base):
         ForeignKey("orders.id"),
         nullable=False
     )
+    product_id = Column(
+        Integer,
+        ForeignKey("products.id"),
+        index=True,
+        nullable=True,
+    )
     product_name = Column(String, nullable=False)
     quantity = Column(Integer, nullable=False)
     price = Column(Float, nullable=False)
     order = relationship("Order")
+    product = relationship("Product")

--- a/backend/tests/test_order_cancel.py
+++ b/backend/tests/test_order_cancel.py
@@ -1,7 +1,7 @@
 """Tests for order cancel stock restoration."""
 from passlib.context import CryptContext
 
-from app.models import Product, Order, User
+from app.models import Product, Order, OrderItem, User
 from tests.conftest import TestingSessionLocal
 
 ORDERS_URL = "/api/orders/"
@@ -120,3 +120,136 @@ def test_cancel_already_cancelled_does_not_double_restock(client):
     product = db.query(Product).filter(Product.name == "Double Cancel Shirt").first()
     assert product.stock == 5
     db.close()
+
+
+def test_order_item_records_product_id(client):
+    """Order items must snapshot the product_id at creation time."""
+    headers = _auth_headers(client)
+    db = TestingSessionLocal()
+    product = _seed_product(db, name="Snapshot Shirt", stock=10)
+    db.close()
+
+    create = client.post(
+        ORDERS_URL,
+        headers=headers,
+        json={
+            "fullName": "Test User",
+            "email": "cancel@example.com",
+            "address": "1 Test St",
+            "city": "Testville",
+            "zip": "12345",
+            "items": [{"product_name": "Snapshot Shirt", "quantity": 1}],
+        },
+    )
+    assert create.status_code == 201, create.text
+    order_id = create.json()["order_id"]
+
+    db = TestingSessionLocal()
+    item = db.query(OrderItem).filter(OrderItem.order_id == order_id).first()
+    assert item.product_id == product.id
+    db.close()
+
+
+def test_cancel_after_product_rename_restores_stock(client):
+    """Stock restore must follow product_id, so a rename cannot leak inventory."""
+    headers = _auth_headers(client)
+    db = TestingSessionLocal()
+    product = _seed_product(db, name="Rename Shirt", stock=10)
+    db.close()
+
+    create = client.post(
+        ORDERS_URL,
+        headers=headers,
+        json={
+            "fullName": "Test User",
+            "email": "cancel@example.com",
+            "address": "1 Test St",
+            "city": "Testville",
+            "zip": "12345",
+            "items": [{"product_name": "Rename Shirt", "quantity": 3}],
+        },
+    )
+    assert create.status_code == 201, create.text
+    order_id = create.json()["order_id"]
+
+    # Simulate an admin renaming the product after the order was placed.
+    db = TestingSessionLocal()
+    db.query(Product).filter(Product.id == product.id).update({"name": "Renamed Tee"})
+    db.commit()
+    db.close()
+
+    cancel = client.post(f"{ORDERS_URL}{order_id}/cancel", headers=headers)
+    assert cancel.status_code == 200, cancel.text
+    assert cancel.json()["status"] == "CANCELLED"
+
+    db = TestingSessionLocal()
+    after = db.query(Product).filter(Product.id == product.id).first()
+    assert after.stock == 10
+    db.close()
+
+
+def test_cancel_with_deleted_product_reports_warning(client):
+    """Missing products must surface a warning instead of silently leaking stock."""
+    headers = _auth_headers(client)
+    db = TestingSessionLocal()
+    product = _seed_product(db, name="Doomed Shirt", stock=5)
+    db.close()
+
+    create = client.post(
+        ORDERS_URL,
+        headers=headers,
+        json={
+            "fullName": "Test User",
+            "email": "cancel@example.com",
+            "address": "1 Test St",
+            "city": "Testville",
+            "zip": "12345",
+            "items": [{"product_name": "Doomed Shirt", "quantity": 2}],
+        },
+    )
+    assert create.status_code == 201, create.text
+    order_id = create.json()["order_id"]
+
+    db = TestingSessionLocal()
+    db.query(Product).filter(Product.id == product.id).delete()
+    db.commit()
+    db.close()
+
+    cancel = client.post(f"{ORDERS_URL}{order_id}/cancel", headers=headers)
+    assert cancel.status_code == 200, cancel.text
+    body = cancel.json()
+    assert body["status"] == "CANCELLED"
+    assert "warning" in body
+
+
+def test_cancel_with_null_created_at_does_not_crash(client):
+    """A NULL created_at must not 500 the cancellation endpoint."""
+    headers = _auth_headers(client)
+    db = TestingSessionLocal()
+    _seed_product(db, name="Null Created Shirt", stock=7)
+    db.close()
+
+    create = client.post(
+        ORDERS_URL,
+        headers=headers,
+        json={
+            "fullName": "Test User",
+            "email": "cancel@example.com",
+            "address": "1 Test St",
+            "city": "Testville",
+            "zip": "12345",
+            "items": [{"product_name": "Null Created Shirt", "quantity": 2}],
+        },
+    )
+    assert create.status_code == 201, create.text
+    order_id = create.json()["order_id"]
+
+    # Simulate a legacy row with a NULL created_at.
+    db = TestingSessionLocal()
+    db.query(Order).filter(Order.id == order_id).update({"created_at": None})
+    db.commit()
+    db.close()
+
+    cancel = client.post(f"{ORDERS_URL}{order_id}/cancel", headers=headers)
+    assert cancel.status_code == 200, cancel.text
+    assert cancel.json()["status"] == "CANCELLED"


### PR DESCRIPTION
## Problem

Order cancellation restores stock by matching the product *name*: renamed products leak inventory, deleted products silently do nothing, and a `NULL` `created_at` crashes the cancellation endpoint.

## Fix

- Order items now record `product_id` at order time (Alembic migration `f6e2b7c4d5a0`).
- Cancellation restores stock by `product_id`, so renames are handled correctly; for deleted products it reports a warning instead of failing.
- The 24-hour cancellation window guards against `NULL` `created_at` instead of crashing.

## Files changed

- `backend/app/api/orders.py`
- `backend/app/models.py`
- `backend/alembic/versions/f6e2b7c4d5a0_add_product_id_to_order_items.py`
- `backend/tests/test_order_cancel.py`

## Testing

- `backend/tests/test_order_cancel.py` — 6 tests covering stock restore, double-cancel guard, product id capture, restore after rename, deleted-product warning, and NULL `created_at`; all pass.
- Full backend suite shows only the known pre-existing baseline failures.

Closes #5510
