### PR TITLE
test: added gift message length coverage to gift-options tests

### DIFF
--- a/tests/unit/gift-options.test.js
+++ b/tests/unit/gift-options.test.js
@@ -57,5 +57,29 @@ describe('gift-options.js unit tests', () => {
     expect(checkbox).toBeNull();
   });
 
-  it('should validate gift message character limit bounds', () => { expect(true).toBe(true); });
+  it('should validate gift message character limit bounds', async () => {
+    await import('../../js/gift-options.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(window.validateGiftMessageLength('Short message')).toBe(true);
+    expect(window.validateGiftMessageLength('x'.repeat(200))).toBe(true);
+    expect(window.validateGiftMessageLength('x'.repeat(201))).toBe(false);
+  });
+
+  it('should accept non-string or empty gift messages', async () => {
+    await import('../../js/gift-options.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(window.validateGiftMessageLength(null)).toBe(true);
+    expect(window.validateGiftMessageLength('')).toBe(true);
+    expect(window.validateGiftMessageLength(undefined)).toBe(true);
+  });
+
+  it('should respect a custom character limit', async () => {
+    await import('../../js/gift-options.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(window.validateGiftMessageLength('abc', 5)).toBe(true);
+    expect(window.validateGiftMessageLength('abcdef', 5)).toBe(false);
+  });
 });


### PR DESCRIPTION
## 📄 Description
Replaced the placeholder assertion in tests/unit/gift-options.test.js with real tests covering the default 200-character limit, non-string inputs, and custom limits.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5878

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.