### PR TITLE
fix: make outfit color-clash rule symmetric (issue #5782)

### DIFF
--- a/backend/app/rules/engine.py
+++ b/backend/app/rules/engine.py
@@ -32,11 +32,15 @@ def filter_by_rules(base_product, candidates):
             if base_product.category == "formal" or c.category == "formal":
                 continue # Strictly block formal mixed with non-formal
                 
-        # Rule 4: Color Harmony
+        # Rule 4: Color Harmony (symmetric — a clash is rejected regardless of
+        # which product is the base, so the same pairing cannot sneak through
+        # when the base/candidate roles are swapped).
         if base_product.color and c.color:
             base_color = base_product.color.lower()
             cand_color = c.color.lower()
             if base_color in clashing_colors and cand_color in clashing_colors[base_color]:
+                continue
+            if cand_color in clashing_colors and base_color in clashing_colors[cand_color]:
                 continue
                 
         # Rule 5: Pattern Clashing (Don't mix two different patterns)

--- a/backend/tests/test_rules_pytest.py
+++ b/backend/tests/test_rules_pytest.py
@@ -74,3 +74,55 @@ def test_allows_same_category_mixed_styles():
     ]
     results = filter_by_rules(base, candidates)
     assert [r.id for r in results] == [2]
+
+
+CLASHING_PAIRS = [
+    ("red", "pink"),
+    ("red", "orange"),
+    ("red", "green"),
+    ("navy", "black"),
+    ("navy", "brown"),
+    ("black", "brown"),
+]
+
+
+def test_clash_is_rejected_in_both_orientations():
+    """Every clashing pair must be blocked with either color as the base.
+
+    The rule used to be directed (only the dict key acted as the clash source),
+    so e.g. base=green + candidate=red slipped through while the reverse was
+    rejected. Both orientations must now behave identically.
+    """
+    for idx, (color_a, color_b) in enumerate(CLASHING_PAIRS):
+        base_first = MockProduct(idx * 2 + 1, "formal", "top", color_a, "classic")
+        cand_first = MockProduct(idx * 2 + 2, "formal", "bottom", color_b, "classic")
+        assert filter_by_rules(base_first, [cand_first]) == [], (
+            f"{color_a} base should clash with {color_b} candidate"
+        )
+
+        base_second = MockProduct(idx * 2 + 3, "formal", "top", color_b, "classic")
+        cand_second = MockProduct(idx * 2 + 4, "formal", "bottom", color_a, "classic")
+        assert filter_by_rules(base_second, [cand_second]) == [], (
+            f"{color_b} base should clash with {color_a} candidate"
+        )
+
+
+def test_mirror_colors_not_in_dict_are_still_blocked():
+    """Colors that only appear as *values* (pink/orange/green) must reject the
+    reverse direction too, not just when they are the candidate."""
+    for idx, base_color in enumerate(["pink", "orange", "green"]):
+        base = MockProduct(100 + idx, "formal", "top", base_color, "classic")
+        candidate = MockProduct(200 + idx, "formal", "bottom", "red", "classic")
+        assert filter_by_rules(base, [candidate]) == [], (
+            f"{base_color} base must clash with red candidate"
+        )
+
+
+def test_non_clashing_colors_are_allowed_in_both_orientations():
+    base = MockProduct(1, "formal", "top", "red", "classic")
+    candidate = MockProduct(2, "formal", "bottom", "blue", "classic")
+    assert [r.id for r in filter_by_rules(base, [candidate])] == [2]
+
+    base2 = MockProduct(3, "formal", "top", "blue", "classic")
+    candidate2 = MockProduct(4, "formal", "bottom", "red", "classic")
+    assert [r.id for r in filter_by_rules(base2, [candidate2])] == [4]


### PR DESCRIPTION
## Problem

The outfit engine's color-clash rule is asymmetric. `filter_by_rules` only rejects a candidate when the **base** product's color is one of the clashing dict keys, so a clashing pair is blocked in one direction but allowed in the other. For example `base=red + candidate=green` is rejected, but `base=green + candidate=red` passes, and mirror pairs (`pink`/`orange`/`green` -> `red`, `brown` -> `black`/`navy`, etc.) are only enforced one way. The recommended outfit therefore depends on which product the user starts from.

## Fix

Made the color-clash check symmetric in `backend/app/rules/engine.py` by also checking the reverse direction (`cand_color` -> `base_color`), so any clashing unordered pair is rejected regardless of which product is the base.

Added unit tests that cover every clashing pair in **both orientations** (`CLASHING_PAIRS`), the mirror colors that only appear as dict values (`pink`/`orange`/`green` as base vs `red`), and non-clashing pairs that must still be allowed in both orientations.

## Files changed

- `backend/app/rules/engine.py` — symmetric clash check for Rule 4 (Color Harmony)
- `backend/tests/test_rules_pytest.py` — both-orientation clash tests

## Testing

- `py -m pytest backend/tests/test_rules_pytest.py backend/tests/test_rules.py` — all rules tests pass (9 passed).

Closes #5782
