### PR TITLE
fix(admin): reject duplicate product names on update

### DIFF
--- a/backend/app/api/admin_products.py
+++ b/backend/app/api/admin_products.py
@@ -40,6 +40,13 @@ def update_product(
     product = db.query(models.Product).filter(models.Product.id == product_id).first()
     if not product:
         raise HTTPException(status_code=404, detail="Product not found")
+    duplicate = (
+        db.query(models.Product)
+        .filter(models.Product.name == payload.name, models.Product.id != product_id)
+        .first()
+    )
+    if duplicate:
+        raise HTTPException(status_code=409, detail="Product with this name already exists")
     for field, value in payload.model_dump().items():
         setattr(product, field, value)
     db.commit()

--- a/backend/tests/test_admin_products.py
+++ b/backend/tests/test_admin_products.py
@@ -140,3 +140,37 @@ def test_admin_update_stock_invalid(client):
         headers=headers,
     )
     assert response.status_code == 404
+
+
+def test_admin_update_rejects_duplicate_name(client):
+    headers = _admin_headers(client)
+    first = {
+        "brand": "Brand",
+        "name": "Unique Name Alpha",
+        "price": 20.0,
+        "img": "a.jpg",
+        "rating": 3,
+        "category": "minimal",
+        "stock": 10,
+    }
+    second = {
+        "brand": "Brand",
+        "name": "Unique Name Beta",
+        "price": 22.0,
+        "img": "b.jpg",
+        "rating": 3,
+        "category": "minimal",
+        "stock": 10,
+    }
+    a = client.post("/api/admin/products/", json=first, headers=headers)
+    b = client.post("/api/admin/products/", json=second, headers=headers)
+    assert a.status_code == 201
+    assert b.status_code == 201
+    alpha_id = a.json()["id"]
+
+    response = client.put(
+        f"/api/admin/products/{alpha_id}",
+        json={**first, "name": "Unique Name Beta"},
+        headers=headers,
+    )
+    assert response.status_code == 409


### PR DESCRIPTION
## 📄 Description
Admin product PUT skipped name uniqueness and could create duplicate Product.name rows.

update_product now 409s when another product already owns payload.name; added regression test.

## 🔗 Related Issues
Closes #5624

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## 🛠️ What Was Changed
- update_product now 409s when another product already owns payload.name; added regression test.

## why this needed
Keeps checkout/auth/orders behavior correct and prevents silent failures or abuse.

## 🧪 How Has This Been Tested?
- [x] Ran `npm test` — passed
- [x] Ran relevant backend pytest where applicable

## ✅ Checklist
- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #5624`)
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue