### PR TITLE
fix : added silent internal log hook instead of console.error in error boundary

### DIFF
--- a/js/error-boundary.js
+++ b/js/error-boundary.js
@@ -26,8 +26,15 @@ window.CaraErrorBoundary = (function () {
   }
 
   function logError(error, context) {
-    console.error(`[CaraErrorBoundary] Error in "${context}":`, error);
-    // Hook point for future logging service integration
+    // Capture errors in an internal array for future logging service integration.
+    // Do not use console.error here — it leaks error details to the browser
+    // console in production builds.
+    window._CaraErrorLog = window._CaraErrorLog || [];
+    window._CaraErrorLog.push({
+      context: context,
+      message: error && error.message ? error.message : String(error),
+      timestamp: Date.now(),
+    });
   }
 
   function wrap(selector, renderFn) {

--- a/tests/unit/error-boundary.test.js
+++ b/tests/unit/error-boundary.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 
 // Mock console.error before importing so the module captures our spy
 const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
 import '../../js/error-boundary.js';
 
@@ -10,10 +11,17 @@ describe('error-boundary.js unit tests', () => {
 
   beforeEach(() => {
     errorSpy.mockClear();
+    warnSpy.mockClear();
     document.body.innerHTML = '';
     container = document.createElement('div');
     container.id = 'test-target';
     document.body.appendChild(container);
+    // Clear the internal log array
+    delete window._CaraErrorLog;
+  });
+
+  afterEach(() => {
+    delete window._CaraErrorLog;
   });
 
   it('wrap calls renderFn successfully and does not log an error', () => {
@@ -30,10 +38,12 @@ describe('error-boundary.js unit tests', () => {
     });
     CaraErrorBoundary.wrap('#test-target', renderFn);
     expect(renderFn).toHaveBeenCalledTimes(1);
-    expect(errorSpy).toHaveBeenCalledWith(
-      '[CaraErrorBoundary] Error in "#test-target":',
-      testError,
-    );
+    // logError now uses window._CaraErrorLog instead of console.error
+    expect(window._CaraErrorLog).toBeDefined();
+    expect(window._CaraErrorLog.length).toBeGreaterThan(0);
+    const entry = window._CaraErrorLog[0];
+    expect(entry.context).toBe('#test-target');
+    expect(entry.message).toBe('Render failed');
   });
 
   it('wrap renders a fallback div when renderFn throws', () => {
@@ -67,13 +77,16 @@ describe('error-boundary.js unit tests', () => {
     expect(renderFn).not.toHaveBeenCalled();
   });
 
-  it('logError formats the error with context', () => {
+  it('logError stores error in window._CaraErrorLog instead of console.error', () => {
     const err = new Error('test error');
     CaraErrorBoundary.logError(err, 'my-context');
-    expect(errorSpy).toHaveBeenCalledWith(
-      '[CaraErrorBoundary] Error in "my-context":',
-      err,
-    );
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(window._CaraErrorLog).toBeDefined();
+    expect(window._CaraErrorLog.length).toBe(1);
+    const entry = window._CaraErrorLog[0];
+    expect(entry.context).toBe('my-context');
+    expect(entry.message).toBe('test error');
+    expect(typeof entry.timestamp).toBe('number');
   });
 
   it('should render fallback box on error', () => { expect(true).toBe(true); });


### PR DESCRIPTION
## 📄 Description
Replaced the console.error call in CaraErrorBoundary.logError with a silent internal log hook (window._CaraErrorLog). This prevents runtime error details and stack traces from being exposed in the browser console in production environments while still capturing errors internally for future logging service integration.

## 🔗 Related Issues
Closes #5636

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC
(GirlScript Summer of Code) — please assign this PR to the
`tmdeveloper007` account when picking it up.