### PR TITLE
fix: reset isProcessing flag when toast is removed by MAX_STACK overflow

### DIFF
--- a/js/toast-notifications.js
+++ b/js/toast-notifications.js
@@ -12,7 +12,8 @@
     if (existing) return existing;
     var el = document.createElement('div');
     el.id = 'cara-notif-container';
-    el.style.cssText = 'position:fixed;bottom:20px;right:20px;z-index:9999;display:flex;flex-direction:column;gap:8px;';
+    el.style.cssText =
+      'position:fixed;bottom:20px;right:20px;z-index:9999;display:flex;flex-direction:column;gap:8px;';
     document.body.appendChild(el);
     return el;
   }
@@ -23,7 +24,7 @@
       info: '#3b82f6',
       success: '#22c55e',
       warning: '#f59e0b',
-      error: '#ef4444'
+      error: '#ef4444',
     };
     var color = colors[type] || colors.info;
     el.style.cssText = [
@@ -38,7 +39,7 @@
       'min-width:200px',
       'max-width:320px',
       'opacity:0',
-      'transition:opacity 0.3s'
+      'transition:opacity 0.3s',
     ].join(';');
     el.textContent = message;
     el.setAttribute('role', 'alert');
@@ -57,12 +58,18 @@
     var el = createNotifEl(message, type);
     container.appendChild(el);
 
-    // Stack limit: remove oldest if exceeded
+    // Stack limit: remove oldest if exceeded — dismiss oldest without blocking isProcessing
     var children = Array.from(container.children);
     if (children.length > MAX_STACK) {
       var oldest = children[0];
       oldest.style.opacity = '0';
-      setTimeout(function () { oldest.remove(); }, 300);
+      clearTimeout(oldest._dismissTimer);
+      setTimeout(function () {
+        oldest.remove();
+        // Reset isProcessing so processQueue can continue processing remaining items
+        isProcessing = false;
+        processQueue();
+      }, 300);
     }
 
     // Fade in
@@ -71,10 +78,14 @@
     });
 
     // Dismiss on click
-    el.addEventListener('click', function () { dismiss(el); });
+    el.addEventListener('click', function () {
+      dismiss(el);
+    });
 
     // Auto-dismiss
-    var timer = setTimeout(function () { dismiss(el); }, duration || DEFAULT_DURATION);
+    var timer = setTimeout(function () {
+      dismiss(el);
+    }, duration || DEFAULT_DURATION);
     el._dismissTimer = timer;
   }
 
@@ -84,6 +95,7 @@
     el.style.opacity = '0';
     setTimeout(function () {
       if (el.parentNode) el.remove();
+      // Reset isProcessing immediately so subsequent notify() calls are not blocked
       isProcessing = false;
       processQueue();
     }, 300);
@@ -91,15 +103,27 @@
 
   function notify(message, type, duration) {
     if (typeof document === 'undefined') return;
-    queue.push({ message: message, type: type || 'info', duration: duration || DEFAULT_DURATION });
+    queue.push({
+      message: message,
+      type: type || 'info',
+      duration: duration || DEFAULT_DURATION,
+    });
     processQueue();
   }
 
   window.CaraNotifications = {
-    info: function (msg, dur) { notify(msg, 'info', dur); },
-    success: function (msg, dur) { notify(msg, 'success', dur); },
-    warning: function (msg, dur) { notify(msg, 'warning', dur); },
-    error: function (msg, dur) { notify(msg, 'error', dur); },
-    dismiss: dismiss
+    info: function (msg, dur) {
+      notify(msg, 'info', dur);
+    },
+    success: function (msg, dur) {
+      notify(msg, 'success', dur);
+    },
+    warning: function (msg, dur) {
+      notify(msg, 'warning', dur);
+    },
+    error: function (msg, dur) {
+      notify(msg, 'error', dur);
+    },
+    dismiss: dismiss,
   };
 })();


### PR DESCRIPTION
## 📄 Description
In toast-notifications.js, when the notification stack exceeds MAX_STACK (5), the oldest element is removed from the DOM directly in showImmediate without calling dismiss(). This bypasses the isProcessing reset, leaving it permanently true and blocking all subsequent notify() calls after the first batch. The fix adds clearTimeout and a setTimeout-based isProcessing reset in the MAX_STACK overflow path, ensuring the processing flag is always properly reset regardless of how the notification is removed.

## 🔗 Related Issues
Closes #5701

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.