### PR TITLE
fix(a11y): accessible checkout success dialog

### DIFF
--- a/checkout.css
+++ b/checkout.css
@@ -518,6 +518,10 @@ textarea {
   display: flex;
 }
 
+.success-overlay.show[hidden] {
+  display: flex !important;
+}
+
 .popup-box {
   background: var(--white);
   border-radius: 20px;

--- a/checkout.html
+++ b/checkout.html
@@ -274,12 +274,19 @@
   </main><!-- /page-wrapper -->
 
   <!-- SUCCESS POPUP -->
-  <div class="success-overlay" id="successPopup">
-    <div class="popup-box">
+  <div class="success-overlay" id="successPopup" hidden>
+    <div
+      class="popup-box"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="successPopupTitle"
+      aria-describedby="successPopupDesc"
+      tabindex="-1"
+    >
       <div class="check-circle" aria-hidden="true"><i class="ri-check-line"></i></div>
-      <h2>Order Successful!</h2>
-      <p>Your order has been placed successfully. We'll send you a confirmation shortly.</p>
-      <button class="popup-btn" onclick="window.location.href='shop.html'">Continue Shopping</button>
+      <h2 id="successPopupTitle">Order Successful!</h2>
+      <p id="successPopupDesc">Your order has been placed successfully. We'll send you a confirmation shortly.</p>
+      <button type="button" class="popup-btn" id="successContinueBtn">Continue Shopping</button>
     </div>
   </div>
 

--- a/checkout.js
+++ b/checkout.js
@@ -1,3 +1,4 @@
+import { createFocusTrap } from './js/a11y-focus-trap.js';
 let checkoutIdempotencyKey = null;
 let checkoutWakeLock = null;
 let isCheckoutProcessing = false;
@@ -440,7 +441,7 @@ function submitCheckoutForm() {
 
       // HIDE CARD DETAILS AGAIN
       cardDetails.style.display = 'none';
-      if (popup) popup.classList.add('show');
+      openSuccessPopup();
 
       // Clear all validation states post-submit
       inputs.forEach((input) => {
@@ -463,9 +464,28 @@ function submitCheckoutForm() {
     });
 }
 
+let successFocusTrap = null;
+
+function openSuccessPopup() {
+  const popup = document.getElementById('successPopup');
+  const dialog = popup ? popup.querySelector('.popup-box') : null;
+  if (!popup || !dialog) return;
+
+  popup.hidden = false;
+  popup.classList.add('show');
+  successFocusTrap = createFocusTrap(dialog);
+  successFocusTrap.activate();
+}
+
 window.closePopup = function () {
   const popup = document.getElementById('successPopup');
-  if (popup) popup.classList.remove('show');
+  if (!popup) return;
+  popup.classList.remove('show');
+  popup.hidden = true;
+  if (successFocusTrap) {
+    successFocusTrap.deactivate();
+    successFocusTrap = null;
+  }
 };
 
 function parsePriceString(priceStr) {
@@ -727,12 +747,23 @@ window.addEventListener('couponRemoved', () => {
   window.updateCheckoutSummary();
 });
 
-// ── Close popup when clicking outside the box ─────────────
+// ── Close popup when clicking outside the box / Escape ─────────────
 const successOverlay = document.getElementById('successPopup');
 if (successOverlay) {
   successOverlay.addEventListener('click', function (e) {
-    if (e.target === this) this.classList.remove('show');
+    if (e.target === this) window.closePopup();
   });
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && successOverlay.classList.contains('show')) {
+      window.closePopup();
+    }
+  });
+  const continueBtn = document.getElementById('successContinueBtn');
+  if (continueBtn) {
+    continueBtn.addEventListener('click', function () {
+      window.location.href = 'shop.html';
+    });
+  }
 }
 // Advanced validation routines checking postal formats and shipping address boundaries.
 console.log("Checkout script updated with Vault integration.");


### PR DESCRIPTION
## 📄 Description
Checkout success overlay lacked dialog semantics, focus trap, and Escape handling.

Dialog ARIA on success popup, createFocusTrap, Escape/outside-click close via closePopup.

## 🔗 Related Issues
Closes #5628

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## 🛠️ What Was Changed
- Dialog ARIA on success popup, createFocusTrap, Escape/outside-click close via closePopup.

## why this needed
Keeps checkout/auth/orders behavior correct and prevents silent failures or abuse.

## 🧪 How Has This Been Tested?
- [x] Ran `npm test` — passed
- [x] Ran relevant backend pytest where applicable

## ✅ Checklist
- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #5628`)
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue