### PR TITLE
fix: fail fast on weak SECRET_KEY, require compose DB/SECRET_KEY secrets (issue #5776)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,19 @@
 # Copy to `.env` and adjust for local/docker use.
-# Generate SECRET_KEY with: python -c "import secrets; print(secrets.token_hex(32))"
-
-SECRET_KEY=change-me-in-production-use-secrets-token-hex
+# SECRET_KEY is REQUIRED and must be at least 32 characters — the API refuses
+# to start with a placeholder or weak value. Generate one with:
+#   python -c "import secrets; print(secrets.token_hex(32))"
+SECRET_KEY=
 COOKIE_SECURE=false
 
 POSTGRES_USER=cara
-POSTGRES_PASSWORD=cara
+# POSTGRES_PASSWORD is REQUIRED by docker compose (no default is shipped).
+# Generate one with: openssl rand -hex 32
+POSTGRES_PASSWORD=
 POSTGRES_DB=cara_db
 
-# Used by docker compose for the API service (compose overrides host to `db`)
-DATABASE_URL=postgresql://cara:cara@localhost:5432/cara_db
+# Used by docker compose for the API service (compose overrides host to `db`).
+# For local (non-Docker) PostgreSQL, set the password to match your local DB.
+DATABASE_URL=postgresql://cara:YOUR_DB_PASSWORD@localhost:5432/cara_db
 
 # Browser origins allowed for credentialed CORS (comma-separated)
 CORS_ORIGINS=http://localhost:8080,http://127.0.0.1:8080,http://localhost:5500,http://127.0.0.1:5500

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,9 +8,10 @@
 # For SQLite (default fallback):
 # DATABASE_URL=sqlite:///./cara.db
 
-# Secret key used for signing JWTs — required, server will not start without it.
-# Generate one with: python -c "import secrets; print(secrets.token_hex(32))"
-SECRET_KEY=your-secret-key-here
+# Secret key used for signing JWTs — REQUIRED, at least 32 characters, and the
+# server will not start with a placeholder or weak value. Generate one with:
+# python -c "import secrets; print(secrets.token_hex(32))"
+SECRET_KEY=
 
 # SMTP settings for sending password reset emails (all optional).
 # If SMTP_HOST is left empty, the reset token is returned directly in the

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -27,10 +27,22 @@ failed_login_attempts = OrderedDict()
 MAX_TRACKED_EMAILS = 1000
 
 SECRET_KEY = os.environ.get("SECRET_KEY")
-if not SECRET_KEY:
+# Known placeholder values that would be trivially guessable if shipped as-is.
+_PLACEHOLDER_SECRET_KEYS = {
+    "change-me-in-production-use-secrets-token-hex",
+    "your-secret-key-here",
+    "changeme",
+    "secret",
+}
+if (
+    not SECRET_KEY
+    or SECRET_KEY.strip() in _PLACEHOLDER_SECRET_KEYS
+    or len(SECRET_KEY) < 32
+):
     raise RuntimeError(
-        "SECRET_KEY environment variable is not set. "
-        "Add SECRET_KEY=<your-secret> to your .env file before starting the server."
+        "SECRET_KEY is not set to a strong value. Generate one with: "
+        "python -c \"import secrets; print(secrets.token_hex(32))\" "
+        "and set SECRET_KEY=<value> in your .env file before starting the server."
     )
 ALGORITHM  = "HS256"
 ACCESS_TOKEN_MINUTES = 15

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
     image: postgres:16-alpine
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-cara}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-cara}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in .env — generate one with `openssl rand -hex 32`}
       POSTGRES_DB: ${POSTGRES_DB:-cara_db}
     volumes:
       - cara_pgdata:/var/lib/postgresql/data
@@ -12,16 +12,16 @@
       interval: 5s
       timeout: 5s
       retries: 10
-    ports:
-      - "5432:5432"
+    # No host port is published: the database is only reachable inside the
+    # compose network. Publish it manually only if you need local tooling.
 
   api:
     build:
       context: ./backend
       dockerfile: Dockerfile
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-cara}:${POSTGRES_PASSWORD:-cara}@db:5432/${POSTGRES_DB:-cara_db}
-      SECRET_KEY: ${SECRET_KEY:-change-me-in-production-use-secrets-token-hex}
+      DATABASE_URL: postgresql://${POSTGRES_USER:-cara}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-cara_db}
+      SECRET_KEY: ${SECRET_KEY:?SECRET_KEY must be set in .env — generate one with `python -c "import secrets; print(secrets.token_hex(32))"`}
       COOKIE_SECURE: ${COOKIE_SECURE:-false}
       CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:8080,http://127.0.0.1:8080,http://localhost:5500,http://127.0.0.1:5500}
     depends_on:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -10,7 +10,7 @@
    ```bash
    cp .env.example .env
    ```
-   Set a strong `SECRET_KEY` before any public deployment.
+   Set a strong `SECRET_KEY` (≥32 chars, e.g. `python -c "import secrets; print(secrets.token_hex(32))"`) and a strong `POSTGRES_PASSWORD` before any deployment — `docker compose` refuses to start without both, and the API refuses to boot with a placeholder/weak `SECRET_KEY`. The database port is no longer published to the host.
 
 2. Start Postgres, FastAPI, and the static frontend:
    ```bash
@@ -30,7 +30,7 @@
 Services:
 | Service | Image / build | Port |
 |---------|---------------|------|
-| `db` | `postgres:16-alpine` | `5432` |
+| `db` | `postgres:16-alpine` | none published (internal only) |
 | `api` | `backend/Dockerfile` (uvicorn) | `8000` |
 | `web` | root `Dockerfile` (nginx) | `8080` |
 


### PR DESCRIPTION
## Problem

The bundled `docker-compose.yml` shipped public, well-known defaults: `SECRET_KEY:-change-me-in-production-use-secrets-token-hex` and `POSTGRES_PASSWORD:-cara`, and it published Postgres on the host port `5432`. A deployment that did not override these ran with a guessable JWT signing key — anyone could forge an access token for any registered email (including admins) and connect to the DB with `cara:cara`. `auth.py` only refused to start when the variable was unset, so the compose default always satisfied the check.

## Fix

- **Fail fast on weak `SECRET_KEY`** (`backend/app/api/auth.py`): the startup check now rejects empty, known-placeholder (`change-me-...`, `your-secret-key-here`, `changeme`, `secret`), and keys shorter than 32 characters with a clear `RuntimeError`.
- **Require secrets in compose** (`docker-compose.yml`): `POSTGRES_PASSWORD` and `SECRET_KEY` now use Compose's `${VAR:?error}` interpolation, so `docker compose up` refuses to start until both are set in `.env` — no defaults are shipped. `DATABASE_URL` uses the required variable.
- **Stop publishing the DB port** (`docker-compose.yml`): the `db` service no longer maps `5432:5432` to the host; Postgres is only reachable inside the compose network.
- **Docs**: `.env.example`, `backend/.env.example`, and `docs/DEPLOYMENT.md` updated — `SECRET_KEY` is now an empty required value (server refuses placeholders), `POSTGRES_PASSWORD` is documented as required with a generation command, and the deployment guide notes the DB port is no longer published.

## Files changed

- `backend/app/api/auth.py` — fail-fast `SECRET_KEY` validation
- `docker-compose.yml` — required secrets, no DB host port
- `.env.example`, `backend/.env.example` — required-value documentation
- `docs/DEPLOYMENT.md` — required secrets + port table update

## Testing

- `SECRET_KEY` validation: empty, both placeholders, and short keys are blocked; a strong (≥32 char) key boots the app.
- `docker compose config` without the variables exits non-zero with a clear "required variable ... missing a value" error; with them set it succeeds and publishes only `8000`/`8080` (no `5432`).
- Full backend suite shows the identical pre-existing failure set as `origin/main` (no new failures).

Closes #5776
