### PR TITLE
fix(migrations): add ambassador_applications table migration (#6052)

### DIFF
--- a/backend/alembic/versions/f3a4b5c6d7e8_add_ambassador_applications_table.py
+++ b/backend/alembic/versions/f3a4b5c6d7e8_add_ambassador_applications_table.py
@@ -1,0 +1,47 @@
+"""add ambassador_applications table
+
+Revision ID: f3a4b5c6d7e8
+Revises: f1a2b3c4d5e6
+Create Date: 2026-08-09 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f3a4b5c6d7e8'
+down_revision: Union[str, Sequence[str], None] = 'f1a2b3c4d5e6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create the ambassador_applications table.
+
+    Without this migration, databases provisioned via ``alembic upgrade head``
+    lack the table that ``POST /api/ambassador/apply`` inserts into, causing
+    every application request to 500 with ``relation does not exist``.
+    """
+    op.create_table(
+        'ambassador_applications',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('full_name', sa.String(), nullable=False),
+        sa.Column('email', sa.String(), nullable=False),
+        sa.Column('instagram_handle', sa.String(), nullable=False),
+        sa.Column('follower_count', sa.Integer(), nullable=False),
+        sa.Column('motivation', sa.String(), nullable=True),
+        sa.Column('submitted_at', sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_ambassador_applications_id'), 'ambassador_applications', ['id'], unique=False)
+    op.create_index(op.f('ix_ambassador_applications_email'), 'ambassador_applications', ['email'], unique=False)
+
+
+def downgrade() -> None:
+    """Drop the ambassador_applications table."""
+    op.drop_index(op.f('ix_ambassador_applications_email'), table_name='ambassador_applications')
+    op.drop_index(op.f('ix_ambassador_applications_id'), table_name='ambassador_applications')
+    op.drop_table('ambassador_applications')

--- a/backend/tests/test_ambassador_migration.py
+++ b/backend/tests/test_ambassador_migration.py
@@ -1,0 +1,64 @@
+"""Regression test: the ambassador_applications table must be created by migrations.
+
+The ``AmbassadorApplication`` model existed in code before any Alembic migration
+created its table, so databases provisioned via ``alembic upgrade head`` (the
+documented docker-entrypoint flow) 500 on ``POST /api/ambassador/apply`` with
+``relation "ambassador_applications" does not exist``.
+
+This test reproduces that pre-fix migrated state (full schema minus the
+ambassador table) and asserts that upgrading to head creates the table.
+"""
+import os
+
+import sqlalchemy as sa
+from alembic import command
+from alembic.config import Config
+
+from app import models
+
+BACKEND_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ALEMBIC_INI = os.path.join(BACKEND_DIR, "alembic.ini")
+PREVIOUS_HEAD = "f1a2b3c4d5e6"
+
+
+def _alembic_config() -> Config:
+    cfg = Config(ALEMBIC_INI)
+    cfg.set_main_option("script_location", os.path.join(BACKEND_DIR, "alembic"))
+    return cfg
+
+
+def test_ambassador_table_created_by_alembic_upgrade(monkeypatch, tmp_path):
+    scratch = tmp_path / "scratch.db"
+    url = f"sqlite:///{scratch.as_posix()}"
+
+    # alembic/env.py reads the URL from app.database at migration time.
+    import app.database as database
+
+    monkeypatch.setattr(database, "SQLALCHEMY_DATABASE_URL", url)
+
+    # Build the schema the way tests/conftest.py does, then drop the ambassador
+    # table to reproduce the broken migrated database state (model present,
+    # table absent).
+    engine = sa.create_engine(url)
+    models.Base.metadata.create_all(bind=engine)
+    models.AmbassadorApplication.__table__.drop(bind=engine)
+    engine.dispose()
+
+    cfg = _alembic_config()
+    command.stamp(cfg, PREVIOUS_HEAD)
+    command.upgrade(cfg, "head")
+
+    engine = sa.create_engine(url)
+    inspector = sa.inspect(engine)
+    assert "ambassador_applications" in inspector.get_table_names()
+    columns = {col["name"] for col in inspector.get_columns("ambassador_applications")}
+    assert columns == {
+        "id",
+        "full_name",
+        "email",
+        "instagram_handle",
+        "follower_count",
+        "motivation",
+        "submitted_at",
+    }
+    engine.dispose()


### PR DESCRIPTION
﻿## Problem

The `AmbassadorApplication` model has no Alembic migration creating its `ambassador_applications` table. In any database provisioned through migrations (the documented setup runs `alembic upgrade head` on container start), `POST /api/ambassador/apply` fails with `ProgrammingError: relation "ambassador_applications" does not exist`.

## Fix

Adds a new Alembic migration (`f3a4b5c6d7e8`) that creates the `ambassador_applications` table (`id`, `full_name`, `email`, `instagram_handle`, `follower_count`, `motivation`, `submitted_at`) matching the `AmbassadorApplication` model, plus its `id`/`email` indexes. Also adds a regression test that runs `alembic upgrade head` against a scratch database and asserts the table and its columns exist.

## Files changed

- `backend/alembic/versions/f3a4b5c6d7e8_add_ambassador_applications_table.py`
- `backend/tests/test_ambassador_migration.py`

## Testing

- `pytest backend/tests/test_ambassador_migration.py backend/tests/test_ambassador.py` - 4 passed
- Verified `alembic heads` shows `f3a4b5c6d7e8 (head)`
- Existing ambassador API tests (`POST /api/ambassador/apply`) still pass

Closes #6052
