### PR TITLE
fix(compare): write selectedProduct contract on view-product navigation (#5516)

### DIFF
--- a/compare.js
+++ b/compare.js
@@ -169,6 +169,24 @@
     );
   }
 
+  function viewProduct(p) {
+    if (!p) return;
+    // singleProduct.js reads a JSON object under 'selectedProduct';
+    // 'selectedProductId' is kept for consumers like reviews.js.
+    window.localStorage.setItem(
+      'selectedProduct',
+      JSON.stringify({
+        id: p.id,
+        name: p.name,
+        price: p.price,
+        brand: p.brand,
+        image: p.img,
+      }),
+    );
+    window.localStorage.setItem('selectedProductId', p.name || '');
+    window.location.href = 'singleProduct.html';
+  }
+
   function renderCompareTable(list) {
     const wrapper = document.getElementById('compareTableWrapper');
     const emptyState = document.getElementById('compareEmpty');
@@ -206,7 +224,7 @@
       html += '<tr>';
       html += '<td class="row-label">' + label + '</td>';
 
-      list.forEach((p) => {
+      list.forEach((p, idx) => {
         if (key === 'header') {
           html += '<th class="product-header">';
           html +=
@@ -214,9 +232,9 @@
             (p.img || 'images/products/f1.jpg') +
             '" alt="' +
             p.name +
-            "\" onclick=\"window.localStorage.setItem('selectedProductId','" +
-            p.name.replace(/'/g, '') +
-            "');window.location.href='singleProduct.html'\" />";
+            '" data-compare-view="' +
+            idx +
+            '" />';
           html += '<div class="prod-name">' + p.name + '</div>';
           html += '<div class="prod-brand">' + (p.brand || '—') + '</div>';
           html +=
@@ -230,9 +248,9 @@
           html += '<td>' + (p.rating ? renderStars(p.rating) : '—') + '</td>';
         } else if (key === 'action') {
           html +=
-            '<td><button class="add-cart-btn" onclick="window.localStorage.setItem(\'selectedProductId\',\'' +
-            p.name.replace(/'/g, '') +
-            "');window.location.href='singleProduct.html'\">View Product</button></td>";
+            '<td><button class="add-cart-btn" data-compare-view="' +
+            idx +
+            '">View Product</button></td>';
         } else if (['category', 'color', 'style'].includes(key)) {
           html +=
             '<td class="badge-cell"><span>' + (p[key] || '—') + '</span></td>';
@@ -246,6 +264,10 @@
 
     html += '</tbody></table></div>';
     wrapper.innerHTML = html;
+    wrapper.querySelectorAll('[data-compare-view]').forEach((el) => {
+      const p = list[parseInt(el.dataset.compareView, 10)];
+      if (p) el.addEventListener('click', () => viewProduct(p));
+    });
   }
 
   function initComparePage() {

--- a/products.js
+++ b/products.js
@@ -586,6 +586,7 @@ function renderProducts(containerId, list, query = '') {
     const card = document.createElement('div');
     card.className = 'pro';
     card.dataset.category = p.category;
+    card.dataset.productId = p.id;
     card.addEventListener('click', () => {
       const selectedProduct = {
         id: p.id,

--- a/tests/unit/compare-view-navigation.test.js
+++ b/tests/unit/compare-view-navigation.test.js
@@ -1,0 +1,105 @@
+/**
+ * compare.js — navigation from the comparison table must write the
+ * storage contract that singleProduct.js reads ('selectedProduct'), while
+ * keeping 'selectedProductId' for consumers like reviews.js.
+ *
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const COMPARE_LIST_KEY = 'cara_compare_list';
+
+function seedCompareList(list) {
+  sessionStorage.setItem(COMPARE_LIST_KEY, JSON.stringify(list));
+}
+
+function setupPage() {
+  document.body.innerHTML = `
+    <div id="compareTableWrapper"></div>
+    <div id="compareEmpty"></div>
+    <div class="compare-actions"></div>
+  `;
+  const location = { href: 'compare.html' };
+  vi.stubGlobal('location', location);
+}
+
+describe('compare.js view-product navigation', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    sessionStorage.clear();
+    localStorage.clear();
+    setupPage();
+  });
+
+  it('renders the comparison table from the stored list', async () => {
+    seedCompareList([
+      {
+        id: 42,
+        name: 'Cartoon Astronaut T-Shirts',
+        price: '₹499',
+        brand: 'Cara',
+        img: 'img/products/f1.jpg',
+        rating: 4,
+      },
+    ]);
+
+    await import('../../compare.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const wrapper = document.getElementById('compareTableWrapper');
+    expect(wrapper.style.display).toBe('block');
+    expect(wrapper.querySelector('.compare-table')).toBeTruthy();
+    expect(wrapper.querySelectorAll('[data-compare-view]').length).toBe(2);
+  });
+
+  it('writes the selectedProduct JSON contract on view-product click', async () => {
+    seedCompareList([
+      {
+        id: 42,
+        name: 'Cartoon Astronaut T-Shirts',
+        price: '₹499',
+        brand: 'Cara',
+        img: 'img/products/f1.jpg',
+        rating: 4,
+      },
+    ]);
+
+    await import('../../compare.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const button = document.querySelector('[data-compare-view]');
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    const stored = JSON.parse(localStorage.getItem('selectedProduct'));
+    expect(stored).toEqual({
+      id: 42,
+      name: 'Cartoon Astronaut T-Shirts',
+      price: '₹499',
+      brand: 'Cara',
+      image: 'img/products/f1.jpg',
+    });
+    expect(localStorage.getItem('selectedProductId')).toBe(
+      'Cartoon Astronaut T-Shirts',
+    );
+    expect(window.location.href).toBe('singleProduct.html');
+  });
+
+  it('navigates to the clicked product from the table image as well', async () => {
+    seedCompareList([
+      { id: 7, name: 'Hoodie', price: '₹1200', brand: 'Cara', img: 'f.jpg' },
+      { id: 9, name: 'Jeans', price: '₹1500', brand: 'Cara', img: 'j.jpg' },
+    ]);
+
+    await import('../../compare.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const images = document.querySelectorAll('img[data-compare-view]');
+    expect(images.length).toBe(2);
+    images[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    const stored = JSON.parse(localStorage.getItem('selectedProduct'));
+    expect(stored.id).toBe(9);
+    expect(stored.name).toBe('Jeans');
+  });
+});


### PR DESCRIPTION
## Problem

The product comparison page writes `selectedProductId`, but the single-product page reads `selectedProduct` — "View Product" navigates to a blank/stale product page.

## Fix

- `compare.js` adds a `viewProduct()` helper that writes the `selectedProduct` JSON contract `{id, name, price, brand, image}` (what `singleProduct.js` reads) and keeps writing `selectedProductId` (still consumed by `js/reviews.js`).
- Replaced fragile inline `onclick` strings with `data-compare-view` attributes and delegated listeners (table rows and image links).
- `products.js` stamps `data-product-id` on shop cards.

## Files changed

- `compare.js`
- `products.js`
- `tests/unit/compare-view-navigation.test.js`

## Testing

- New `tests/unit/compare-view-navigation.test.js` — 3 tests covering table rendering, the `selectedProduct` JSON contract on view-product click, and navigation from the image link; all pass.
- Full frontend suite passes (476 tests across 86 files).

Closes #5516
