### PR TITLE
fix(orders): stop silently discarding checkout email

### DIFF
--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -113,6 +113,12 @@ def create_order(
     if existing:
         return _idempotent_replay(existing.id)
 
+    if order_data.email.lower() != current_user.email.lower():
+        raise HTTPException(
+            status_code=400,
+            detail="Checkout email must match the authenticated account email",
+        )
+
     subtotal = 0.0
     db_items = []
 

--- a/backend/tests/test_order_email_match.py
+++ b/backend/tests/test_order_email_match.py
@@ -1,0 +1,61 @@
+"""Checkout email must match the authenticated account."""
+from passlib.context import CryptContext
+
+from app.models import Product, User
+from tests.conftest import TestingSessionLocal
+
+ORDERS_URL = "/api/orders/"
+pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def _auth_headers(client):
+    db = TestingSessionLocal()
+    if db.query(User).filter(User.email == "emailmatch@example.com").first() is None:
+        db.add(
+            User(
+                username="emailmatch",
+                email="emailmatch@example.com",
+                hashed_password=pwd.hash("Test@1234"),
+            )
+        )
+        db.commit()
+    db.close()
+    login = client.post(
+        "/api/auth/login",
+        json={"email": "emailmatch@example.com", "password": "Test@1234"},
+    )
+    assert login.status_code == 200
+    return {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+
+def test_create_order_rejects_mismatched_email(client):
+    headers = _auth_headers(client)
+    db = TestingSessionLocal()
+    db.add(
+        Product(
+            brand="B",
+            name="Email Match Shirt",
+            price=50.0,
+            img="x.jpg",
+            rating=4,
+            category="minimal",
+            stock=5,
+        )
+    )
+    db.commit()
+    db.close()
+
+    response = client.post(
+        ORDERS_URL,
+        headers=headers,
+        json={
+            "fullName": "Test User",
+            "email": "someone-else@example.com",
+            "address": "1 Test St",
+            "city": "Testville",
+            "zip": "12345",
+            "items": [{"product_name": "Email Match Shirt", "quantity": 1}],
+        },
+    )
+    assert response.status_code == 400
+    assert "must match" in response.json()["detail"]

--- a/checkout.js
+++ b/checkout.js
@@ -705,11 +705,30 @@ function highlightError(el) {
 // Call init on DOM ready
 function initCheckoutPage() {
   initCheckoutValidation();
+  prefillAccountEmail();
 
   CaraErrorBoundary.wrap('#checkoutForm', function () {
     renderCheckoutItems();
     window.updateCheckoutSummary();
   });
+}
+
+function prefillAccountEmail() {
+  const emailInput = document.getElementById('email');
+  if (!emailInput) return;
+
+  fetch(`${API_BASE_URL}/api/auth/me`, { credentials: 'include' })
+    .then((res) => (res.ok ? res.json() : null))
+    .then((data) => {
+      if (!data || !data.email) return;
+      emailInput.value = data.email;
+      emailInput.readOnly = true;
+      emailInput.setAttribute('aria-readonly', 'true');
+      emailInput.title = 'Orders are tied to your account email';
+    })
+    .catch(() => {
+      /* anonymous / offline — leave the field editable until submit auth fails */
+    });
 }
 
 document.addEventListener('DOMContentLoaded', initCheckoutPage);


### PR DESCRIPTION
## 📄 Description
Checkout collected an email then the API overwrote it with current_user.email.

Reject mismatched checkout emails server-side; prefill/lock account email from /api/auth/me; regression test.

## 🔗 Related Issues
Closes #5626

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## 🛠️ What Was Changed
- Reject mismatched checkout emails server-side; prefill/lock account email from /api/auth/me; regression test.

## why this needed
Keeps checkout/auth/orders behavior correct and prevents silent failures or abuse.

## 🧪 How Has This Been Tested?
- [x] Ran `npm test` — passed
- [x] Ran relevant backend pytest where applicable

## ✅ Checklist
- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #5626`)
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue