### PR TITLE
fix : corrected getSalesToastDisplayDuration to return 6000 matching DISPLAY_DURATION

### DIFF
--- a/js/live-sales-toast.js
+++ b/js/live-sales-toast.js
@@ -204,4 +204,4 @@
 })();
 
 
-export function getSalesToastDisplayDuration() { return 4000; }
+export function getSalesToastDisplayDuration() { return 6000; }

--- a/tests/unit/live-sales-toast.test.js
+++ b/tests/unit/live-sales-toast.test.js
@@ -205,7 +205,7 @@ describe('live-sales-toast.js unit tests', () => {
   });
 
   it('should return sales toast display duration in milliseconds', () => {
-    expect(getSalesToastDisplayDuration()).toBe(4000);
+    expect(getSalesToastDisplayDuration()).toBe(6000);
   });
 });
 


### PR DESCRIPTION
## 📄 Description
The exported function getSalesToastDisplayDuration in js/live-sales-toast.js was returning a hardcoded 4000 (ms) while the actual DISPLAY_DURATION constant used by the toast lifecycle is 6000 (ms). The unit test also asserted the stale value of 4000. Both are corrected to 6000.

## 🔗 Related Issues
Closes #6032

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.