### PR TITLE
fix: escape LIKE wildcards in product search (issue #5785)

### DIFF
--- a/backend/app/api/products.py
+++ b/backend/app/api/products.py
@@ -72,12 +72,21 @@ def search_products(
     query = db.query(models.Product)
 
     # --- Keyword search: case-insensitive match on name OR brand ---------
+    # % and _ are SQL LIKE wildcards and \ is the escape character; they must
+    # be escaped in the user input or q=% would match the entire catalog and
+    # q=a_ would match any term starting with "a".
     if q:
-        search_term = f"%{q.strip()}%"
+        escaped = (
+            q.strip()
+            .replace("\\", "\\\\")
+            .replace("%", "\\%")
+            .replace("_", "\\_")
+        )
+        search_term = f"%{escaped}%"
         query = query.filter(
             or_(
-                func.lower(models.Product.name).like(func.lower(search_term)),
-                func.lower(models.Product.brand).like(func.lower(search_term)),
+                func.lower(models.Product.name).like(func.lower(search_term), escape="\\"),
+                func.lower(models.Product.brand).like(func.lower(search_term), escape="\\"),
             )
         )
 

--- a/backend/tests/test_product_search.py
+++ b/backend/tests/test_product_search.py
@@ -158,6 +158,61 @@ class TestProductSearchQuery:
         for product in resp.json()["products"]:
             assert product["rating"] >= 4
 
+    def test_like_wildcards_are_literal(self, client: TestClient):
+        """LIKE wildcards (% / _) in the query must not over-match the catalog.
+
+        Before the fix q=% matched every product and q=____ matched anything
+        with at least 4 chars. After escaping they are matched literally.
+        """
+        from app.models import Product
+        from tests.conftest import TestingSessionLocal
+
+        db = TestingSessionLocal()
+        db.add_all([
+            Product(brand="LiteralBrand", name="Plain Shirt", price=10.0,
+                    img="a.jpg", rating=3, category="minimal", subcategory="top",
+                    color="white", style="casual", stock=5),
+            Product(brand="WildcardBrand", name="100% Cotton Tee", price=10.0,
+                    img="b.jpg", rating=3, category="minimal", subcategory="top",
+                    color="white", style="casual", stock=5),
+            Product(brand="UnderscoreBrand", name="Premium_Tee", price=10.0,
+                    img="c.jpg", rating=3, category="minimal", subcategory="top",
+                    color="white", style="casual", stock=5),
+            Product(brand="BackslashBrand", name="A\\B Tee", price=10.0,
+                    img="d.jpg", rating=3, category="minimal", subcategory="top",
+                    color="white", style="casual", stock=5),
+        ])
+        db.commit()
+        db.close()
+
+        # q=% must NOT return the entire catalog.
+        resp = client.get("/api/products/search/query?q=%25")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 1
+        assert body["products"][0]["name"] == "100% Cotton Tee"
+
+        # q=_ must match only the literal underscore, not every 1+ char name.
+        resp = client.get("/api/products/search/query?q=_")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 1
+        assert body["products"][0]["name"] == "Premium_Tee"
+
+        # q=Premium_Tee must match the literal underscore product only.
+        resp = client.get("/api/products/search/query?q=Premium_Tee")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 1
+        assert body["products"][0]["name"] == "Premium_Tee"
+
+        # q=A\B must match the literal backslash product only.
+        resp = client.get("/api/products/search/query?q=A%5CB")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 1
+        assert body["products"][0]["name"] == "A\\B Tee"
+
 
 class TestCategorySummary:
     def test_categories_endpoint_returns_correct_schema(self, client: TestClient):


### PR DESCRIPTION
## Problem

The product search endpoint builds a SQL `LIKE` pattern directly from the user's `q` value, so the SQL wildcards `%` and `_` (and the escape character `\`) are interpreted instead of matched literally. `q=%` matched the entire catalog, `q=a_` matched any term starting with `a`, and `q=___` matched anything with at least 3 characters, letting callers trivially enumerate the whole catalog beyond pagination intent.

## Fix

Escaped `%`, `_`, and `\` in the user input before building the `LIKE` pattern in `backend/app/api/products.py`, and passed `escape="\\"` explicitly to the `LIKE` clauses so the escaping is honored consistently across backends (SQLite/PostgreSQL). Wildcards are now matched literally.

Added tests in `backend/tests/test_product_search.py` covering:
- `q=%` matches only products whose name/brand actually contains `%`
- `q=_` matches only literal underscores (not every 1+ char name)
- `q=Premium_Tee` matches the literal-underscore product only
- `q=A\B` matches the literal-backslash product only

## Files changed

- `backend/app/api/products.py` — escape `%`/`_`/`\` and use `escape="\\"` on both `LIKE` clauses
- `backend/tests/test_product_search.py` — wildcard-literal tests

## Testing

- `py -m pytest backend/tests/test_product_search.py backend/tests/test_products.py` — 23 passed.

Closes #5785
