### PR TITLE
test: added boundary coverage to size-fit-calculator tests

### DIFF
--- a/tests/unit/size-fit-calculator.test.js
+++ b/tests/unit/size-fit-calculator.test.js
@@ -13,4 +13,32 @@ describe('SizeFitCalculator', () => {
     expect(calc.recommendSize(95, 76, 'slim')).toBe('S');
     expect(calc.recommendSize(95, 76, 'loose')).toBe('L');
   });
+
+  it('returns a default size for invalid chest measurements', () => {
+    expect(calc.recommendSize(0, 70)).toBe('M');
+    expect(calc.recommendSize(-5, 70)).toBe('M');
+    expect(calc.recommendSize(NaN, 70)).toBe('M');
+  });
+
+  it('caps at XXL for chest measurements above the chart', () => {
+    expect(calc.recommendSize(150, 100)).toBe('XXL');
+    expect(calc.recommendSize(150, 100, 'loose')).toBe('XXL');
+  });
+
+  it('keeps slim adjustment within the size chart bounds', () => {
+    // XS is the smallest size; slim must not go below it.
+    expect(calc.recommendSize(80, 60, 'slim')).toBe('XS');
+  });
+
+  it('returns the same size for an unknown fit preference', () => {
+    expect(calc.recommendSize(95, 76, 'athletic')).toBe('M');
+  });
+
+  it('gets adjacent sizes within the chart bounds', () => {
+    expect(calc.getAdjacentSize('M', -1)).toBe('S');
+    expect(calc.getAdjacentSize('M', 1)).toBe('L');
+    expect(calc.getAdjacentSize('XS', -1)).toBe('XS');
+    expect(calc.getAdjacentSize('XXL', 1)).toBe('XXL');
+    expect(calc.getAdjacentSize('UNKNOWN', 1)).toBe('UNKNOWN');
+  });
 });


### PR DESCRIPTION
## 📄 Description
Added tests to tests/unit/size-fit-calculator.test.js covering invalid chest measurements, the XXL cap, slim adjustment bounds, unknown fit preferences, and adjacent-size boundary handling.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5812

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.