### PR TITLE
fix: validate product price/stock/rating at API and DB layer (issue #5784)

### DIFF
--- a/backend/alembic/versions/a3b4c5d6e7f8_add_product_validation_constraints.py
+++ b/backend/alembic/versions/a3b4c5d6e7f8_add_product_validation_constraints.py
@@ -1,0 +1,37 @@
+"""add non-negative/range check constraints to products
+
+Revision ID: a3b4c5d6e7f8
+Revises: f1a2b3c4d5e6
+Create Date: 2026-08-08 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a3b4c5d6e7f8'
+down_revision: Union[str, Sequence[str], None] = 'f1a2b3c4d5e6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Enforce the ProductBase validation at the database layer too.
+
+    Prevents negative price/stock and out-of-range ratings from being written
+    by import scripts or anything that bypasses the API schemas.
+    """
+    with op.batch_alter_table('products') as batch_op:
+        batch_op.create_check_constraint('ck_products_price_nonnegative', 'price >= 0')
+        batch_op.create_check_constraint('ck_products_stock_nonnegative', 'stock >= 0')
+        batch_op.create_check_constraint('ck_products_rating_range', 'rating >= 0 AND rating <= 5')
+
+
+def downgrade() -> None:
+    """Drop the check constraints."""
+    with op.batch_alter_table('products') as batch_op:
+        batch_op.drop_constraint('ck_products_rating_range', type_='check')
+        batch_op.drop_constraint('ck_products_stock_nonnegative', type_='check')
+        batch_op.drop_constraint('ck_products_price_nonnegative', type_='check')

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Float, ForeignKey, JSON, Boolean, DateTime, UniqueConstraint
+from sqlalchemy import Column, Integer, String, Float, ForeignKey, JSON, Boolean, DateTime, UniqueConstraint, CheckConstraint
 from sqlalchemy.orm import relationship
 from .database import Base
 from datetime import datetime, timezone
@@ -27,6 +27,11 @@ class AmbassadorApplication(Base):
 
 class Product(Base):
     __tablename__ = "products"
+    __table_args__ = (
+        CheckConstraint("price >= 0", name="ck_products_price_nonnegative"),
+        CheckConstraint("stock >= 0", name="ck_products_stock_nonnegative"),
+        CheckConstraint("rating >= 0 AND rating <= 5", name="ck_products_rating_range"),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     brand = Column(String, index=True)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -7,14 +7,14 @@ import re
 class ProductBase(BaseModel):
     brand: str
     name: str
-    price: float
+    price: float = Field(ge=0)
     img: str
-    rating: int
+    rating: int = Field(ge=0, le=5)
     category: str
     subcategory: Optional[str] = None
     color: Optional[str] = None
     style: Optional[str] = None
-    stock: int = 10
+    stock: int = Field(default=10, ge=0)
 
 class ProductCreate(ProductBase):
     """Admin create/update payload. Primary key is assigned by the database."""

--- a/backend/tests/test_admin_products.py
+++ b/backend/tests/test_admin_products.py
@@ -174,3 +174,75 @@ def test_admin_update_rejects_duplicate_name(client):
         headers=headers,
     )
     assert response.status_code == 409
+
+
+def _valid_payload(**overrides):
+    payload = {
+        "brand": "Brand",
+        "name": "Validation Product",
+        "price": 20.0,
+        "img": "test.jpg",
+        "rating": 3,
+        "category": "minimal",
+        "stock": 10,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_admin_create_rejects_negative_price(client):
+    headers = _admin_headers(client)
+    response = client.post(
+        "/api/admin/products/",
+        json=_valid_payload(name="Neg Price Product", price=-500),
+        headers=headers,
+    )
+    assert response.status_code == 422
+
+
+def test_admin_create_rejects_negative_stock(client):
+    headers = _admin_headers(client)
+    response = client.post(
+        "/api/admin/products/",
+        json=_valid_payload(name="Neg Stock Product", stock=-1),
+        headers=headers,
+    )
+    assert response.status_code == 422
+
+
+def test_admin_create_rejects_rating_above_5(client):
+    headers = _admin_headers(client)
+    response = client.post(
+        "/api/admin/products/",
+        json=_valid_payload(name="Bad Rating Product", rating=999),
+        headers=headers,
+    )
+    assert response.status_code == 422
+
+
+def test_admin_create_rejects_rating_below_0(client):
+    headers = _admin_headers(client)
+    response = client.post(
+        "/api/admin/products/",
+        json=_valid_payload(name="Neg Rating Product", rating=-1),
+        headers=headers,
+    )
+    assert response.status_code == 422
+
+
+def test_admin_update_rejects_negative_price(client):
+    headers = _admin_headers(client)
+    created = client.post(
+        "/api/admin/products/",
+        json=_valid_payload(name="Update Validation Product"),
+        headers=headers,
+    )
+    assert created.status_code == 201
+    product_id = created.json()["id"]
+
+    response = client.put(
+        f"/api/admin/products/{product_id}",
+        json=_valid_payload(name="Update Validation Product", price=-1),
+        headers=headers,
+    )
+    assert response.status_code == 422


### PR DESCRIPTION
## Problem

`ProductBase` (used by admin create/update) has no lower-bound or range validation: `price` and `stock` could be negative, and `rating` was unbounded. A negative price turned checkout totals into zero-cost/credit orders, negative stock permanently locked products out of orders, and `rating: 999` distorted `min_rating` filters and rating-sorted output.

## Fix

- Added validation constraints in `ProductBase` (`backend/app/schemas.py`):
  - `price: float = Field(ge=0)`
  - `stock: int = Field(default=10, ge=0)`
  - `rating: int = Field(ge=0, le=5)`
- Added matching database `CheckConstraint`s on the `Product` model (`backend/app/models.py`) so the invariants hold even for writes that bypass the API (import scripts, direct DB access):
  - `ck_products_price_nonnegative`, `ck_products_stock_nonnegative`, `ck_products_rating_range`
- Added Alembic migration `a3b4c5d6e7f8` adding the three constraints (batch mode, so it works on both SQLite and PostgreSQL).

## Files changed

- `backend/app/schemas.py` — `Field` bounds on `price`/`stock`/`rating`
- `backend/app/models.py` — `CheckConstraint`s on `Product`
- `backend/alembic/versions/a3b4c5d6e7f8_add_product_validation_constraints.py` — new migration (chains after `f1a2b3c4d5e6`)
- `backend/tests/test_admin_products.py` — tests for negative price/stock, out-of-range rating on create and update

## Testing

- `py -m pytest backend/tests/test_admin_products.py` — 12 passed.
- Verified the DB `CheckConstraint` rejects a negative-price insert at the SQLAlchemy layer (SQLite `IntegrityError`).
- Pre-existing `test_admin.py` analytics failures are unchanged and fail identically on `origin/main`.

Closes #5784
