### PR TITLE
fix: require auth and user-scope outfit feedback (issue #5780)

### DIFF
--- a/backend/app/api/recommendation.py
+++ b/backend/app/api/recommendation.py
@@ -3,14 +3,19 @@ from sqlalchemy.orm import Session
 from typing import List
 import hashlib
 import os
+from datetime import datetime, timedelta, timezone
 from .. import models, schemas
 from ..database import get_db
 from ..vector_search.faiss_index import get_similar_product_ids
 from ..rules.engine import filter_by_rules
 from ..limiter import limiter
+from .auth import get_current_user
 
 router = APIRouter()
 SALT = os.environ.get("SECRET_KEY", "fallback_secret_key_for_dev").encode('utf-8')
+# Per-user write ceiling on /feedback so one compromised account cannot flood
+# the interactions table past what a human session could plausibly produce.
+MAX_FEEDBACK_PER_MINUTE = 30
 
 @router.post("/recommend", response_model=List[schemas.Product])
 @limiter.limit("20/minute")
@@ -51,14 +56,32 @@ def recommend_outfit(request: Request, req: schemas.RecommendationRequest, db: S
 
 @router.post("/feedback")
 @limiter.limit("30/minute")
-def track_feedback(request: Request, interaction: schemas.InteractionCreate, db: Session = Depends(get_db)):
+def track_feedback(
+    request: Request,
+    interaction: schemas.InteractionCreate,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
     product = db.query(models.Product).filter(models.Product.id == interaction.product_id).first()
     if not product:
         raise HTTPException(status_code=404, detail="Product not found")
-        
-    # Anonymize PII (like raw IP addresses) via salted hashing before database insertion
-    hashed_user_id = hashlib.sha256(interaction.user_id.encode('utf-8') + SALT).hexdigest()
-    
+
+    # "buy" is recorded by the order pipeline after payment succeeds; accepting it
+    # from a client would let anyone mint purchase signals that feed the reranker.
+    if interaction.interaction_type == "buy":
+        raise HTTPException(status_code=403, detail="Buy feedback must be order-verified.")
+
+    # Identity comes from the authenticated session. The client cannot choose who
+    # the interaction is attributed to, and raw identifiers never reach the DB.
+    hashed_user_id = hashlib.sha256(str(current_user.id).encode('utf-8') + SALT).hexdigest()
+
+    recent_count = db.query(models.Interaction).filter(
+        models.Interaction.user_id == hashed_user_id,
+        models.Interaction.created_at >= datetime.now(timezone.utc) - timedelta(minutes=1),
+    ).count()
+    if recent_count >= MAX_FEEDBACK_PER_MINUTE:
+        raise HTTPException(status_code=429, detail="Feedback rate limit exceeded")
+
     new_interaction = models.Interaction(
         user_id=hashed_user_id,
         product_id=interaction.product_id,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -37,7 +37,8 @@ class InteractionType(str, Enum):
 
 
 class InteractionCreate(BaseModel):
-    user_id: str
+    # Identity is derived from the authenticated user server-side, never trusted
+    # from the client payload (see POST /api/outfit/feedback).
     product_id: int
     interaction_type: InteractionType
 

--- a/backend/tests/test_recommendation.py
+++ b/backend/tests/test_recommendation.py
@@ -1,7 +1,10 @@
 """Tests for POST /api/outfit/recommend and POST /api/outfit/feedback."""
-import numpy as np
+import uuid
 
-from app.models import Product
+import numpy as np
+import pytest
+
+from app.models import Product, User, Interaction
 from app.api import admin_products
 from app.vector_search import faiss_index
 from tests.conftest import TestingSessionLocal
@@ -24,58 +27,165 @@ def _seed_product(db, **kwargs) -> Product:
     return p
 
 
+@pytest.fixture()
+def feedback_user(client, db_session):
+    """Registers a fresh account per test so repeated logins never collide.
+
+    The shared ``auth_headers`` fixture hardcodes one username/email, which
+    breaks once a second test in the same file requests it.
+    """
+    from passlib.context import CryptContext
+    pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+    suffix = uuid.uuid4().hex[:8]
+    email = f"feedback-{suffix}@example.com"
+    user = User(
+        username=f"feedbackuser{suffix}",
+        email=email,
+        hashed_password=pwd.hash("Test@1234"),
+    )
+    db_session.add(user)
+    db_session.commit()
+
+    response = client.post(
+        "/api/auth/login",
+        json={"email": email, "password": "Test@1234"},
+    )
+    token = response.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+    return headers, email
+
+
 # ---------------------------------------------------------------------------
 # /feedback
 # ---------------------------------------------------------------------------
 
-def test_feedback_success(client):
+def test_feedback_requires_auth(client):
     db = TestingSessionLocal()
     p = _seed_product(db)
     db.close()
 
     r = client.post(FEEDBACK_URL, json={
-        "user_id": "anon-123",
         "product_id": p.id,
         "interaction_type": "view",
     })
+    assert r.status_code == 401
+
+
+def test_feedback_success(client, feedback_user):
+    headers, _ = feedback_user
+    db = TestingSessionLocal()
+    p = _seed_product(db)
+    db.close()
+
+    r = client.post(FEEDBACK_URL, json={
+        "product_id": p.id,
+        "interaction_type": "view",
+    }, headers=headers)
     assert r.status_code == 200
     assert r.json()["status"] == "success"
 
 
-def test_feedback_all_interaction_types(client):
+def test_feedback_all_client_interaction_types(client, feedback_user):
+    headers, _ = feedback_user
     db = TestingSessionLocal()
     p = _seed_product(db)
     db.close()
 
-    for itype in ("view", "click", "wishlist", "cart", "buy"):
+    for itype in ("view", "click", "wishlist", "cart"):
         r = client.post(FEEDBACK_URL, json={
-            "user_id": "anon-test",
             "product_id": p.id,
             "interaction_type": itype,
-        })
+        }, headers=headers)
         assert r.status_code == 200, f"Failed for interaction_type={itype}"
 
 
-def test_feedback_invalid_product(client):
-    r = client.post(FEEDBACK_URL, json={
-        "user_id": "anon-123",
-        "product_id": 999999,
-        "interaction_type": "view",
-    })
-    assert r.status_code == 404
-
-
-def test_feedback_invalid_interaction_type(client):
+def test_feedback_buy_rejected(client, feedback_user):
+    """Buy is recorded by the order pipeline; clients cannot mint purchase signals."""
+    headers, _ = feedback_user
     db = TestingSessionLocal()
     p = _seed_product(db)
     db.close()
 
     r = client.post(FEEDBACK_URL, json={
-        "user_id": "anon-123",
+        "product_id": p.id,
+        "interaction_type": "buy",
+    }, headers=headers)
+    assert r.status_code == 403
+
+
+def test_feedback_ignores_client_user_id(client, feedback_user):
+    """Identity is derived from the authenticated user, never from the payload."""
+    headers, email = feedback_user
+    db = TestingSessionLocal()
+    p = _seed_product(db)
+    db.close()
+
+    r = client.post(FEEDBACK_URL, json={
+        "user_id": "attacker-chosen-identity",
+        "product_id": p.id,
+        "interaction_type": "view",
+    }, headers=headers)
+    assert r.status_code == 200
+
+    import hashlib
+    from app.api.recommendation import SALT
+
+    db = TestingSessionLocal()
+    user = db.query(User).filter(User.email == email).first()
+    expected_hash = hashlib.sha256(str(user.id).encode('utf-8') + SALT).hexdigest()
+    stored = db.query(Interaction).filter(
+        Interaction.product_id == p.id
+    ).order_by(Interaction.id.desc()).first()
+    db.close()
+
+    assert stored is not None
+    assert stored.user_id == expected_hash
+    assert stored.user_id != hashlib.sha256(b"attacker-chosen-identity" + SALT).hexdigest()
+
+
+def test_feedback_invalid_product(client, feedback_user):
+    headers, _ = feedback_user
+    r = client.post(FEEDBACK_URL, json={
+        "product_id": 999999,
+        "interaction_type": "view",
+    }, headers=headers)
+    assert r.status_code == 404
+
+
+def test_feedback_invalid_interaction_type(client, feedback_user):
+    headers, _ = feedback_user
+    db = TestingSessionLocal()
+    p = _seed_product(db)
+    db.close()
+
+    r = client.post(FEEDBACK_URL, json={
         "product_id": p.id,
         "interaction_type": "invalid_type",
-    })
+    }, headers=headers)
     assert r.status_code == 422
