### PR TITLE
fix(orders): algorithmic Estimated Return Date policy engine

### DIFF
--- a/backend/alembic/versions/f1a2b3c4d5e6_add_delivered_at_to_orders.py
+++ b/backend/alembic/versions/f1a2b3c4d5e6_add_delivered_at_to_orders.py
@@ -1,0 +1,29 @@
+"""add delivered_at to orders
+
+Revision ID: f1a2b3c4d5e6
+Revises: e9f0a1b2c3d4
+Create Date: 2026-08-08 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f1a2b3c4d5e6'
+down_revision: Union[str, Sequence[str], None] = 'e9f0a1b2c3d4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add delivered_at so the Estimated Return Date policy engine can
+    compute an immutable return deadline as delivered_at + 30 days."""
+    op.add_column('orders', sa.Column('delivered_at', sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop delivered_at."""
+    op.drop_column('orders', 'delivered_at')

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -110,3 +110,41 @@ def get_status_distribution(
         }
         for r in results
     ]
+
+
+@router.post("/orders/{order_id}/status")
+def update_order_status(
+    order_id: int,
+    payload: schemas.OrderStatusUpdate,
+    db: Session = Depends(get_db),
+    admin_user: models.User = Depends(_enforce_admin)
+):
+    """Transition an order's fulfillment status.
+
+    Marking an order DELIVERED captures the delivery timestamp exactly once;
+    the Estimated Return Date policy engine then exposes the immutable
+    return deadline (delivered_at + 30 days) to the buyer.
+    """
+    from .orders import ORDER_STATUSES, return_deadline, set_order_status
+
+    order = db.query(models.Order).filter(models.Order.id == order_id).first()
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+
+    if payload.status not in ORDER_STATUSES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid order status: {payload.status}",
+        )
+
+    set_order_status(order, payload.status)
+    db.commit()
+    db.refresh(order)
+
+    return {
+        "message": "Order status updated",
+        "order_id": order.id,
+        "status": order.status,
+        "delivered_at": order.delivered_at,
+        "return_deadline": return_deadline(order),
+    }

--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -10,6 +10,38 @@ from datetime import datetime, timezone, timedelta
 
 router = APIRouter()
 
+# The rigid policy window applied on top of the delivery timestamp.
+#  return_deadline = delivered_at + RETURN_WINDOW_DAYS
+RETURN_WINDOW_DAYS = 30
+
+# Statuses a carrier/admin may move an order through.
+ORDER_STATUSES = {"PENDING", "CONFIRMED", "SHIPPED", "DELIVERED", "CANCELLED"}
+
+
+def return_deadline(order: models.Order) -> datetime | None:
+    """Algorithmically compute the immutable return deadline.
+
+    Only orders that have a captured delivery timestamp get a deadline;
+    anything still in fulfillment has no return window yet.
+    """
+    if order.delivered_at is None:
+        return None
+    return order.delivered_at.replace(tzinfo=timezone.utc) + timedelta(
+        days=RETURN_WINDOW_DAYS
+    )
+
+
+def set_order_status(order: models.Order, status: str) -> None:
+    """Transition an order to a new status.
+
+    When the order is marked DELIVERED, the delivery timestamp is captured
+    exactly once so the return deadline is immutable.
+    """
+    if status == "DELIVERED":
+        order.mark_delivered()
+    else:
+        order.status = status
+
 
 def _existing_order_for_key(db: Session, email: str, idempotency_key: str | None):
     if not idempotency_key:
@@ -42,6 +74,8 @@ def serialize_order(order: models.Order, db: Session, include_items: bool = True
         "total_amount": order.total_amount,
         "status": order.status,
         "created_at": order.created_at,
+        "delivered_at": order.delivered_at,
+        "return_deadline": return_deadline(order),
         "items": [],
     }
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -91,8 +91,17 @@ class Order(Base):
     total_amount = Column(Float, nullable=False)
     status = Column(String, default="PENDING")
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    # Captured exactly once when the carrier marks the order DELIVERED; the
+    # estimated return deadline is computed as delivered_at + return window.
+    delivered_at = Column(DateTime, nullable=True)
     # Uniqueness is scoped per buyer email via uq_orders_email_idempotency_key
     idempotency_key = Column(String, index=True, nullable=True)
+
+    def mark_delivered(self) -> None:
+        """Transition to DELIVERED, capturing the delivery timestamp once."""
+        if self.delivered_at is None:
+            self.delivered_at = datetime.now(timezone.utc)
+        self.status = "DELIVERED"
 
 class PasswordResetToken(Base):
     __tablename__ = "password_reset_tokens"

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -145,10 +145,17 @@ class OrderResponse(BaseModel):
     total_amount: float
     status: str
     created_at: datetime
+    delivered_at: Optional[datetime] = None
+    return_deadline: Optional[datetime] = None
     items: list[OrderItemResponse] = Field(default_factory=list)
 
     class Config:
         from_attributes = True
+
+
+class OrderStatusUpdate(BaseModel):
+    """Admin/carrier transition of an order's fulfillment status."""
+    status: str = Field(pattern=r"^(PENDING|CONFIRMED|SHIPPED|DELIVERED|CANCELLED)$")
 
 class OrderItemCreate(BaseModel):
     product_id: int = Field(gt=0)

--- a/backend/tests/test_return_date.py
+++ b/backend/tests/test_return_date.py
@@ -5,10 +5,51 @@ Covers the delivered_at capture + immutable return deadline
 """
 from datetime import datetime, timezone
 
-from app.models import Order, Product
+from passlib.context import CryptContext
+
+from app.models import Order, Product, User
 from tests.conftest import TestingSessionLocal
 
 ORDERS_URL = "/api/orders/"
+pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+USER_EMAIL = "return@example.com"
+ADMIN_EMAIL = "returnadmin@example.com"
+
+
+def _ensure_user(email, username, *, role="USER"):
+    db = TestingSessionLocal()
+    user = db.query(User).filter(User.email == email).first()
+    if user is None:
+        user = User(
+            username=username,
+            email=email,
+            hashed_password=pwd.hash("Test@1234"),
+            role=role,
+        )
+        db.add(user)
+        db.commit()
+    db.close()
+
+
+def _auth_headers(client, *, email=USER_EMAIL, username="returnuser"):
+    _ensure_user(email, username)
+    response = client.post(
+        "/api/auth/login",
+        json={"email": email, "password": "Test@1234"},
+    )
+    assert response.status_code == 200, response.text
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+def _admin_headers(client):
+    _ensure_user(ADMIN_EMAIL, "returnadmin", role="ADMIN")
+    response = client.post(
+        "/api/auth/login",
+        json={"email": ADMIN_EMAIL, "password": "Test@1234"},
+    )
+    assert response.status_code == 200, response.text
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
 
 
 def _seed_product(name="Return Tee", stock=20):
@@ -37,7 +78,7 @@ def _create_order(client, headers):
         headers=headers,
         json={
             "fullName": "Return User",
-            "email": "test@example.com",
+            "email": USER_EMAIL,
             "address": "1 Test St",
             "city": "Testville",
             "zip": "12345",
@@ -48,12 +89,13 @@ def _create_order(client, headers):
     return response.json()["order_id"]
 
 
-def test_mark_delivered_captures_timestamp_and_deadline(client, auth_headers, admin_auth_headers):
-    order_id = _create_order(client, auth_headers)
+def test_mark_delivered_captures_timestamp_and_deadline(client):
+    headers = _auth_headers(client)
+    order_id = _create_order(client, headers)
 
     shipped = client.post(
         f"/api/admin/orders/{order_id}/status",
-        headers=admin_auth_headers,
+        headers=_admin_headers(client),
         json={"status": "SHIPPED"},
     )
     assert shipped.status_code == 200, shipped.text
@@ -62,7 +104,7 @@ def test_mark_delivered_captures_timestamp_and_deadline(client, auth_headers, ad
 
     delivered = client.post(
         f"/api/admin/orders/{order_id}/status",
-        headers=admin_auth_headers,
+        headers=_admin_headers(client),
         json={"status": "DELIVERED"},
     )
     assert delivered.status_code == 200, delivered.text
@@ -77,66 +119,73 @@ def test_mark_delivered_captures_timestamp_and_deadline(client, auth_headers, ad
     db.close()
 
 
-def test_delivering_twice_keeps_original_timestamp(client, auth_headers, admin_auth_headers):
-    order_id = _create_order(client, auth_headers)
+def test_delivering_twice_keeps_original_timestamp(client):
+    headers = _auth_headers(client)
+    order_id = _create_order(client, headers)
 
     first = client.post(
         f"/api/admin/orders/{order_id}/status",
-        headers=admin_auth_headers,
+        headers=_admin_headers(client),
         json={"status": "DELIVERED"},
     )
     second = client.post(
         f"/api/admin/orders/{order_id}/status",
-        headers=admin_auth_headers,
+        headers=_admin_headers(client),
         json={"status": "DELIVERED"},
     )
     assert first.json()["delivered_at"] == second.json()["delivered_at"]
 
 
-def test_non_admin_cannot_update_status(client, auth_headers):
-    order_id = _create_order(client, auth_headers)
+def test_non_admin_cannot_update_status(client):
+    headers = _auth_headers(client)
+    order_id = _create_order(client, headers)
     response = client.post(
         f"/api/admin/orders/{order_id}/status",
-        headers=auth_headers,
+        headers=headers,
         json={"status": "DELIVERED"},
     )
     assert response.status_code == 403, response.text
 
 
-def test_order_response_exposes_return_deadline(client, auth_headers, admin_auth_headers):
-    order_id = _create_order(client, auth_headers)
+def _as_utc(value):
+    dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def test_order_response_exposes_return_deadline(client):
+    headers = _auth_headers(client)
+    order_id = _create_order(client, headers)
 
     # Not yet delivered: no deadline surfaced.
-    detail = client.get(f"{ORDERS_URL}{order_id}", headers=auth_headers)
+    detail = client.get(f"{ORDERS_URL}{order_id}", headers=headers)
     assert detail.status_code == 200, detail.text
     assert detail.json()["delivered_at"] is None
     assert detail.json()["return_deadline"] is None
 
     client.post(
         f"/api/admin/orders/{order_id}/status",
-        headers=admin_auth_headers,
+        headers=_admin_headers(client),
         json={"status": "DELIVERED"},
     )
 
-    detail = client.get(f"{ORDERS_URL}{order_id}", headers=auth_headers)
+    detail = client.get(f"{ORDERS_URL}{order_id}", headers=headers)
     assert detail.status_code == 200, detail.text
     assert detail.json()["delivered_at"] is not None
     assert detail.json()["return_deadline"] is not None
 
-    delivered_at = datetime.fromisoformat(
-        detail.json()["delivered_at"].replace("Z", "+00:00")
-    )
-    deadline = datetime.fromisoformat(
-        detail.json()["return_deadline"].replace("Z", "+00:00")
-    )
+    delivered_at = _as_utc(detail.json()["delivered_at"])
+    deadline = _as_utc(detail.json()["return_deadline"])
     assert (deadline - delivered_at).days == 30
 
 
-def test_invalid_status_rejected(client, auth_headers, admin_auth_headers):
-    order_id = _create_order(client, auth_headers)
+def test_invalid_status_rejected(client):
+    headers = _auth_headers(client)
+    order_id = _create_order(client, headers)
     response = client.post(
         f"/api/admin/orders/{order_id}/status",
-        headers=admin_auth_headers,
+        headers=_admin_headers(client),
         json={"status": "IN_TRANSIT"},
     )
     assert response.status_code == 422, response.text

--- a/backend/tests/test_return_date.py
+++ b/backend/tests/test_return_date.py
@@ -1,0 +1,142 @@
+"""Estimated Return Date policy engine tests.
+
+Covers the delivered_at capture + immutable return deadline
+(delivered_at + 30 days) surfaced on the order API.
+"""
+from datetime import datetime, timezone
+
+from app.models import Order, Product
+from tests.conftest import TestingSessionLocal
+
+ORDERS_URL = "/api/orders/"
+
+
+def _seed_product(name="Return Tee", stock=20):
+    db = TestingSessionLocal()
+    product = Product(
+        brand="Cara",
+        name=name,
+        price=1000.0,
+        img="tee.jpg",
+        rating=4,
+        category="minimal",
+        stock=stock,
+    )
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+    product_id = product.id
+    db.close()
+    return product_id
+
+
+def _create_order(client, headers):
+    product_id = _seed_product()
+    response = client.post(
+        ORDERS_URL,
+        headers=headers,
+        json={
+            "fullName": "Return User",
+            "email": "test@example.com",
+            "address": "1 Test St",
+            "city": "Testville",
+            "zip": "12345",
+            "items": [{"product_id": product_id, "quantity": 1}],
+        },
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["order_id"]
+
+
+def test_mark_delivered_captures_timestamp_and_deadline(client, auth_headers, admin_auth_headers):
+    order_id = _create_order(client, auth_headers)
+
+    shipped = client.post(
+        f"/api/admin/orders/{order_id}/status",
+        headers=admin_auth_headers,
+        json={"status": "SHIPPED"},
+    )
+    assert shipped.status_code == 200, shipped.text
+    assert shipped.json()["delivered_at"] is None
+    assert shipped.json()["return_deadline"] is None
+
+    delivered = client.post(
+        f"/api/admin/orders/{order_id}/status",
+        headers=admin_auth_headers,
+        json={"status": "DELIVERED"},
+    )
+    assert delivered.status_code == 200, delivered.text
+    delivered_at = delivered.json()["delivered_at"]
+    assert delivered_at is not None
+    assert delivered.json()["return_deadline"] is not None
+
+    db = TestingSessionLocal()
+    order = db.query(Order).filter(Order.id == order_id).one()
+    assert order.status == "DELIVERED"
+    assert order.delivered_at is not None
+    db.close()
+
+
+def test_delivering_twice_keeps_original_timestamp(client, auth_headers, admin_auth_headers):
+    order_id = _create_order(client, auth_headers)
+
+    first = client.post(
+        f"/api/admin/orders/{order_id}/status",
+        headers=admin_auth_headers,
+        json={"status": "DELIVERED"},
+    )
+    second = client.post(
+        f"/api/admin/orders/{order_id}/status",
+        headers=admin_auth_headers,
+        json={"status": "DELIVERED"},
+    )
+    assert first.json()["delivered_at"] == second.json()["delivered_at"]
+
+
+def test_non_admin_cannot_update_status(client, auth_headers):
+    order_id = _create_order(client, auth_headers)
+    response = client.post(
+        f"/api/admin/orders/{order_id}/status",
+        headers=auth_headers,
+        json={"status": "DELIVERED"},
+    )
+    assert response.status_code == 403, response.text
+
+
+def test_order_response_exposes_return_deadline(client, auth_headers, admin_auth_headers):
+    order_id = _create_order(client, auth_headers)
+
+    # Not yet delivered: no deadline surfaced.
+    detail = client.get(f"{ORDERS_URL}{order_id}", headers=auth_headers)
+    assert detail.status_code == 200, detail.text
+    assert detail.json()["delivered_at"] is None
+    assert detail.json()["return_deadline"] is None
+
+    client.post(
+        f"/api/admin/orders/{order_id}/status",
+        headers=admin_auth_headers,
+        json={"status": "DELIVERED"},
+    )
+
+    detail = client.get(f"{ORDERS_URL}{order_id}", headers=auth_headers)
+    assert detail.status_code == 200, detail.text
+    assert detail.json()["delivered_at"] is not None
+    assert detail.json()["return_deadline"] is not None
+
+    delivered_at = datetime.fromisoformat(
+        detail.json()["delivered_at"].replace("Z", "+00:00")
+    )
+    deadline = datetime.fromisoformat(
+        detail.json()["return_deadline"].replace("Z", "+00:00")
+    )
+    assert (deadline - delivered_at).days == 30
+
+
+def test_invalid_status_rejected(client, auth_headers, admin_auth_headers):
+    order_id = _create_order(client, auth_headers)
+    response = client.post(
+        f"/api/admin/orders/{order_id}/status",
+        headers=admin_auth_headers,
+        json={"status": "IN_TRANSIT"},
+    )
+    assert response.status_code == 422, response.text

--- a/js/return-status.js
+++ b/js/return-status.js
@@ -1,0 +1,141 @@
+/**
+ * Estimated Return Date policy engine (ReturnStatus)
+ *
+ * Algorithmically computes the immutable return deadline for a delivered
+ * order as `delivered_at + RETURN_WINDOW_DAYS` and renders a clear status
+ * into the Account Dashboard / Order History:
+ *   - eligible: "Eligible for return until {date}" (return button enabled)
+ *   - expired:  "Return window closed on {date}" (return button disabled)
+ *   - otherwise: no return window yet (button disabled)
+ *
+ * Mirrors the backend policy (backend/app/api/orders.py RETURN_WINDOW_DAYS).
+ */
+const RETURN_WINDOW_DAYS = 30;
+
+function toDate(value) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function ordinalSuffix(day) {
+  const s = ['th', 'st', 'nd', 'rd'];
+  const v = day % 100;
+  return s[(v - 20) % 10] || s[v] || s[0];
+}
+
+function formatDeadline(date) {
+  const month = date.toLocaleDateString('en-US', { month: 'long' });
+  return `${month} ${date.getDate()}${ordinalSuffix(date.getDate())}`;
+}
+
+function computeReturnDeadline(deliveredAt, windowDays = RETURN_WINDOW_DAYS) {
+  const delivered = toDate(deliveredAt);
+  if (!delivered) return null;
+  const deadline = new Date(delivered.getTime());
+  deadline.setDate(deadline.getDate() + windowDays);
+  return deadline;
+}
+
+function getReturnStatus(order, windowDays = RETURN_WINDOW_DAYS) {
+  const status = String((order && order.status) || '').toUpperCase();
+
+  if (status === 'CANCELLED') {
+    return {
+      state: 'unavailable',
+      deadline: null,
+      deadlineLabel: '',
+      message: 'This order was cancelled.',
+      canRequestReturn: false,
+    };
+  }
+
+  const deliveredAt = order && (order.delivered_at || order.deliveredAt);
+  const deadline = computeReturnDeadline(deliveredAt, windowDays);
+
+  if (!deadline) {
+    return {
+      state: 'not-delivered',
+      deadline: null,
+      deadlineLabel: '',
+      message: 'Returns available once the order is delivered.',
+      canRequestReturn: false,
+    };
+  }
+
+  const now = new Date();
+  const eligible = deadline.getTime() >= now.getTime();
+  const deadlineLabel = formatDeadline(deadline);
+
+  return {
+    state: eligible ? 'eligible' : 'expired',
+    deadline,
+    deadlineLabel,
+    message: eligible
+      ? `Eligible for return until ${deadlineLabel}.`
+      : `Return window closed on ${deadlineLabel}.`,
+    canRequestReturn: eligible,
+  };
+}
+
+function escapeHtml(value) {
+  return String(value ?? '').replace(
+    /[&<>"']/g,
+    (ch) =>
+      ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;',
+      })[ch],
+  );
+}
+
+function renderReturnStatus(order, windowDays = RETURN_WINDOW_DAYS) {
+  const info = getReturnStatus(order, windowDays);
+  const stateClass = `return-status return-status--${info.state}`;
+
+  let button = '';
+  if (info.state === 'eligible' || info.state === 'expired') {
+    const disabled = info.state === 'expired';
+    button = `<button class="return-request-btn" type="button" ${
+      disabled ? 'disabled' : ''
+    }>${disabled ? 'Returns Closed' : 'Request Return'}</button>`;
+  }
+
+  return `
+    <div class="${stateClass}" role="status">
+      <span class="return-status__text">${escapeHtml(info.message)}</span>
+      ${button}
+    </div>
+  `;
+}
+
+function renderReturnDeadlineInline(order, windowDays = RETURN_WINDOW_DAYS) {
+  const info = getReturnStatus(order, windowDays);
+  if (info.state !== 'eligible' && info.state !== 'expired') {
+    return '';
+  }
+  return `<div class="return-deadline-inline return-deadline-inline--${info.state}">${escapeHtml(
+    info.message,
+  )}</div>`;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    RETURN_WINDOW_DAYS,
+    computeReturnDeadline,
+    getReturnStatus,
+    renderReturnStatus,
+    renderReturnDeadlineInline,
+  };
+} else {
+  window.ReturnStatus = {
+    RETURN_WINDOW_DAYS,
+    computeReturnDeadline,
+    getReturnStatus,
+    renderReturnStatus,
+    renderReturnDeadlineInline,
+  };
+}

--- a/js/return-status.js
+++ b/js/return-status.js
@@ -99,9 +99,10 @@ function renderReturnStatus(order, windowDays = RETURN_WINDOW_DAYS) {
   let button = '';
   if (info.state === 'eligible' || info.state === 'expired') {
     const disabled = info.state === 'expired';
-    button = `<button class="return-request-btn" type="button" ${
-      disabled ? 'disabled' : ''
-    }>${disabled ? 'Returns Closed' : 'Request Return'}</button>`;
+    const disabledAttr = disabled ? ' disabled' : '';
+    button = `<button class="return-request-btn" type="button"${disabledAttr}>${
+      disabled ? 'Returns Closed' : 'Request Return'
+    }</button>`;
   }
 
   return `

--- a/order-history.css
+++ b/order-history.css
@@ -246,3 +246,42 @@
   .order-history-hero { align-items: start; flex-direction: column; }
   .order-modal { padding: 12px; }
 }
+/* Estimated Return Date policy engine — dynamic return-status messaging */
+.return-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin: 14px 0;
+  padding: 12px 16px;
+  border-radius: 10px;
+  font-size: 0.92rem;
+}
+.return-status--eligible { background: #ecfdf5; color: #065f46; border: 1px solid #a7f3d0; }
+.return-status--expired { background: #fef2f2; color: #991b1b; border: 1px solid #fecaca; }
+.return-status--not-delivered,
+.return-status--unavailable { background: #f8fafc; color: #475569; border: 1px solid #e2e8f0; }
+.return-status__text { font-weight: 600; }
+.return-request-btn {
+  border: none;
+  border-radius: 8px;
+  padding: 8px 14px;
+  font-weight: 700;
+  font-size: 0.85rem;
+  cursor: pointer;
+  background: #1f2937;
+  color: #ffffff;
+}
+.return-request-btn:disabled {
+  background: #e2e8f0;
+  color: #94a3b8;
+  cursor: not-allowed;
+}
+.return-deadline-inline {
+  margin-top: 4px;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+.return-deadline-inline--eligible { color: #047857; }
+.return-deadline-inline--expired { color: #b91c1c; }

--- a/order-history.js
+++ b/order-history.js
@@ -1,3 +1,5 @@
+import { renderReturnStatus, renderReturnDeadlineInline } from './js/return-status.js';
+
 const ORDER_API_BASE_URL = window.CARA_API_BASE_URL || '';
 
 
@@ -63,7 +65,7 @@ function renderOrders(orders) {
       <td>#${escapeHtml(order.id)}</td>
       <td>${escapeHtml(createdAt)}</td>
       <td>${escapeHtml(formatCurrency(order.total_amount))}</td>
-      <td><span class="${escapeHtml(statusClass(order.status))}">${escapeHtml(order.status)}</span></td>
+      <td><span class="${escapeHtml(statusClass(order.status))}">${escapeHtml(order.status)}</span>${renderReturnDeadlineInline(order)}</td>
       <td><button class="details-btn" type="button" data-order-id="${escapeHtml(order.id)}">View</button></td>
        <td><button class="cancel-btn" type="button" data-order-id="${escapeHtml(order.id)}">Cancel</button></td>
     `;
@@ -122,6 +124,8 @@ function renderOrderDetails(order) {
       <h2 style="margin: 0 0 8px;">${escapeHtml(order.status)}</h2>
       <p style="margin: 0; color: #55606f;">Placed on ${escapeHtml(order.created_at ? new Date(order.created_at).toLocaleString() : 'N/A')}</p>
     </div>
+
+    ${renderReturnStatus(order)}
 
     <div class="order-meta-grid">
       <div class="meta-card"><span class="meta-label">Customer</span><strong>${escapeHtml(order.full_name)}</strong></div>

--- a/tests/unit/return-status.test.js
+++ b/tests/unit/return-status.test.js
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for js/return-status.js — the Estimated Return Date
+ * policy engine (delivered_at + 30 days).
+ *
+ * Regression tests for https://github.com/janavipandole/Cara/issues/5578
+ */
+import { describe, expect, it } from 'vitest';
+
+const ReturnStatus = require('../../js/return-status.js');
+
+const { computeReturnDeadline, getReturnStatus, renderReturnStatus, renderReturnDeadlineInline } =
+  ReturnStatus;
+
+function daysAgo(days) {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+describe('computeReturnDeadline', () => {
+  it('returns null when no delivery timestamp exists', () => {
+    expect(computeReturnDeadline(null)).toBeNull();
+    expect(computeReturnDeadline('')).toBeNull();
+  });
+
+  it('adds the 30-day policy window to the delivery timestamp', () => {
+    const deliveredAt = '2026-08-01T10:00:00.000Z';
+    const deadline = computeReturnDeadline(deliveredAt);
+    expect(deadline.toISOString()).toBe('2026-08-31T10:00:00.000Z');
+  });
+
+  it('respects a custom window', () => {
+    const deadline = computeReturnDeadline('2026-08-01T00:00:00.000Z', 45);
+    expect(deadline.toISOString()).toBe('2026-09-15T00:00:00.000Z');
+  });
+});
+
+describe('getReturnStatus', () => {
+  it('marks cancelled orders as unavailable', () => {
+    const info = getReturnStatus({ status: 'CANCELLED', delivered_at: daysAgo(10) });
+    expect(info.state).toBe('unavailable');
+    expect(info.canRequestReturn).toBe(false);
+  });
+
+  it('reports not-delivered orders as having no window yet', () => {
+    const info = getReturnStatus({ status: 'CONFIRMED', delivered_at: null });
+    expect(info.state).toBe('not-delivered');
+    expect(info.canRequestReturn).toBe(false);
+    expect(info.deadline).toBeNull();
+  });
+
+  it('flags an in-window delivered order as eligible', () => {
+    const info = getReturnStatus({ status: 'DELIVERED', delivered_at: daysAgo(10) });
+    expect(info.state).toBe('eligible');
+    expect(info.canRequestReturn).toBe(true);
+    expect(info.message).toContain('Eligible for return until');
+  });
+
+  it('flags an out-of-window delivered order as expired', () => {
+    const info = getReturnStatus({ status: 'DELIVERED', delivered_at: daysAgo(40) });
+    expect(info.state).toBe('expired');
+    expect(info.canRequestReturn).toBe(false);
+    expect(info.message).toContain('Return window closed on');
+  });
+});
+
+describe('renderReturnStatus', () => {
+  it('renders an enabled return button while eligible', () => {
+    const html = renderReturnStatus({ status: 'DELIVERED', delivered_at: daysAgo(5) });
+    expect(html).toContain('return-status--eligible');
+    expect(html).toContain('Eligible for return until');
+    expect(html).toContain('<button class="return-request-btn" type="button">Request Return</button>');
+  });
+
+  it('renders a disabled button once the window closes', () => {
+    const html = renderReturnStatus({ status: 'DELIVERED', delivered_at: daysAgo(60) });
+    expect(html).toContain('return-status--expired');
+    expect(html).toContain('Return window closed on');
+    expect(html).toContain('disabled');
+    expect(html).toContain('Returns Closed');
+  });
+
+  it('renders no return button for non-delivered orders', () => {
+    const html = renderReturnStatus({ status: 'CONFIRMED' });
+    expect(html).toContain('return-status--not-delivered');
+    expect(html).not.toContain('return-request-btn');
+  });
+});
+
+describe('renderReturnDeadlineInline', () => {
+  it('returns empty markup when the order is not delivered', () => {
+    expect(renderReturnDeadlineInline({ status: 'CONFIRMED' })).toBe('');
+  });
+
+  it('returns a compact deadline for delivered orders', () => {
+    const html = renderReturnDeadlineInline({ status: 'DELIVERED', delivered_at: daysAgo(3) });
+    expect(html).toContain('return-deadline-inline');
+    expect(html).toContain('Eligible for return until');
+  });
+});


### PR DESCRIPTION
Closes #5578

## Summary
When an order is marked `DELIVERED`, the backend now captures the delivery timestamp exactly once and algorithmically computes an immutable return deadline of `delivered_at + 30 days`. The deadline is surfaced on the order API and rendered dynamically in Order History through a new `ReturnStatus` component:

- While the window is open: **"Eligible for return until {date}"**
- After it closes: **"Return window closed on {date}"** (return button disabled)
- Pre-delivery: no return window yet (button disabled)

## Changes
- `Order` model gains `delivered_at`; new Alembic migration `f1a2b3c4d5e6`
- `POST /api/admin/orders/{id}/status` records `delivered_at` once when transitioning to `DELIVERED` (idempotent — re-delivering keeps the original timestamp)
- Order API exposes `delivered_at` and computed `return_deadline`
- `js/return-status.js` — `ReturnStatus` policy engine + Order History UI wiring
- Backend regression tests (`backend/tests/test_return_date.py`) and frontend unit tests (`tests/unit/return-status.test.js`)

## Verification
- Backend: `5 passed`
- Frontend: `12 passed`
