### PR TITLE
test: added SQL keyword detection coverage to input-shield tests

### DIFF
--- a/tests/unit/input-shield.test.js
+++ b/tests/unit/input-shield.test.js
@@ -48,5 +48,30 @@ describe('input-shield', () => {
     expect(document.getElementById('field').value).toBe('hello world');
   });
 
-  it('should detect SQL injection keywords in user inputs', () => { expect(true).toBe(true); });
+  it('should detect SQL injection keywords in user inputs', async () => {
+    await import('../../js/input-shield.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(window.containsSqlInjectionKeywords('SELECT * FROM users')).toBe(true);
+    expect(window.containsSqlInjectionKeywords('DROP TABLE orders')).toBe(true);
+    expect(window.containsSqlInjectionKeywords('insert into cart values')).toBe(true);
+  });
+
+  it('should ignore SQL keywords in non-string or safe input', async () => {
+    await import('../../js/input-shield.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(window.containsSqlInjectionKeywords('hello world')).toBe(false);
+    expect(window.containsSqlInjectionKeywords(null)).toBe(false);
+    expect(window.containsSqlInjectionKeywords(undefined)).toBe(false);
+    expect(window.containsSqlInjectionKeywords(42)).toBe(false);
+  });
+
+  it('should match SQL keywords case-insensitively', async () => {
+    await import('../../js/input-shield.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(window.containsSqlInjectionKeywords('select name from users')).toBe(true);
+    expect(window.containsSqlInjectionKeywords('Delete FROM sessions')).toBe(true);
+  });
 });


### PR DESCRIPTION
## 📄 Description
Replaced the placeholder assertion in tests/unit/input-shield.test.js with real tests covering SQL keyword detection, non-string safe inputs, and case-insensitive matching for the exposed containsSqlInjectionKeywords helper.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5846

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.