+
+
+def test_feedback_per_user_rate_cap(client, feedback_user, monkeypatch):
+    headers, _ = feedback_user
+    db = TestingSessionLocal()
+    p = _seed_product(db)
+    db.close()
+
+    from app.api import recommendation
+    monkeypatch.setattr(recommendation, "MAX_FEEDBACK_PER_MINUTE", 2)
+
+    for _ in range(2):
+        r = client.post(FEEDBACK_URL, json={
+            "product_id": p.id,
+            "interaction_type": "view",
+        }, headers=headers)
+        assert r.status_code == 200
+
+    r = client.post(FEEDBACK_URL, json={
+        "product_id": p.id,
+        "interaction_type": "view",
+    }, headers=headers)
+    assert r.status_code == 429
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`POST /api/outfit/feedback` is unauthenticated and trusts the client-supplied `user_id` body field. Anyone can:
- attribute interactions to any arbitrary identity (`user_id: "attacker"`), poisoning the personalized re-ranker for that target,
- flood the `interactions` table with bogus rows (rate limit is per-IP only),
- mint `buy` events to fake purchase signals, since `buy` is accepted from any client.

## Fix

- The endpoint now requires an authenticated user (`Depends(get_current_user)`); unauthenticated calls return `401`.
- Identity is derived server-side from the authenticated user's id, salted-hashed before storage. The client-chosen `user_id` field was removed from `InteractionCreate` (and is ignored if still sent).
- `buy` is rejected with `403` — buy signals must be order-verified and recorded by the order pipeline, not asserted by clients.
- Added a per-user write ceiling (`MAX_FEEDBACK_PER_MINUTE = 30`) enforced with a rolling 1-minute count against the DB, preventing one account from flooding the table.

## Files changed

- `backend/app/schemas.py` — dropped client-supplied `user_id` from `InteractionCreate`
- `backend/app/api/recommendation.py` — auth requirement, server-side identity hashing, `buy` rejection, per-user rate cap
- `backend/tests/test_recommendation.py` — new `feedback_user` fixture (the shared `auth_headers` fixture cannot be reused within one file, pre-existing issue) plus tests: 401 without auth, attribution cannot be client-chosen, `buy` rejected, per-user 429 cap, all allowed interaction types

## Testing

- `py -m pytest backend/tests/test_recommendation.py` — 13 passed (including the pre-existing FAISS index-sync tests).
- Verified the stored `interactions.user_id` matches the authenticated user's salted hash and not any payload-supplied string.

Closes #5780
