### PR TITLE
fix: added silent logging hook to error boundary instead of console.error

### DIFF
--- a/js/error-boundary.js
+++ b/js/error-boundary.js
@@ -2,6 +2,13 @@
 // so one broken component doesn't blank out the whole page.
 
 window.CaraErrorBoundary = (function () {
+  // Internal silent logging hook — replace with error-logger.js wiring in future
+  var _logHook = function (msg, error) {
+    // Silent by default — no console output in production builds.
+    // Wire in window.CaraErrorLogger and call _logHook('error', {msg, error})
+    // to integrate with a centralized logging service.
+  };
+
   function renderFallback(container, message) {
     container.innerHTML = `
       <div class="cara-error-fallback" role="alert" style="
@@ -26,22 +33,21 @@ window.CaraErrorBoundary = (function () {
   }
 
   function logError(error, context) {
-    console.error(`[CaraErrorBoundary] Error in "${context}":`, error);
-    // Hook point for future logging service integration
+    _logHook('[CaraErrorBoundary] Error in "' + context + '":', error);
   }
 
   function wrap(selector, renderFn) {
-    const container = document.querySelector(selector);
+    var container = document.querySelector(selector);
     if (!container) return;
 
-    const attempt = () => {
+    var attempt = function () {
       try {
         renderFn();
       } catch (error) {
         logError(error, selector);
         renderFallback(container, error.message);
 
-        const retryBtn = container.querySelector('.cara-error-retry');
+        var retryBtn = container.querySelector('.cara-error-retry');
         if (retryBtn) {
           retryBtn.addEventListener('click', attempt);
         }
@@ -60,7 +66,12 @@ window.CaraErrorBoundary = (function () {
     logError(event.reason, 'unhandledPromiseRejection');
   });
 
-  return { wrap, logError };
+  return { wrap: wrap, logError: logError };
 })();
 
-function getErrorFallbackHTML(message = 'An unexpected error occurred.') { return `<div class="error-fallback-box"><p>${message}</p></div>`; }
+function getErrorFallbackHTML(message) {
+  if (message === undefined) {
+    message = 'An unexpected error occurred.';
+  }
+  return '<div class="error-fallback-box"><p>' + message + '</p></div>';
+}

--- a/tests/unit/error-boundary.test.js
+++ b/tests/unit/error-boundary.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 
-// Mock console.error before importing so the module captures our spy
+// Mock console.error to prevent test output noise
 const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
 import '../../js/error-boundary.js';
@@ -23,17 +23,15 @@ describe('error-boundary.js unit tests', () => {
     expect(errorSpy).not.toHaveBeenCalled();
   });
 
-  it('wrap catches errors from renderFn and calls logError', () => {
+  it('wrap catches errors from renderFn and does not emit to console.error', () => {
     const testError = new Error('Render failed');
     const renderFn = vi.fn(() => {
       throw testError;
     });
     CaraErrorBoundary.wrap('#test-target', renderFn);
     expect(renderFn).toHaveBeenCalledTimes(1);
-    expect(errorSpy).toHaveBeenCalledWith(
-      '[CaraErrorBoundary] Error in "#test-target":',
-      testError,
-    );
+    // logError now uses a silent internal hook — no console.error in production
+    expect(errorSpy).not.toHaveBeenCalled();
   });
 
   it('wrap renders a fallback div when renderFn throws', () => {
@@ -67,14 +65,14 @@ describe('error-boundary.js unit tests', () => {
     expect(renderFn).not.toHaveBeenCalled();
   });
 
-  it('logError formats the error with context', () => {
+  it('logError does not emit to console.error (silent hook)', () => {
     const err = new Error('test error');
     CaraErrorBoundary.logError(err, 'my-context');
-    expect(errorSpy).toHaveBeenCalledWith(
-      '[CaraErrorBoundary] Error in "my-context":',
-      err,
-    );
+    // logError uses _logHook which is silent by default
+    expect(errorSpy).not.toHaveBeenCalled();
   });
 
-  it('should render fallback box on error', () => { expect(true).toBe(true); });
+  it('should render fallback box on error', () => {
+    expect(true).toBe(true);
+  });
 });


### PR DESCRIPTION
## 📄 Description
The logError function in CaraErrorBoundary called console.error directly, leaking runtime error details (stack traces, context) to the browser console in production. This replaces that with a silent internal _logHook that does nothing by default, providing a clean future integration point for window.CaraErrorLogger wiring.

## 🔗 Related Issues
Closes #5699

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.