### PR TITLE
fix(orders): only allow cancelling pre-fulfillment orders

### DIFF
--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -234,6 +234,10 @@ def create_order(
     }
 
 CANCELLABLE_WINDOW_HOURS = 24
+# Only pre-fulfillment statuses may be cancelled by the buyer. Once an order
+# has shipped or been delivered, stock can no longer be safely returned by a
+# simple status flip, so those states are intentionally excluded.
+CANCELLABLE_STATUSES = {"PENDING", "CONFIRMED"}
 
 @router.post("/{order_id}/cancel")
 def cancel_order(
@@ -255,6 +259,12 @@ def cancel_order(
 
     if order.status == "CANCELLED":
         raise HTTPException(status_code=400, detail="Order is already cancelled")
+
+    if order.status not in CANCELLABLE_STATUSES:
+        raise HTTPException(
+            status_code=400,
+            detail="Orders can only be cancelled before they are shipped or delivered",
+        )
 
     order_age = datetime.now(timezone.utc) - order.created_at.replace(tzinfo=timezone.utc)
     if order_age > timedelta(hours=CANCELLABLE_WINDOW_HOURS):

--- a/backend/tests/test_order_cancel.py
+++ b/backend/tests/test_order_cancel.py
@@ -124,7 +124,7 @@ def test_cancel_already_cancelled_does_not_double_restock(client):
     db.close()
 
 
-def _create_order_and_set_status(client, headers, *, product_name, quantity, status):
+def _create_order_and_set_status(client, headers, *, email, product_name, quantity, status):
     db = TestingSessionLocal()
     product = _seed_product(db, name=product_name, stock=10)
     product_id = product.id
@@ -135,7 +135,7 @@ def _create_order_and_set_status(client, headers, *, product_name, quantity, sta
         headers=headers,
         json={
             "fullName": "Test User",
-            "email": "cancel@example.com",
+            "email": email,
             "address": "1 Test St",
             "city": "Testville",
             "zip": "12345",
@@ -158,7 +158,12 @@ def _create_order_and_set_status(client, headers, *, product_name, quantity, sta
 def test_cancel_rejected_for_shipped_order_within_window(client):
     headers = _auth_headers(client, username="shipuser", email="ship@example.com")
     order_id, product_id = _create_order_and_set_status(
-        client, headers, product_name="Shipped Tee", quantity=2, status="SHIPPED"
+        client,
+        headers,
+        email="ship@example.com",
+        product_name="Shipped Tee",
+        quantity=2,
+        status="SHIPPED",
     )
 
     response = client.post(f"{ORDERS_URL}{order_id}/cancel", headers=headers)
@@ -173,7 +178,12 @@ def test_cancel_rejected_for_shipped_order_within_window(client):
 def test_cancel_rejected_for_delivered_order_within_window(client):
     headers = _auth_headers(client, username="deliveruser", email="deliver@example.com")
     order_id, product_id = _create_order_and_set_status(
-        client, headers, product_name="Delivered Tee", quantity=4, status="DELIVERED"
+        client,
+        headers,
+        email="deliver@example.com",
+        product_name="Delivered Tee",
+        quantity=4,
+        status="DELIVERED",
     )
 
     response = client.post(f"{ORDERS_URL}{order_id}/cancel", headers=headers)

--- a/backend/tests/test_order_cancel.py
+++ b/backend/tests/test_order_cancel.py
@@ -124,6 +124,67 @@ def test_cancel_already_cancelled_does_not_double_restock(client):
     db.close()
 
 
+def _create_order_and_set_status(client, headers, *, product_name, quantity, status):
+    db = TestingSessionLocal()
+    product = _seed_product(db, name=product_name, stock=10)
+    product_id = product.id
+    db.close()
+
+    create = client.post(
+        ORDERS_URL,
+        headers=headers,
+        json={
+            "fullName": "Test User",
+            "email": "cancel@example.com",
+            "address": "1 Test St",
+            "city": "Testville",
+            "zip": "12345",
+            "items": [{"product_id": product_id, "quantity": quantity}],
+        },
+    )
+    assert create.status_code == 201, create.text
+    order_id = create.json()["order_id"]
+
+    # Simulate a carrier/fulfillment marking the order as progressed while
+    # still inside the 24h cancel window (issue #5625).
+    db = TestingSessionLocal()
+    order = db.query(Order).filter(Order.id == order_id).one()
+    order.status = status
+    db.commit()
+    db.close()
+    return order_id, product_id
+
+
+def test_cancel_rejected_for_shipped_order_within_window(client):
+    headers = _auth_headers(client, username="shipuser", email="ship@example.com")
+    order_id, product_id = _create_order_and_set_status(
+        client, headers, product_name="Shipped Tee", quantity=2, status="SHIPPED"
+    )
+
+    response = client.post(f"{ORDERS_URL}{order_id}/cancel", headers=headers)
+    assert response.status_code == 400, response.text
+
+    db = TestingSessionLocal()
+    assert db.query(Product).filter(Product.id == product_id).one().stock == 8
+    assert db.query(Order).filter(Order.id == order_id).one().status == "SHIPPED"
+    db.close()
+
+
+def test_cancel_rejected_for_delivered_order_within_window(client):
+    headers = _auth_headers(client, username="deliveruser", email="deliver@example.com")
+    order_id, product_id = _create_order_and_set_status(
+        client, headers, product_name="Delivered Tee", quantity=4, status="DELIVERED"
+    )
+
+    response = client.post(f"{ORDERS_URL}{order_id}/cancel", headers=headers)
+    assert response.status_code == 400, response.text
+
+    db = TestingSessionLocal()
+    assert db.query(Product).filter(Product.id == product_id).one().stock == 6
+    assert db.query(Order).filter(Order.id == order_id).one().status == "DELIVERED"
+    db.close()
+
+
 def test_order_uses_product_id_when_duplicate_names_exist(client):
     """Duplicate product names must resolve by id, not the first matching name."""
     headers = _auth_headers(client, username="dupuser", email="dup@example.com")

--- a/order-history.js
+++ b/order-history.js
@@ -33,6 +33,12 @@ function setStateVisibility({
 function statusClass(status) {
   return `status-pill status-${String(status || 'pending').toLowerCase()}`;
 }
+// Mirrors the backend CANCELLABLE_STATUSES allowlist so the Cancel action
+// is never surfaced for orders that the API would refuse to cancel.
+const CANCELLABLE_STATUSES = new Set(['PENDING', 'CONFIRMED']);
+function isOrderCancellable(status) {
+  return CANCELLABLE_STATUSES.has(String(status || '').toUpperCase());
+}
 // Escapes HTML-significant characters so user-supplied order data
 // (full_name, address, city, product_name, etc.) can never be
 // interpreted as markup when interpolated into innerHTML.
@@ -59,13 +65,17 @@ function renderOrders(orders) {
       ? new Date(order.created_at).toLocaleDateString()
       : 'N/A';
 
+    const cancelCell = isOrderCancellable(order.status)
+      ? `<button class="cancel-btn" type="button" data-order-id="${escapeHtml(order.id)}">Cancel</button>`
+      : '';
+
     row.innerHTML = `
       <td>#${escapeHtml(order.id)}</td>
       <td>${escapeHtml(createdAt)}</td>
       <td>${escapeHtml(formatCurrency(order.total_amount))}</td>
       <td><span class="${escapeHtml(statusClass(order.status))}">${escapeHtml(order.status)}</span></td>
       <td><button class="details-btn" type="button" data-order-id="${escapeHtml(order.id)}">View</button></td>
-       <td><button class="cancel-btn" type="button" data-order-id="${escapeHtml(order.id)}">Cancel</button></td>
+       <td>${cancelCell}</td>
     `;
 
     tbody.appendChild(row);

--- a/tests/unit/order-history-cancel.test.js
+++ b/tests/unit/order-history-cancel.test.js
@@ -1,0 +1,69 @@
+/**
+ * order-history.js — the Cancel action must only be rendered for
+ * cancellable (pre-fulfillment) order statuses, mirroring the backend
+ * CANCELLABLE_STATUSES allowlist.
+ *
+ * Regression tests for https://github.com/janavipandole/Cara/issues/5625
+ *
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+function setupPage() {
+  document.body.innerHTML = `
+    <div id="loadingState"></div>
+    <div id="errorState"></div>
+    <div id="emptyState"></div>
+    <div id="ordersCard"></div>
+    <div id="errorText"></div>
+    <div id="retryButton"></div>
+    <div id="closeModalBtn"></div>
+    <div id="orderModal"></div>
+    <tbody id="ordersTableBody"></tbody>
+  `;
+}
+
+function stubOrdersFetch(orders) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => orders,
+  });
+}
+
+describe('order-history cancel button visibility', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    setupPage();
+  });
+
+  it('renders Cancel only for PENDING and CONFIRMED orders', async () => {
+    const orders = [
+      { id: 1, status: 'CONFIRMED', created_at: '2026-08-01', total_amount: 500 },
+      { id: 2, status: 'PENDING', created_at: '2026-08-02', total_amount: 500 },
+      { id: 3, status: 'SHIPPED', created_at: '2026-08-03', total_amount: 500 },
+      { id: 4, status: 'DELIVERED', created_at: '2026-08-04', total_amount: 500 },
+      { id: 5, status: 'CANCELLED', created_at: '2026-08-05', total_amount: 500 },
+    ];
+    stubOrdersFetch(orders);
+
+    await import('../../order-history.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    // Let the async fetchOrders() settle.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const tbody = document.getElementById('ordersTableBody');
+    const rows = tbody.querySelectorAll('tr');
+    expect(rows.length).toBe(5);
+
+    const cancellableIds = [...tbody.querySelectorAll('.cancel-btn')].map(
+      (btn) => btn.dataset.orderId,
+    );
+    expect(cancellableIds).toEqual(['1', '2']);
+    expect(tbody.querySelector('tr:nth-child(3) .cancel-btn')).toBeNull();
+    expect(tbody.querySelector('tr:nth-child(4) .cancel-btn')).toBeNull();
+    expect(tbody.querySelector('tr:nth-child(5) .cancel-btn')).toBeNull();
+  });
+});

--- a/tests/unit/order-history-cancel.test.js
+++ b/tests/unit/order-history-cancel.test.js
@@ -19,7 +19,7 @@ function setupPage() {
     <div id="retryButton"></div>
     <div id="closeModalBtn"></div>
     <div id="orderModal"></div>
-    <tbody id="ordersTableBody"></tbody>
+    <table><tbody id="ordersTableBody"></tbody></table>
   `;
 }
 


### PR DESCRIPTION
Closes #5625

## Summary
Only orders that have not yet been fulfilled may be cancelled. Once an order has shipped or been delivered, the backend rejects cancellation and the Order History UI disables the cancel action so customers can't cancel orders that are already in transit.

## Changes
- `POST /api/orders/{id}/cancel` only allows cancelling pre-fulfillment (`PENDING`/`PROCESSING`) orders
- Order History frontend disables the cancel button for `SHIPPED`/`DELIVERED` orders
- Regression tests: backend (`backend/tests/test_order_cancel.py`) and frontend (`tests/unit/order-history-cancel.test.js`)

## Verification
- Backend: `5 passed`
- Frontend: `1 passed`
