### PR TITLE
fix(auth): revoke refresh sessions after password reset

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -329,6 +329,13 @@ def reset_password(
 
     user.hashed_password = pwd.hash(payload.new_password)
     reset_token.used = True
+    # Invalidate outstanding sessions so a stolen refresh token cannot outlive the reset.
+    revoke_refresh_token(user.email)
+    db.query(models.PasswordResetToken).filter(
+        models.PasswordResetToken.user_id == user.id,
+        models.PasswordResetToken.used == False,
+        models.PasswordResetToken.id != reset_token.id,
+    ).update({"used": True})
     db.commit()
 
     return {"message": "Password has been reset successfully"}

--- a/backend/tests/test_password_reset.py
+++ b/backend/tests/test_password_reset.py
@@ -70,3 +70,42 @@ def test_reset_password_expired_token(client):
     )
     assert response.status_code == 400
     assert "Invalid or expired" in response.json()["detail"]
+
+
+def test_reset_password_revokes_refresh_session(client):
+    from app.models import User, PasswordResetToken
+    from app.api import auth as auth_api
+    from passlib.context import CryptContext
+    from datetime import datetime, timedelta, timezone
+    from tests.conftest import TestingSessionLocal
+    import secrets
+
+    pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+    db = TestingSessionLocal()
+    user = User(
+        username="resetrevoke",
+        email="resetrevoke@example.com",
+        hashed_password=pwd.hash("OldPass@123"),
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    auth_api.active_refresh_jtis[user.email] = "stolen-jti"
+    token = secrets.token_urlsafe(32)
+    db.add(
+        PasswordResetToken(
+            user_id=user.id,
+            token=token,
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+    )
+    db.commit()
+    db.close()
+
+    response = client.post(
+        "/api/auth/reset-password",
+        json={"token": token, "new_password": "NewPass@456"},
+    )
+    assert response.status_code == 200
+    assert "resetrevoke@example.com" not in auth_api.active_refresh_jtis


### PR DESCRIPTION
## 📄 Description
Password reset updated the hash but left refresh JTIs valid, so stolen sessions survived the reset.

Call revoke_refresh_token on successful reset, mark other unused reset tokens used, and add a regression test.

## 🔗 Related Issues
Closes #5623

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## 🛠️ What Was Changed
- Call revoke_refresh_token on successful reset, mark other unused reset tokens used, and add a regression test.

## why this needed
Keeps checkout/auth/orders behavior correct and prevents silent failures or abuse.

## 🧪 How Has This Been Tested?
- [x] Ran `npm test` — passed
- [x] Ran relevant backend pytest where applicable

## ✅ Checklist
- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #5623`)
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue