### PR TITLE
fix: rate limit on effective client IP behind trusted proxies (issue #5778)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -29,3 +29,10 @@ SECRET_KEY=your-secret-key-here
 
 # Set false for local HTTP; true behind HTTPS in production.
 # COOKIE_SECURE=false
+
+# Comma or semicolon separated IPs / CIDRs of reverse proxies whose
+# X-Forwarded-For / X-Real-IP headers the rate limiter may trust (e.g. the
+# nginx container: "172.16.0.0/12,10.0.0.0/8"). When empty, rate limits are
+# keyed on the direct socket address — behind a proxy every user would share
+# one bucket, so set this whenever traffic flows through a proxy.
+# TRUSTED_PROXIES=

--- a/backend/app/limiter.py
+++ b/backend/app/limiter.py
@@ -1,4 +1,81 @@
+import ipaddress
+import os
+
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
-limiter = Limiter(key_func=get_remote_address)
+
+def _parse_trusted_proxies():
+    """Parse the TRUSTED_PROXIES env var into IP/CIDR objects.
+
+    Comma or semicolon separated list of IPs or CIDR blocks, e.g.
+    "10.0.0.0/8,127.0.0.1". Unparseable entries are ignored.
+    """
+    raw = os.environ.get("TRUSTED_PROXIES", "").strip()
+    if not raw:
+        return []
+    trusted = []
+    for token in raw.replace(";", ",").split(","):
+        token = token.strip()
+        if not token:
+            continue
+        try:
+            if "/" in token:
+                trusted.append(ipaddress.ip_network(token, strict=False))
+            else:
+                trusted.append(ipaddress.ip_address(token))
+        except ValueError:
+            continue
+    return trusted
+
+
+_TRUSTED_NETWORKS = _parse_trusted_proxies()
+
+
+def _is_trusted(ip_str) -> bool:
+    if not ip_str:
+        return False
+    try:
+        ip = ipaddress.ip_address(ip_str.strip())
+    except ValueError:
+        return False
+    for net in _TRUSTED_NETWORKS:
+        if isinstance(net, ipaddress._BaseNetwork):
+            if ip in net:
+                return True
+        elif ip == net:
+            return True
+    return False
+
+
+def get_client_ip(request) -> str:
+    """Effective client IP for rate limiting, honoring trusted proxy headers.
+
+    Only ``X-Forwarded-For`` / ``X-Real-IP`` are consulted when the direct
+    socket peer is within the ``TRUSTED_PROXIES`` allow-list. Untrusted clients
+    (or clients connecting straight to the app) are keyed on the raw socket
+    address, so the header cannot be spoofed to rotate rate-limit buckets.
+    Falls back to slowapi's default behavior when no proxy is involved.
+    """
+    peer = request.client.host if request.client else None
+    if not _is_trusted(peer):
+        return peer or get_remote_address(request)
+
+    forwarded_for = request.headers.get("x-forwarded-for")
+    if forwarded_for:
+        # Proxies append their peer to the right; walk inward from the last hop
+        # and return the first address that is not one of our trusted proxies.
+        hops = [hop.strip() for hop in forwarded_for.split(",") if hop.strip()]
+        for hop in reversed(hops):
+            if not _is_trusted(hop):
+                return hop
+
+    real_ip = request.headers.get("x-real-ip")
+    if real_ip:
+        # Set by the trusted reverse proxy from its own remote_addr.
+        return real_ip
+
+    return peer
+
+
+limiter = Limiter(key_func=get_client_ip)

--- a/backend/tests/test_limiter.py
+++ b/backend/tests/test_limiter.py
@@ -1,0 +1,89 @@
+"""Tests for the trusted-proxy-aware rate-limit key function."""
+import ipaddress
+
+import pytest
+from starlette.requests import Request
+
+from app import limiter as limiter_module
+from app.limiter import _is_trusted, _parse_trusted_proxies, get_client_ip
+
+
+def _make_request(client_host, headers=None):
+    raw_headers = [
+        (k.lower().encode("latin-1"), v.encode("latin-1")) for k, v in (headers or {}).items()
+    ]
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "scheme": "http",
+        "client": (client_host, 50000),
+        "headers": raw_headers,
+    }
+    return Request(scope)
+
+
+def _set_trusted(monkeypatch, networks):
+    monkeypatch.setattr(limiter_module, "_TRUSTED_NETWORKS", networks)
+
+
+@pytest.fixture(autouse=True)
+def _no_trusted_by_default(monkeypatch):
+    _set_trusted(monkeypatch, [])
+
+
+def test_trusted_networks_parsing():
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setenv("TRUSTED_PROXIES", "10.0.0.0/8, 127.0.0.1;192.168.1.1, not-an-ip")
+    networks = _parse_trusted_proxies()
+    monkeypatch.undo()
+    assert len(networks) == 3
+    assert ipaddress.ip_network("10.0.0.0/8") in networks
+    assert ipaddress.ip_address("127.0.0.1") in networks
+
+
+def test_untrusted_peer_ignores_spoofed_headers(monkeypatch):
+    """A client connecting directly cannot rotate the bucket via X-Forwarded-For."""
+    request = _make_request(
+        "203.0.113.5",
+        headers={"X-Forwarded-For": "1.1.1.1, 2.2.2.2", "X-Real-IP": "3.3.3.3"},
+    )
+    assert get_client_ip(request) == "203.0.113.5"
+
+
+def test_trusted_peer_returns_client_from_forwarded_for(monkeypatch):
+    _set_trusted(monkeypatch, [ipaddress.ip_network("10.0.0.0/8")])
+    request = _make_request(
+        "10.0.0.1",
+        headers={"X-Forwarded-For": "198.51.100.7, 10.0.0.1"},
+    )
+    assert get_client_ip(request) == "198.51.100.7"
+
+
+def test_trusted_peer_skips_inner_trusted_hops(monkeypatch):
+    _set_trusted(monkeypatch, [ipaddress.ip_network("10.0.0.0/8")])
+    request = _make_request(
+        "10.0.0.3",
+        headers={"X-Forwarded-For": "198.51.100.7, 10.0.0.2, 10.0.0.3"},
+    )
+    assert get_client_ip(request) == "198.51.100.7"
+
+
+def test_trusted_peer_falls_back_to_x_real_ip(monkeypatch):
+    _set_trusted(monkeypatch, [ipaddress.ip_network("10.0.0.0/8")])
+    request = _make_request("10.0.0.1", headers={"X-Real-IP": "198.51.100.7"})
+    assert get_client_ip(request) == "198.51.100.7"
+
+
+def test_trusted_peer_no_headers_uses_socket(monkeypatch):
+    _set_trusted(monkeypatch, [ipaddress.ip_network("10.0.0.0/8")])
+    request = _make_request("10.0.0.1")
+    assert get_client_ip(request) == "10.0.0.1"
+
+
+def test_all_forwarded_hops_trusted_uses_socket(monkeypatch):
+    _set_trusted(monkeypatch, [ipaddress.ip_network("10.0.0.0/8")])
+    request = _make_request(
+        "10.0.0.2", headers={"X-Forwarded-For": "10.0.0.1, 10.0.0.2"}
+    )
+    assert get_client_ip(request) == "10.0.0.2"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@
       DATABASE_URL: postgresql://${POSTGRES_USER:-cara}:${POSTGRES_PASSWORD:-cara}@db:5432/${POSTGRES_DB:-cara_db}
       SECRET_KEY: ${SECRET_KEY:-change-me-in-production-use-secrets-token-hex}
       COOKIE_SECURE: ${COOKIE_SECURE:-false}
+      TRUSTED_PROXIES: ${TRUSTED_PROXIES:-}
       CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:8080,http://127.0.0.1:8080,http://localhost:5500,http://127.0.0.1:5500}
     depends_on:
       db:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -55,3 +55,23 @@ uvicorn app.main:app --reload --port 8000
 
 ## Production Nginx Configuration
 Ensure gzip compression, cache control headers for assets, and TLS 1.3 encryption are enabled in your Nginx reverse proxy configuration. The bundled `nginx.conf` is a local-compose helper, not a hardened production TLS config.
+
+## Rate limiting behind a reverse proxy
+
+The API rate-limits login, registration, orders, recommendations, and feedback. By default slowapi keys each request on the **direct socket address** (`request.client.host`), so once traffic flows through nginx/cloud load balancers every request appears to come from the proxy and the whole site shares a single rate-limit bucket.
+
+To keep limits per-user behind a proxy, configure the `TRUSTED_PROXIES` environment variable with the IPs/CIDRs of the proxies that sit in front of the API (comma or semicolon separated):
+
+```bash
+TRUSTED_PROXIES=172.16.0.0/12,10.0.0.0/8
+```
+
+The rate limiter only honors `X-Forwarded-For` / `X-Real-IP` when the direct peer is in this allow-list, and otherwise falls back to the socket address — so an untrusted client cannot spoof the header to rotate its own rate-limit bucket.
+
+In the bundled Docker Compose stack the nginx container proxies `/api/*` to the API, so the proxy IP will be inside Docker's default bridge network (`172.16.0.0/12` / `172.17.0.0/16`). Set `TRUSTED_PROXIES` accordingly in `.env`:
+
+```bash
+TRUSTED_PROXIES=172.16.0.0/12,172.17.0.0/16
+```
+
+For uvicorn-managed deployments the equivalent is `--proxy-headers --forwarded-allow-ips <proxy CIDR>`, which rewrites `request.client.host` to the forwarded client IP before slowapi sees it.


### PR DESCRIPTION
## Problem

`slowapi.Limiter` was configured with `get_remote_address`, which keys every rate limit on `request.client.host` — the **direct socket address**. Behind the bundled nginx reverse proxy (or any cloud load balancer), every request shows the proxy's IP, so the whole site shares a single rate-limit bucket: `5/minute` login/register limits become global, and orders/recommendations throttle all shoppers together. The converse risk is also real: trusting `X-Forwarded-For` from untrusted clients would let attackers rotate the header to bypass limits.

## Fix

- Replaced the key function in `backend/app/limiter.py` with `get_client_ip(request)`:
  - Honors `X-Forwarded-For`/`X-Real-IP` **only when the direct socket peer is inside the `TRUSTED_PROXIES` allow-list** (IPs and/or CIDRs, comma/semicolon separated).
  - Walks the `X-Forwarded-For` chain from the innermost hop and returns the first address that is not a trusted proxy; falls back to `X-Real-IP`, then the socket address.
  - Untrusted peers are always keyed on the socket address, so the header cannot be spoofed to rotate rate-limit buckets.
- Exposed `TRUSTED_PROXIES` in `docker-compose.yml` (passed through to the API service) and documented it in `backend/.env.example` and `docs/DEPLOYMENT.md` (including the uvicorn `--proxy-headers --forwarded-allow-ips` equivalent and the compose nginx bridge network CIDRs).

## Files changed

- `backend/app/limiter.py` — trusted-proxy-aware `get_client_ip` key function
- `backend/tests/test_limiter.py` — new tests: untrusted peer ignores spoofed headers; trusted peer resolves client from forwarded hops; skips inner trusted hops; falls back to `X-Real-IP`/socket
- `docker-compose.yml` — pass `TRUSTED_PROXIES` to the API service
- `backend/.env.example` — document `TRUSTED_PROXIES`
- `docs/DEPLOYMENT.md` — "Rate limiting behind a reverse proxy" section

## Testing

- `py -m pytest backend/tests/test_limiter.py` — 7 passed.
- Full backend suite shows the identical pre-existing failure set as `origin/main` (18 pre-existing failures in admin analytics, newsletter, profile fixture, order, and password-reset tests — none introduced by this change).
- Default behavior is unchanged when `TRUSTED_PROXIES` is unset (direct-access/tests still key on the socket address).

Closes #5778
