### PR TITLE
test: added defaults coverage to fetch-timeout tests

### DIFF
--- a/tests/unit/fetch-timeout.test.js
+++ b/tests/unit/fetch-timeout.test.js
@@ -70,7 +70,20 @@ describe('fetchWithTimeout', () => {
     );
   });
 
-  it('should handle fetchWithTimeout correctly', () => { expect(true).toBe(true); });
+  it('should handle fetchWithTimeout correctly', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(new Response('ok', { status: 200 }));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const result = await fetchWithTimeout('https://example.com/default');
+    expect(result.status).toBe(200);
+    // Credentials default to include.
+    const opts = mockFetch.mock.calls[0][1];
+    expect(opts.credentials).toBe('include');
+    // The signal option is always attached.
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
 
   describe('createTimeoutSignalHelper', () => {
     it('returns an AbortSignal and a cleanup function', () => {


### PR DESCRIPTION
## 📄 Description
Replaced the placeholder assertion in tests/unit/fetch-timeout.test.js with a real test verifying the default credentials value and that an AbortSignal is attached to fetch calls.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #5905

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.