### PR TITLE
fix: exported orphaned generateCsrfFallbackToken function from csrf-protection

### DIFF
--- a/js/csrf-protection.js
+++ b/js/csrf-protection.js
@@ -63,4 +63,4 @@ if (typeof document !== 'undefined') {
 }
 
 
-function generateCsrfFallbackToken() { return 'csrf-' + Math.random().toString(36).substring(2, 15); }
+export function generateCsrfFallbackToken() { return 'csrf-' + Math.random().toString(36).substring(2, 15); }

--- a/tests/unit/csrf-protection.test.js
+++ b/tests/unit/csrf-protection.test.js
@@ -3,7 +3,8 @@ import {
   generateCSRFToken,
   getOrCreateCSRFToken,
   injectCSRFInputs,
-  attachCSRFHeader
+  attachCSRFHeader,
+  generateCsrfFallbackToken
 } from '../../js/csrf-protection.js';
 
 describe('CSRF Protection Unit Tests', () => {
@@ -56,5 +57,17 @@ describe('CSRF Protection Unit Tests', () => {
     } finally {
       Object.defineProperty(globalThis, 'document', { value: originalDocument, writable: true, configurable: true });
     }
+  });
+
+  it('should generate a fallback csrf token with a csrf- prefix', () => {
+    const token = generateCsrfFallbackToken();
+    expect(token.startsWith('csrf-')).toBe(true);
+    expect(token.length).toBeGreaterThan('csrf-'.length);
+  });
+
+  it('should generate distinct fallback tokens on consecutive calls', () => {
+    const t1 = generateCsrfFallbackToken();
+    const t2 = generateCsrfFallbackToken();
+    expect(t1).not.toBe(t2);
   });
 });


### PR DESCRIPTION
## 📄 Description
Exported generateCsrfFallbackToken from js/csrf-protection.js and added unit tests covering the token prefix, minimum length, and distinctness across calls.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5842

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.