### PR TITLE
fix(checkout): wire selectPayment for payment tabs

### DIFF
--- a/checkout.js
+++ b/checkout.js
@@ -240,8 +240,20 @@ cardName.addEventListener('input', function () {
 });
 
 // --- Show/Hide Card Details and clear validation states ---
-paymentMethod.addEventListener('change', function () {
-  if (this.value === 'online') {
+function applyPaymentMethod(method) {
+  const value = method === 'online' ? 'online' : 'cod';
+  if (paymentMethod) {
+    paymentMethod.value = value;
+  }
+
+  const tabCod = document.getElementById('tabCOD');
+  const tabOnline = document.getElementById('tabOnline');
+  if (tabCod && tabOnline) {
+    tabCod.classList.toggle('active', value === 'cod');
+    tabOnline.classList.toggle('active', value === 'online');
+  }
+
+  if (value === 'online') {
     cardDetails.style.display = 'block';
     cardName.required = true;
     cardNumber.required = true;
@@ -263,9 +275,17 @@ paymentMethod.addEventListener('change', function () {
     });
   }
 
-  if (this.classList.contains('is-invalid')) {
-    validateField(this);
+  if (paymentMethod && paymentMethod.classList.contains('is-invalid')) {
+    validateField(paymentMethod);
   }
+}
+
+window.selectPayment = function (method) {
+  applyPaymentMethod(method);
+};
+
+paymentMethod.addEventListener('change', function () {
+  applyPaymentMethod(this.value);
 });
 
 // --- Form Submission & Final Validation Check ---


### PR DESCRIPTION
## 📄 Description
Payment tabs called undefined selectPayment and threw ReferenceError on click.

Added applyPaymentMethod / window.selectPayment so tabs and the payment select share the same show/hide logic.

## 🔗 Related Issues
Closes #5620

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## 🛠️ What Was Changed
- Added applyPaymentMethod / window.selectPayment so tabs and the payment select share the same show/hide logic.

## why this needed
Keeps checkout/auth/orders behavior correct and prevents silent failures or abuse.

## 🧪 How Has This Been Tested?
- [x] Ran `npm test` — passed
- [x] Ran relevant backend pytest where applicable

## ✅ Checklist
- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #5620`)
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue