### PR TITLE
test: added lifecycle coverage to abandoned-cart-notifier tests

### DIFF
--- a/tests/unit/abandoned-cart-notifier.test.js
+++ b/tests/unit/abandoned-cart-notifier.test.js
@@ -18,4 +18,42 @@ describe('AbandonedCartNotifier', () => {
     vi.advanceTimersByTime(1000);
     expect(spy).toHaveBeenCalledOnce();
   });
+
+  it('does not start tracking for an empty cart', () => {
+    const spy = vi.fn();
+    const notifier = new AbandonedCartNotifier({ idleThresholdMs: 1000, onNotify: spy });
+    notifier.startTracking(0);
+    vi.advanceTimersByTime(2000);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('stops tracking and cancels the pending notification', () => {
+    const spy = vi.fn();
+    const notifier = new AbandonedCartNotifier({ idleThresholdMs: 1000, onNotify: spy });
+    notifier.startTracking(2);
+    notifier.stopTracking();
+    vi.advanceTimersByTime(2000);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('restarts tracking when startTracking is called again', () => {
+    const spy = vi.fn();
+    const notifier = new AbandonedCartNotifier({ idleThresholdMs: 1000, onNotify: spy });
+    notifier.startTracking(2);
+    vi.advanceTimersByTime(500);
+    notifier.startTracking(3);
+    vi.advanceTimersByTime(1000);
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
+  it('includes a title, body, and timestamp in the notification payload', () => {
+    const spy = vi.fn();
+    const notifier = new AbandonedCartNotifier({ idleThresholdMs: 1000, onNotify: spy });
+    notifier.startTracking(2);
+    vi.advanceTimersByTime(1000);
+    const payload = spy.mock.calls[0][0];
+    expect(payload.title).toContain('cart');
+    expect(payload.body).toBeTruthy();
+    expect(typeof payload.timestamp).toBe('number');
+  });
 });


### PR DESCRIPTION
## 📄 Description
Added tests to tests/unit/abandoned-cart-notifier.test.js covering empty carts not tracking, stop-tracking cancelling the timer, restarting the timer, and the notification payload contents.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5826

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.