### PR TITLE
fix(recommend): keep FAISS index in sync with admin product changes (#5511)

### DIFF
--- a/backend/app/api/admin_products.py
+++ b/backend/app/api/admin_products.py
@@ -4,6 +4,7 @@ from typing import List
 from .. import models, schemas
 from ..database import get_db
 from .auth import get_current_user
+from ..vector_search.faiss_index import rebuild_index
 
 router = APIRouter()
 
@@ -27,6 +28,7 @@ def create_product(
     db.add(product)
     db.commit()
     db.refresh(product)
+    rebuild_index(db)
     return product
 
 
@@ -44,6 +46,7 @@ def update_product(
         setattr(product, field, value)
     db.commit()
     db.refresh(product)
+    rebuild_index(db)
     return product
 
 
@@ -58,6 +61,7 @@ def delete_product(
         raise HTTPException(status_code=404, detail="Product not found")
     db.delete(product)
     db.commit()
+    rebuild_index(db)
     return {"message": "Product deleted successfully"}
 
 

--- a/backend/app/vector_search/faiss_index.py
+++ b/backend/app/vector_search/faiss_index.py
@@ -1,8 +1,20 @@
 import os
 import numpy as np
 
-index_path = os.path.join(os.path.dirname(__file__), '..', '..', 'faiss_index.bin')
-embeddings_path = os.path.join(os.path.dirname(__file__), '..', '..', 'faiss_embeddings.npz')
+index_path = os.environ.get(
+    "FAISS_INDEX_PATH",
+    os.path.join(os.path.dirname(__file__), '..', '..', 'faiss_index.bin'),
+)
+embeddings_path = os.environ.get(
+    "FAISS_EMBEDDINGS_PATH",
+    os.path.join(os.path.dirname(__file__), '..', '..', 'faiss_embeddings.npz'),
+)
+EMBEDDING_DIM = 512
+
+# Lazily-loaded CLIP handles so runtime rebuilds do not reload the model every call.
+_clip_loaded = False
+_clip_model = None
+_clip_processor = None
 
 
 def _load_faiss():
@@ -12,6 +24,46 @@ def _load_faiss():
         return faiss
     except Exception:
         return None
+
+
+def _load_clip():
+    """Load the CLIP model + processor once; return (model, processor) or (None, None)."""
+    global _clip_loaded, _clip_model, _clip_processor
+    if _clip_loaded:
+        return _clip_model, _clip_processor
+    _clip_loaded = True
+    if os.environ.get("CARA_DISABLE_CLIP", "").lower() in ("1", "true", "yes"):
+        _clip_model, _clip_processor = None, None
+        return _clip_model, _clip_processor
+    try:
+        from transformers import CLIPProcessor, CLIPModel
+        _clip_model = CLIPModel.from_pretrained("openai/clip-vit-base-patch32")
+        _clip_processor = CLIPProcessor.from_pretrained("openai/clip-vit-base-patch32")
+    except Exception as e:
+        print(f"Failed to load CLIP: {e}. Using fallback synthetic embeddings.")
+        _clip_model, _clip_processor = None, None
+    return _clip_model, _clip_processor
+
+
+def _embedding_for_product(product):
+    """Embed a single product image; fall back to a deterministic synthetic vector."""
+    model, processor = _load_clip()
+    img_path = os.path.join(os.path.dirname(__file__), '..', '..', product.img)
+    if model is not None and processor is not None and os.path.exists(img_path):
+        try:
+            from PIL import Image
+            import torch
+            image = Image.open(img_path).convert("RGB")
+            inputs = processor(images=image, return_tensors="pt")
+            with torch.no_grad():
+                image_features = model.get_image_features(**inputs)
+            emb = image_features.numpy()[0]
+            return (emb / np.linalg.norm(emb)).astype('float32')
+        except Exception as e:
+            print(f"Error processing {img_path}: {e}")
+    np.random.seed(product.id)
+    emb = np.random.rand(EMBEDDING_DIM).astype('float32')
+    return emb / np.linalg.norm(emb)
 
 
 def _load_index(faiss):
@@ -45,20 +97,62 @@ index = _load_index(faiss)
 embedding_ids, embeddings = _load_embeddings()
 
 
+def rebuild_index(db):
+    """Rebuild the persisted FAISS index + embeddings from the current catalog.
+
+    Called after admin product create/update/delete so recommendations always
+    reflect the live catalog instead of a stale offline snapshot. Refreshes the
+    module-level objects used by the search paths.
+    """
+    global index, embedding_ids, embeddings
+
+    from .. import models
+
+    products = db.query(models.Product).all()
+
+    ids = []
+    embs = []
+    for product in products:
+        ids.append(product.id)
+        embs.append(_embedding_for_product(product))
+
+    embeddings_np = np.array(embs, dtype='float32')
+    if len(embs):
+        embeddings_np = embeddings_np.reshape(-1, EMBEDDING_DIM)
+    ids_np = np.array(ids).astype('int64')
+
+    # Persist embeddings for brute-force fallback.
+    np.savez(embeddings_path, ids=ids_np, embeddings=embeddings_np)
+
+    # Rebuild the FAISS index with product-id labels.
+    if faiss is not None:
+        try:
+            index_id_map = faiss.IndexIDMap(faiss.IndexFlatL2(EMBEDDING_DIM))
+            if len(ids):
+                index_id_map.add_with_ids(embeddings_np, ids_np)
+            faiss.write_index(index_id_map, index_path)
+            index = index_id_map
+        except Exception as e:
+            print(f"Warning: Failed to rebuild FAISS index: {e}")
+            index = None
+
+    embedding_ids = ids_np
+    embeddings = embeddings_np
+    print(f"Rebuilt FAISS index with {len(ids)} products.")
+    return index, embedding_ids, embeddings
+
+
 def _query_embedding(product_id):
-    """Resolve the stored embedding for a product, preferring persisted data."""
+    """Resolve the stored embedding for a product by its id.
+
+    Only the persisted id -> embedding mapping is used. FAISS reconstruct() takes
+    a positional vector index (not a product id), so it is never used here; when
+    the mapping is unavailable we return None rather than a wrong vector.
+    """
     if embedding_ids is not None and embeddings is not None:
         match = np.where(embedding_ids == product_id)[0]
         if match.size:
             return embeddings[match[0]]
-
-    if faiss is not None and index is not None:
-        try:
-            emb = np.zeros((index.d,), dtype='float32')
-            index.reconstruct(product_id, emb)
-            return emb
-        except Exception:
-            pass
 
     return None
 

--- a/backend/scripts/precompute_embeddings.py
+++ b/backend/scripts/precompute_embeddings.py
@@ -1,86 +1,20 @@
 import os
 import sys
-import numpy as np
-from PIL import Image
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from app.database import SessionLocal
-from app import models
-import faiss
+from app.vector_search.faiss_index import rebuild_index
 
-# Try importing transformers, fallback if not available
-try:
-    from transformers import CLIPProcessor, CLIPModel
-    import torch
-    HAS_TRANSFORMERS = True
-except ImportError:
-    HAS_TRANSFORMERS = False
 
 def precompute():
-    global HAS_TRANSFORMERS
+    """Build the FAISS index + persisted embeddings from the current catalog."""
     db = SessionLocal()
-    products = db.query(models.Product).all()
-    
-    # We will use a dimension of 512 for CLIP
-    d = 512 
-    index = faiss.IndexFlatL2(d)
-    
-    ids = []
-    embeddings = []
-    
-    if HAS_TRANSFORMERS:
-        print("Loading CLIP model (this may take a moment)...")
-        model_name = "openai/clip-vit-base-patch32"
-        try:
-            model = CLIPModel.from_pretrained(model_name)
-            processor = CLIPProcessor.from_pretrained(model_name)
-        except Exception as e:
-            print(f"Failed to load CLIP: {e}. Using fallback synthetic embeddings.")
-            HAS_TRANSFORMERS = False
+    try:
+        rebuild_index(db)
+    finally:
+        db.close()
 
-    for p in products:
-        img_path = os.path.join(os.path.dirname(__file__), '..', '..', p.img)
-        emb = None
-        
-        if HAS_TRANSFORMERS and os.path.exists(img_path):
-            try:
-                image = Image.open(img_path).convert("RGB")
-                inputs = processor(images=image, return_tensors="pt")
-                with torch.no_grad():
-                    image_features = model.get_image_features(**inputs)
-                emb = image_features.numpy()[0]
-                # Normalize
-                emb = emb / np.linalg.norm(emb)
-            except Exception as e:
-                print(f"Error processing {img_path}: {e}")
-                
-        if emb is None:
-            # Fallback synthetic embedding based on id
-            np.random.seed(p.id)
-            emb = np.random.rand(d).astype('float32')
-            emb = emb / np.linalg.norm(emb)
-            
-        embeddings.append(emb)
-        ids.append(p.id)
-        
-    embeddings_np = np.array(embeddings).astype('float32')
-
-    # Persist embeddings alongside the index so the API can run a NumPy
-    # brute-force search when faiss is unavailable at runtime.
-    np.savez(
-        os.path.join(os.path.dirname(__file__), '..', 'faiss_embeddings.npz'),
-        ids=np.array(ids).astype('int64'),
-        embeddings=embeddings_np,
-    )
-
-    # Map faiss ids to product ids
-    index_id_map = faiss.IndexIDMap(index)
-    index_id_map.add_with_ids(embeddings_np, np.array(ids).astype('int64'))
-    
-    faiss.write_index(index_id_map, os.path.join(os.path.dirname(__file__), '..', 'faiss_index.bin'))
-    print(f"Saved FAISS index with {len(ids)} products.")
-    db.close()
 
 if __name__ == "__main__":
     precompute()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,6 +3,19 @@ import os
 # TestClient speaks HTTP; Secure cookies would not round-trip otherwise.
 os.environ.setdefault("COOKIE_SECURE", "false")
 
+# Never download CLIP weights or hit the network during tests; rebuilds use
+# synthetic embeddings instead.
+os.environ.setdefault("CARA_DISABLE_CLIP", "true")
+
+# Keep FAISS artifact writes out of the working tree during tests.
+import tempfile
+
+_FAISS_TMP_DIR = tempfile.mkdtemp(prefix="cara_faiss_test_")
+os.environ.setdefault("FAISS_INDEX_PATH", os.path.join(_FAISS_TMP_DIR, "faiss_index.bin"))
+os.environ.setdefault(
+    "FAISS_EMBEDDINGS_PATH", os.path.join(_FAISS_TMP_DIR, "faiss_embeddings.npz")
+)
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine

--- a/backend/tests/test_recommendation.py
+++ b/backend/tests/test_recommendation.py
@@ -1,5 +1,9 @@
 """Tests for POST /api/outfit/recommend and POST /api/outfit/feedback."""
+import numpy as np
+
 from app.models import Product
+from app.api import admin_products
+from app.vector_search import faiss_index
 from tests.conftest import TestingSessionLocal
 
 RECOMMEND_URL = "/api/outfit/recommend"
@@ -95,3 +99,117 @@ def test_recommend_limit_bounds(client):
     # limit=51 should fail (le=50 constraint in schema)
     r = client.post(RECOMMEND_URL, json={"product_id": p.id, "limit": 51})
     assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# FAISS index sync
+# ---------------------------------------------------------------------------
+
+def _fake_embedding_for_product(product):
+    """Deterministic, network-free embedding for tests."""
+    rng = np.random.RandomState(product.id)
+    emb = rng.rand(faiss_index.EMBEDDING_DIM).astype('float32')
+    return emb / np.linalg.norm(emb)
+
+
+def _rebuild_with_fakes(monkeypatch, tmp_path):
+    monkeypatch.setattr(faiss_index, "index_path", str(tmp_path / "faiss_index.bin"))
+    monkeypatch.setattr(faiss_index, "embeddings_path", str(tmp_path / "faiss_embeddings.npz"))
+    monkeypatch.setattr(faiss_index, "_embedding_for_product", _fake_embedding_for_product)
+    monkeypatch.setattr(faiss_index, "_load_clip", lambda: (None, None))
+
+
+def test_query_embedding_resolves_by_id_not_position(monkeypatch):
+    """Non-contiguous product ids must resolve to the right embedding (no positional reconstruct)."""
+    # Ids are deliberately sparse (as after deletions); embeddings differ per position.
+    ids = np.array([100, 5, 42], dtype='int64')
+    embs = np.zeros((3, faiss_index.EMBEDDING_DIM), dtype='float32')
+    embs[0][:] = 1.0
+    embs[1][:] = 2.0
+    embs[2][:] = 3.0
+    monkeypatch.setattr(faiss_index, "embedding_ids", ids)
+    monkeypatch.setattr(faiss_index, "embeddings", embs)
+
+    # Product 5 lives at position 1; a positional lookup (position 5) would be wrong.
+    q = faiss_index._query_embedding(5)
+    assert q is not None
+    assert q[0] == 2.0
+
+    # Unknown product ids return None instead of a fabricated vector.
+    assert faiss_index._query_embedding(999) is None
+
+
+def test_rebuild_index_tracks_catalog(monkeypatch, tmp_path):
+    _rebuild_with_fakes(monkeypatch, tmp_path)
+
+    db = TestingSessionLocal()
+    a = _seed_product(db, name="IndexA", stock=1)
+    db.close()
+    db = TestingSessionLocal()
+    b = _seed_product(db, name="IndexB", stock=1)
+    db.close()
+
+    db = TestingSessionLocal()
+    faiss_index.rebuild_index(db)
+    db.close()
+
+    def _ids():
+        return {int(i) for i in faiss_index.embedding_ids}
+
+    assert a.id in _ids()
+    assert b.id in _ids()
+
+    # A newly created product shows up after the next rebuild.
+    db = TestingSessionLocal()
+    c = _seed_product(db, name="IndexC", stock=1)
+    db.close()
+    db = TestingSessionLocal()
+    faiss_index.rebuild_index(db)
+    db.close()
+    assert c.id in _ids()
+
+    # A deleted product is removed from the index after the next rebuild.
+    db = TestingSessionLocal()
+    db.query(Product).filter(Product.id == a.id).delete()
+    db.commit()
+    db.close()
+    db = TestingSessionLocal()
+    faiss_index.rebuild_index(db)
+    db.close()
+    assert a.id not in _ids()
+
+
+def test_admin_product_crud_triggers_rebuild(client, monkeypatch, tmp_path, admin_auth_headers):
+    _rebuild_with_fakes(monkeypatch, tmp_path)
+    calls = []
+    monkeypatch.setattr(admin_products, "rebuild_index", lambda db: calls.append(db))
+
+    payload = {
+        "brand": "CRUDBrand",
+        "name": "CRUD Rebuild Shirt",
+        "price": 49.99,
+        "img": "images/products/crud-shirt.jpg",
+        "rating": 4,
+        "category": "minimal",
+        "subcategory": "top",
+        "color": "black",
+        "style": "casual",
+        "stock": 5,
+    }
+
+    created = client.post("/api/admin/products/", headers=admin_auth_headers, json=payload)
+    assert created.status_code == 201, created.text
+    product_id = created.json()["id"]
+    assert len(calls) == 1
+
+    updated = client.put(
+        f"/api/admin/products/{product_id}",
+        headers=admin_auth_headers,
+        json={**payload, "name": "CRUD Rebuild Renamed", "price": 39.99},
+    )
+    assert updated.status_code == 200, updated.text
+    assert len(calls) == 2
+
+    deleted = client.delete(f"/api/admin/products/{product_id}", headers=admin_auth_headers)
+    assert deleted.status_code == 200, deleted.text
+    assert len(calls) == 3


### PR DESCRIPTION
## Problem

The vector-search FAISS index is never kept in sync with admin product create/update/delete, and the fallback `reconstruct()` treats DB ids as positional FAISS indices, producing wrong embeddings.

## Fix

- `faiss_index.py`: index metadata now maps DB ids to FAISS positions; `query`/`reconstruct` resolve by id, not position.
- Admin product CRUD triggers an index rebuild after create/update/delete (`admin_products.py`).
- New `CARA_DISABLE_CLIP` guard and env-configurable `FAISS_INDEX_PATH` / `FAISS_EMBEDDINGS_PATH`; `precompute_embeddings.py` updated to write both artifacts.
- Test fixture cleanup so embedding artifacts don't leak across tests.

## Files changed

- `backend/app/api/admin_products.py`
- `backend/app/vector_search/faiss_index.py`
- `backend/scripts/precompute_embeddings.py`
- `backend/tests/conftest.py`
- `backend/tests/test_recommendation.py`

## Testing

- `backend/tests/test_recommendation.py` — added `test_query_embedding_resolves_by_id_not_position`, `test_rebuild_index_tracks_catalog`, `test_admin_product_crud_triggers_rebuild`; all pass.
- Full backend suite shows only the known pre-existing baseline failures.

Closes #5511
