### PR TITLE
fix(orders): rate limit order creation

### DIFF
--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -1,10 +1,11 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
 from .. import models, schemas
 from ..database import get_db
 from .auth import get_current_user
+from ..limiter import limiter
 from datetime import datetime, timezone, timedelta
 
 router = APIRouter()
@@ -103,7 +104,9 @@ def get_order_detail(
 
 
 @router.post("/", status_code=201)
+@limiter.limit("10/minute")
 def create_order(
+    request: Request,
     order_data: schemas.OrderCreate,
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user)


### PR DESCRIPTION
## 📄 Description
POST /api/orders/ had no rate limit while auth endpoints are capped.

Added @limiter.limit("10/minute") and Request param on create_order.

## 🔗 Related Issues
Closes #5627

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## 🛠️ What Was Changed
- Added @limiter.limit("10/minute") and Request param on create_order.

## why this needed
Keeps checkout/auth/orders behavior correct and prevents silent failures or abuse.

## 🧪 How Has This Been Tested?
- [x] Ran `npm test` — passed
- [x] Ran relevant backend pytest where applicable

## ✅ Checklist
- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #5627`)
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue