### PR TITLE
fix: never return password reset token; refuse reset without SMTP (issue #5777)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,9 +12,9 @@
 # Generate one with: python -c "import secrets; print(secrets.token_hex(32))"
 SECRET_KEY=your-secret-key-here
 
-# SMTP settings for sending password reset emails (all optional).
-# If SMTP_HOST is left empty, the reset token is returned directly in the
-# forgot-password response so the client-side flow still works.
+# SMTP settings for sending password reset emails. REQUIRED for the password
+# reset flow: reset tokens are never returned in the API response, so without
+# a working SMTP_HOST the forgot-password endpoint refuses requests (503).
 # SMTP_HOST=smtp.example.com
 # SMTP_PORT=587
 # SMTP_USERNAME=your-smtp-username

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -311,8 +311,9 @@ def refresh_access_token(request: Request, response: Response, db: Session = Dep
 def send_password_reset_email(recipient: str, token: str) -> bool:
     """Send a password reset email with a one-click reset link.
 
-    Returns False when SMTP is not configured so callers can fall back to
-    returning the token to the client (the flow the frontend already uses).
+    Returns False when SMTP is not configured or delivery fails. Reset tokens
+    are only ever delivered inside the emailed link — they are never returned
+    to the caller of /forgot-password.
     """
     if not SMTP_HOST:
         return False
@@ -360,6 +361,18 @@ def forgot_password(
     payload: ForgotPasswordRequest,
     db: Session = Depends(get_db),
 ):
+    # The reset token can only be delivered out-of-band via email. Without SMTP
+    # configured there is no safe channel, so refuse every request (uniformly,
+    # before the user lookup, to avoid leaking which addresses are registered).
+    if not SMTP_HOST:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Password reset is unavailable: email delivery is not "
+                "configured. Please contact support."
+            ),
+        )
+
     user = db.query(models.User).filter(models.User.email == payload.email).first()
     if not user:
         return {"message": "If the email exists, a reset link has been sent"}
@@ -375,16 +388,14 @@ def forgot_password(
     db.add(reset_token)
     db.commit()
 
-    # Deliver the reset link. When SMTP is configured the email is sent with a
-    # link containing the token; otherwise the token is returned so the app's
-    # existing client-side flow (forgotPassword.js) can complete the reset.
+    # The token is sent only inside the emailed reset link. It is never
+    # returned in the response, so a caller cannot redeem a reset they did not
+    # receive the email for.
     email_sent = send_password_reset_email(user.email, token)
+    if not email_sent:
+        logger.warning("Password reset email could not be delivered to %s", user.email)
 
-    return {
-        "message": "If the email exists, a reset link has been sent",
-        "reset_token": token,
-        "email_sent": email_sent,
-    }
+    return {"message": "If the email exists, a reset link has been sent"}
 
 
 @router.post("/reset-password")

--- a/backend/tests/test_password_reset.py
+++ b/backend/tests/test_password_reset.py
@@ -1,4 +1,20 @@
-def test_forgot_password_nonexistent_email(client):
+def test_forgot_password_refuses_without_smtp(client):
+    """No SMTP configured -> 503 for every address (no token issued, no enumeration)."""
+    for email in ("existing@example.com", "nonexistent@example.com"):
+        response = client.post(
+            "/api/auth/forgot-password",
+            json={"email": email},
+        )
+        assert response.status_code == 503
+        assert "reset_token" not in response.json()
+
+
+def test_forgot_password_nonexistent_email(client, monkeypatch):
+    from app.api import auth as auth_api
+
+    monkeypatch.setattr(auth_api, "SMTP_HOST", "smtp.example.com")
+    monkeypatch.setattr(auth_api, "send_password_reset_email", lambda r, t: True)
+
     response = client.post(
         "/api/auth/forgot-password",
         json={"email": "nonexistent@example.com"},
@@ -6,40 +22,54 @@ def test_forgot_password_nonexistent_email(client):
     assert response.status_code == 200
     data = response.json()
     assert "message" in data
+    assert "reset_token" not in data
 
 
-def test_forgot_password_existing_email(client, db_session):
-    from backend.app.models import User
+def test_forgot_password_existing_email_does_not_leak_token(client, db_session, monkeypatch):
+    from app.models import User, PasswordResetToken
+    from app.api import auth as auth_api
+    from tests.conftest import TestingSessionLocal
     from passlib.context import CryptContext
-    pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
+    pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
     user = User(
-        username="testuser",
-        email="test@example.com",
+        username="resetforgotuser",
+        email="forgot@example.com",
         hashed_password=pwd.hash("Test@1234"),
     )
     db_session.add(user)
     db_session.commit()
 
+    monkeypatch.setattr(auth_api, "SMTP_HOST", "smtp.example.com")
+    monkeypatch.setattr(auth_api, "send_password_reset_email", lambda r, t: True)
+
     response = client.post(
         "/api/auth/forgot-password",
-        json={"email": "test@example.com"},
+        json={"email": "forgot@example.com"},
     )
     assert response.status_code == 200
     data = response.json()
     assert "message" in data
+    assert "reset_token" not in data
+
+    # A one-time token row was still created for the emailed link.
+    db = TestingSessionLocal()
+    rows = db.query(PasswordResetToken).filter(PasswordResetToken.user_id == user.id).all()
+    db.close()
+    assert len(rows) == 1
+    assert rows[0].token
 
 
 def test_reset_password_valid_token(client, db_session):
-    from backend.app.models import User, PasswordResetToken
+    from app.models import User, PasswordResetToken
     from passlib.context import CryptContext
     from datetime import datetime, timedelta, timezone
     import secrets
     pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
     user = User(
-        username="testuser",
-        email="test@example.com",
+        username="resetvaliduser",
+        email="validtoken@example.com",
         hashed_password=pwd.hash("OldPass@123"),
     )
     db_session.add(user)

--- a/forgotPassword.js
+++ b/forgotPassword.js
@@ -106,7 +106,20 @@ document.addEventListener('DOMContentLoaded', function () {
 
       const API_BASE = window.CARA_API_BASE_URL || '';
       // If the user arrived via the emailed reset link, the token is in the URL.
+      // Reset tokens are never returned by the API, so without a URL token this
+      // page can only *request* a reset link, not complete one.
       const urlToken = new URLSearchParams(window.location.search).get('token');
+
+      const doReset = function (token) {
+        return fetch(API_BASE + '/api/auth/reset-password', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            token: token,
+            new_password: newPass,
+          }),
+        });
+      };
 
       fetch(API_BASE + '/api/auth/forgot-password', {
         method: 'POST',
@@ -122,37 +135,37 @@ document.addEventListener('DOMContentLoaded', function () {
           return res.json();
         })
         .then(function (data) {
-          const resetToken = data.reset_token || urlToken;
-
-          if (!resetToken) {
-            throw new Error('No reset token provided');
+          if (urlToken) {
+            // Arrived via the emailed link: complete the reset directly.
+            return doReset(urlToken);
           }
-
-          return fetch(API_BASE + '/api/auth/reset-password', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              token: resetToken,
-              new_password: newPass,
-            }),
-          });
+          // Request-only page: the API never returns a token, so the user must
+          // follow the link that was emailed to them.
+          showToast(
+            'If the email exists, a reset link has been sent. Check your inbox.',
+            'success',
+          );
+          return null;
         })
-        .then(function (res) {
-          if (!res.ok) {
-            return res.json().then(function (data) {
+        .then(function (resetResponse) {
+          if (!resetResponse) return;
+          if (!resetResponse.ok) {
+            return resetResponse.json().then(function (data) {
               throw new Error(data.detail || 'Reset failed');
             });
           }
-          return res.json();
+          return resetResponse.json();
         })
         .then(function () {
-          showToast(
-            'Password reset successful! Redirecting to login...',
-            'success',
-          );
-          setTimeout(function () {
-            window.location.href = 'login.html';
-          }, 2000);
+          if (urlToken) {
+            showToast(
+              'Password reset successful! Redirecting to login...',
+              'success',
+            );
+            setTimeout(function () {
+              window.location.href = 'login.html';
+            }, 2000);
+          }
         })
         .catch(function (err) {
           console.warn("[ForgotPassword] Failed:", err);


### PR DESCRIPTION
## Problem

`POST /api/auth/forgot-password` returned the password-reset token in the API response body whenever SMTP was not configured. Since SMTP is optional and unset by default, the default deployment handed a working reset token to anyone who called the endpoint with a victim's email — a full account-takeover primitive (attacker requests reset for victim, receives token, resets victim's password, logs in).

## Fix

- **Never return the reset token** (`backend/app/api/auth.py`): the `/forgot-password` response no longer contains `reset_token` or `email_sent`; only the generic message is returned. The token is delivered exclusively inside the emailed reset link.
- **Refuse the flow without SMTP**: when `SMTP_HOST` is unset, the endpoint returns `503` with a clear detail message. The check runs *before* the user lookup so the response is uniform for registered and unregistered addresses (no account enumeration).
- **Frontend** (`forgotPassword.js`): the request page no longer expects a token in the response. With no `?token=` in the URL it only requests a reset link and shows "check your inbox"; arriving via the emailed link (`?token=...`) completes the reset directly. `data.reset_token` is no longer read.
- **Docs** (`backend/.env.example`): SMTP is now documented as required for the password reset flow and the old "token returned in response" note is removed.

## Files changed

- `backend/app/api/auth.py` — no token in response; `503` when SMTP unconfigured; docstring update on `send_password_reset_email`
- `forgotPassword.js` — two-step flow: request-only vs. complete-reset-via-URL-token
- `backend/.env.example` — SMTP documented as required for reset
- `backend/tests/test_password_reset.py` — rewritten: `503` without SMTP (uniform), no token leaked when SMTP configured, token row still created for the emailed link, plus the existing reset/revocation tests (fixed imports/username collisions)

## Testing

- `py -m pytest backend/tests/test_password_reset.py` — 6 passed.

## Note on defense-in-depth

The issue also suggests requiring the caller to be the authenticated account owner. That would break the legitimate use case (a forgot-password flow is entered from a logged-out state), so it is intentionally not implemented; requiring working SMTP delivery + never exposing the token closes the takeover primitive while keeping the flow usable.

Closes #5777
