### PR TITLE
test: fixed incorrect expected values in coupon-stacking-engine test

### DIFF
--- a/tests/unit/coupon-stacking-engine.test.js
+++ b/tests/unit/coupon-stacking-engine.test.js
@@ -10,7 +10,8 @@ describe('CouponStackingEngine', () => {
       { code: 'FLAT50', type: 'flat', value: 50 }
     ];
     const res = engine.calculateStackedDiscount(1000, coupons);
-    expect(res.discountTotal).toBe(140);
-    expect(res.finalTotal).toBe(860);
+    // 10% of 1000 = 100, then flat 50 applied to the reduced total.
+    expect(res.discountTotal).toBe(150);
+    expect(res.finalTotal).toBe(850);
   });
 });


### PR DESCRIPTION
## 📄 Description
Corrected the expected values in tests/unit/coupon-stacking-engine.test.js. For a 10% coupon on a 1000 cart followed by a flat 50 coupon, the engine sequentially computes a 150 discount (100 + 50) and an 850 final total. The test expected 140/860, which no stacking order produces, causing the vitest suite to fail for every pull request on the repository. This fix unblocks the repo-wide CI pipeline.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5763

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.