### PR TITLE
fix : return -1 from getStageIndex for unrecognised status in order-tracking-visualizer

### DIFF
--- a/js/order-tracking-visualizer.js
+++ b/js/order-tracking-visualizer.js
@@ -15,11 +15,12 @@ export class OrderTrackingVisualizer {
     if (norm.includes('ship')) return 2;
     if (norm.includes('out') || norm.includes('delivery')) return 3;
     if (norm.includes('deliver')) return 4;
-    return 0;
+    return -1;
   }
 
   calculateProgressPercent(statusString = '') {
     const index = this.getStageIndex(statusString);
+    if (index < 0) return 0;
     return Math.round((index / (this.stages.length - 1)) * 100);
   }
 

--- a/tests/unit/order-tracking-visualizer.test.js
+++ b/tests/unit/order-tracking-visualizer.test.js
@@ -32,13 +32,15 @@ describe('OrderTrackingVisualizer', () => {
   it('should map out-for-delivery and unknown statuses to stages', () => {
     expect(visualizer.getStageIndex('Out for Delivery')).toBe(3);
     expect(visualizer.getStageIndex('Processing')).toBe(1);
-    expect(visualizer.getStageIndex('unknown-status')).toBe(0);
-    expect(visualizer.getStageIndex('')).toBe(0);
+    expect(visualizer.getStageIndex('unknown-status')).toBe(-1);
+    expect(visualizer.getStageIndex('')).toBe(-1);
+    expect(visualizer.getStageIndex('Cancelled')).toBe(-1);
   });
 
   it('should compute 75 percent for the out-for-delivery stage', () => {
     expect(visualizer.calculateProgressPercent('Out for Delivery')).toBe(75);
     expect(visualizer.calculateProgressPercent('Processing')).toBe(25);
+    expect(visualizer.calculateProgressPercent('unknown-status')).toBe(0);
   });
 
   it('should mark the current stage node as current', () => {


### PR DESCRIPTION
## 📄 Description
Changed getStageIndex in js/order-tracking-visualizer.js to return -1 for unrecognised status strings instead of defaulting to 0 (Order Placed). Added a guard in calculateProgressPercent to return 0% when index is -1. Updated the test assertions to reflect the new -1 sentinel value for unknown statuses such as 'unknown-status', empty string, and 'Cancelled'.

## 🔗 Related Issues
Closes #6039

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.