### PR TITLE
test: added vitest coverage for toast-notifications.js

### DIFF
--- a/tests/unit/toast-notifications.test.js
+++ b/tests/unit/toast-notifications.test.js
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+describe('toast-notifications.js — CaraNotifications', () => {
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    document.body.innerHTML = '';
+    vi.resetModules();
+    const existing = document.getElementById('cara-notif-container');
+    if (existing) existing.remove();
+    await import('../../js/toast-notifications.js');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.resetModules();
+  });
+
+  function advanceFadeIn() {
+    // Advance requestAnimationFrame (synthetic timer in vitest)
+    vi.advanceTimersByTime(0);
+  }
+
+  function advanceDismiss() {
+    // Advance the 300ms dismiss fade-out timer
+    vi.advanceTimersByTime(300);
+  }
+
+  it('info() creates a notification with correct message', () => {
+    window.CaraNotifications.info('Test info message', 5000);
+    advanceFadeIn();
+    const container = document.getElementById('cara-notif-container');
+    expect(container).not.toBeNull();
+    const el = container.querySelector('[role="alert"]');
+    expect(el).not.toBeNull();
+    expect(el.textContent).toBe('Test info message');
+  });
+
+  it('success() creates a notification', () => {
+    window.CaraNotifications.success('Success!', 5000);
+    advanceFadeIn();
+    const el = document.querySelector('[role="alert"]');
+    expect(el).not.toBeNull();
+    expect(el.textContent).toBe('Success!');
+  });
+
+  it('warning() creates a notification', () => {
+    window.CaraNotifications.warning('Warning text', 5000);
+    advanceFadeIn();
+    const el = document.querySelector('[role="alert"]');
+    expect(el).not.toBeNull();
+    expect(el.textContent).toBe('Warning text');
+  });
+
+  it('error() creates a notification', () => {
+    window.CaraNotifications.error('Error text', 5000);
+    advanceFadeIn();
+    const el = document.querySelector('[role="alert"]');
+    expect(el).not.toBeNull();
+    expect(el.textContent).toBe('Error text');
+  });
+
+  it('notifications have role="alert" for accessibility', () => {
+    window.CaraNotifications.info('Alert test', 5000);
+    advanceFadeIn();
+    const el = document.querySelector('[role="alert"]');
+    expect(el).not.toBeNull();
+    expect(el.getAttribute('role')).toBe('alert');
+  });
+
+  it('click on notification triggers dismiss', () => {
+    window.CaraNotifications.info('Click to dismiss', 100000);
+    advanceFadeIn();
+    const el = document.querySelector('[role="alert"]');
+    expect(el).not.toBeNull();
+    el.click();
+    advanceDismiss();
+    const remaining = document.querySelectorAll('[role="alert"]');
+    expect(remaining.length).toBe(0);
+  });
+
+  it('auto-dismiss removes notification after duration', () => {
+    window.CaraNotifications.info('Auto-dismiss me', 2000);
+    advanceFadeIn();
+    // Advance past the 2000ms auto-dismiss timer
+    vi.advanceTimersByTime(2000);
+    advanceDismiss();
+    const remaining = document.querySelectorAll('[role="alert"]');
+    expect(remaining.length).toBe(0);
+  });
+
+  it('dismiss() API manually removes the notification', () => {
+    window.CaraNotifications.info('Manual dismiss', 100000);
+    advanceFadeIn();
+    expect(document.querySelector('[role="alert"]')).not.toBeNull();
+    window.CaraNotifications.dismiss(document.querySelector('[role="alert"]'));
+    advanceDismiss();
+    expect(document.querySelector('[role="alert"]')).toBeNull();
+  });
+});


### PR DESCRIPTION
## 📄 Description
Adds vitest unit tests for js/toast-notifications.js (CaraNotifications). Tests cover: info/success/warning/error notification creation with correct message and role=alert accessibility attribute, click-to-dismiss behavior, manual dismiss() API, and auto-dismiss after the specified duration. Uses vi.useFakeTimers() for timer control.

## 🔗 Related Issues
Closes #5702

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.