### PR TITLE
fix(auth): enforce is_active in get_current_user

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -146,6 +146,8 @@ def get_current_user(
     user = db.query(models.User).filter(models.User.email == email).first()
     if not user:
         raise HTTPException(404, "User not found.")
+    if not user.is_active:
+        raise HTTPException(403, "Account is deactivated.")
     return user
 
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -87,3 +87,26 @@ def test_me_requires_auth(client):
 def test_me_rejects_invalid_token(client):
     r = client.get(ME_URL, cookies={"access_token": "Bearer invalid.token.here"})
     assert r.status_code == 401
+
+
+def test_me_rejects_deactivated_user(client):
+    payload = {
+        "username": "inactiveuser",
+        "email": "inactive@example.com",
+        "password": "Secure123@",
+    }
+    register = client.post(REGISTER_URL, json=payload)
+    assert register.status_code == 201
+    token = register.json()["access_token"]
+
+    from tests.conftest import TestingSessionLocal
+    from app.models import User
+
+    db = TestingSessionLocal()
+    user = db.query(User).filter(User.email == payload["email"]).first()
+    user.is_active = False
+    db.commit()
+    db.close()
+
+    response = client.get(ME_URL, headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 403


### PR DESCRIPTION
## 📄 Description
get_current_user never checked is_active, so deactivated accounts kept API access via outstanding JWTs.

get_current_user now returns 403 when user.is_active is false; added regression test.

## 🔗 Related Issues
Closes #5622

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## 🛠️ What Was Changed
- get_current_user now returns 403 when user.is_active is false; added regression test.

## why this needed
Keeps checkout/auth/orders behavior correct and prevents silent failures or abuse.

## 🧪 How Has This Been Tested?
- [x] Ran `npm test` — passed
- [x] Ran relevant backend pytest where applicable

## ✅ Checklist
- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #5622`)
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue