### PR TITLE
fix: handled non-ASCII ids in wishlist share link export

### DIFF
--- a/js/wishlist-share-exporter.js
+++ b/js/wishlist-share-exporter.js
@@ -6,7 +6,8 @@ export class WishlistShareExporter {
   static exportToShareableLink(items = [], baseUrl = 'https://cara.store/wishlist.html') {
     if (!Array.isArray(items) || items.length === 0) return baseUrl;
     const ids = items.map(item => typeof item === 'object' ? item.id : item).filter(Boolean);
-    const encoded = btoa(JSON.stringify(ids));
+    // encodeURIComponent keeps btoa from throwing on non-Latin1 characters.
+    const encoded = btoa(encodeURIComponent(JSON.stringify(ids)));
     return `${baseUrl}?share=${encodeURIComponent(encoded)}`;
   }
 
@@ -15,7 +16,7 @@ export class WishlistShareExporter {
     const shareData = params.get('share');
     if (!shareData) return [];
     try {
-      const decoded = atob(shareData);
+      const decoded = decodeURIComponent(atob(shareData));
       return JSON.parse(decoded);
     } catch {
       return [];

--- a/tests/unit/wishlist-share-exporter.test.js
+++ b/tests/unit/wishlist-share-exporter.test.js
@@ -11,4 +11,28 @@ describe('WishlistShareExporter', () => {
     const parsed = WishlistShareExporter.parseShareableLink(query);
     expect(parsed).toEqual(['p1', 'p2']);
   });
+
+  it('round-trips ids containing non-ASCII characters', () => {
+    const items = [{ id: 'p₹1' }, { id: 't−shirt' }];
+    const url = WishlistShareExporter.exportToShareableLink(items, 'http://localhost/wishlist.html');
+    expect(url).toContain('?share=');
+    const query = url.substring(url.indexOf('?'));
+    const parsed = WishlistShareExporter.parseShareableLink(query);
+    expect(parsed).toEqual(['p₹1', 't−shirt']);
+  });
+
+  it('returns the base url when there are no items', () => {
+    expect(WishlistShareExporter.exportToShareableLink([], 'http://localhost/wishlist.html')).toBe(
+      'http://localhost/wishlist.html',
+    );
+    expect(WishlistShareExporter.exportToShareableLink('not-array', 'http://localhost/wishlist.html')).toBe(
+      'http://localhost/wishlist.html',
+    );
+  });
+
+  it('returns an empty list for a missing or malformed share param', () => {
+    expect(WishlistShareExporter.parseShareableLink('')).toEqual([]);
+    expect(WishlistShareExporter.parseShareableLink('?other=1')).toEqual([]);
+    expect(WishlistShareExporter.parseShareableLink('?share=%%%bad')).toEqual([]);
+  });
 });


### PR DESCRIPTION
## 📄 Description
Fixed exportToShareableLink in js/wishlist-share-exporter.js to encode the JSON with encodeURIComponent before btoa so non-ASCII product ids no longer trigger InvalidCharacterError. Added unit tests covering non-ASCII round-trips, empty input, and malformed share params.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5801

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.