### PR TITLE
fix: rate-limit newsletter and ambassador routes, bound input lengths (issue #5781)

### DIFF
--- a/backend/app/api/ambassador.py
+++ b/backend/app/api/ambassador.py
@@ -1,26 +1,25 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
 from typing import Optional
 from .. import models
 from ..database import get_db
+from ..limiter import limiter
 
 router = APIRouter()
 
 
 class AmbassadorApplyRequest(BaseModel):
-    full_name: str
+    full_name: str = Field(min_length=1, max_length=120)
     email: EmailStr
-    instagram_handle: str
-    follower_count: int
-    motivation: Optional[str] = None
+    instagram_handle: str = Field(min_length=1, max_length=50)
+    follower_count: int = Field(ge=0, le=100_000_000)
+    motivation: Optional[str] = Field(default=None, max_length=2000)
 
 
 @router.post("/apply", status_code=201)
-def apply_ambassador(payload: AmbassadorApplyRequest, db: Session = Depends(get_db)):
-    if payload.follower_count < 0:
-        raise HTTPException(status_code=400, detail="Follower count cannot be negative")
-
+@limiter.limit("3/minute")
+def apply_ambassador(request: Request, payload: AmbassadorApplyRequest, db: Session = Depends(get_db)):
     application = models.AmbassadorApplication(
         full_name=payload.full_name,
         email=payload.email,

--- a/backend/app/api/newsletter.py
+++ b/backend/app/api/newsletter.py
@@ -1,9 +1,10 @@
 import secrets
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 from pydantic import BaseModel, EmailStr
 from .. import models
 from ..database import get_db
+from ..limiter import limiter
 
 router = APIRouter()
 
@@ -17,7 +18,8 @@ class NewsletterUnsubscribeRequest(BaseModel):
 
 
 @router.post("/subscribe", status_code=201)
-def subscribe(payload: NewsletterSubscribeRequest, db: Session = Depends(get_db)):
+@limiter.limit("5/minute")
+def subscribe(request: Request, payload: NewsletterSubscribeRequest, db: Session = Depends(get_db)):
     existing = (
         db.query(models.NewsletterSubscriber)
         .filter(models.NewsletterSubscriber.email == payload.email)
@@ -43,7 +45,8 @@ def subscribe(payload: NewsletterSubscribeRequest, db: Session = Depends(get_db)
 
 
 @router.post("/unsubscribe")
-def unsubscribe(payload: NewsletterUnsubscribeRequest, db: Session = Depends(get_db)):
+@limiter.limit("10/minute")
+def unsubscribe(request: Request, payload: NewsletterUnsubscribeRequest, db: Session = Depends(get_db)):
     subscriber = (
         db.query(models.NewsletterSubscriber)
         .filter(models.NewsletterSubscriber.unsubscribe_token == payload.token)

--- a/backend/tests/test_ambassador.py
+++ b/backend/tests/test_ambassador.py
@@ -24,7 +24,50 @@ def test_ambassador_apply_negative_followers(client):
             "motivation": "Test"
         },
     )
-    assert response.status_code == 400
+    # follower_count is validated by Field(ge=0) at the schema boundary.
+    assert response.status_code == 422
+
+
+def test_ambassador_apply_oversized_motivation(client):
+    response = client.post(
+        "/api/ambassador/apply",
+        json={
+            "full_name": "Jane Doe",
+            "email": "jane@example.com",
+            "instagram_handle": "@janedoe",
+            "follower_count": 5000,
+            "motivation": "x" * 5000,
+        },
+    )
+    assert response.status_code == 422
+
+
+def test_ambassador_apply_oversized_full_name(client):
+    response = client.post(
+        "/api/ambassador/apply",
+        json={
+            "full_name": "x" * 500,
+            "email": "jane@example.com",
+            "instagram_handle": "@janedoe",
+            "follower_count": 5000,
+            "motivation": "Test"
+        },
+    )
+    assert response.status_code == 422
+
+
+def test_ambassador_apply_oversized_instagram_handle(client):
+    response = client.post(
+        "/api/ambassador/apply",
+        json={
+            "full_name": "Jane Doe",
+            "email": "jane@example.com",
+            "instagram_handle": "@" + "x" * 500,
+            "follower_count": 5000,
+            "motivation": "Test"
+        },
+    )
+    assert response.status_code == 422
 
 
 def test_ambassador_apply_invalid_email(client):


### PR DESCRIPTION
## Problem

`POST /api/newsletter/subscribe` and `POST /api/ambassador/apply` are public, unauthenticated write endpoints with **no rate limiting** — unlike every other public write endpoint in the app (`login`, `register`, orders, feedback, etc.). Anonymous callers could insert an unbounded number of rows (newsletter emails, ambassador applications) into the database, and a single ambassador request could carry a multi-MB `motivation` string.

## Fix

- Added `@limiter.limit(...)` to both routes (consistent with the rest of the API):
  - `subscribe` → `5/minute`, `unsubscribe` → `10/minute`
  - `ambassador/apply` → `3/minute`
- Bound the `AmbassadorApplyRequest` schema fields with `max_length` / ranges:
  - `full_name` ≤ 120 chars, `instagram_handle` ≤ 50 chars, `motivation` ≤ 2000 chars
  - `follower_count` constrained to `0 <= n <= 100_000_000`
- Removed the now-dead manual negative-follower check (Pydantic `Field(ge=0)` validates at the schema boundary).

## Files changed

- `backend/app/api/newsletter.py` — rate limits on subscribe/unsubscribe
- `backend/app/api/ambassador.py` — rate limit + input length bounds
- `backend/tests/test_ambassador.py` — updated negative-follower expectation (400 → 422) and added oversized `motivation`/`full_name`/`instagram_handle` tests

## Testing

- `py -m pytest backend/tests/test_ambassador.py` — all pass.
- Pre-existing `test_newsletter.py` failures (stale API contract: response messages / unsubscribe body shape) are unchanged and fail identically on `origin/main` without this PR.

Closes #5781
