### PR TITLE
fix(auth): case-insensitive email/username handling (#6053)

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta, timezone
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.security import OAuth2PasswordBearer
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 from passlib.context import CryptContext
 from jose import jwt, JWTError
@@ -166,7 +167,7 @@ def get_current_user(
     except JWTError:
         raise HTTPException(401, "Invalid or expired token.")
 
-    user = db.query(models.User).filter(models.User.email == email).first()
+    user = db.query(models.User).filter(func.lower(models.User.email) == email.lower()).first()
     if not user:
         raise HTTPException(404, "User not found.")
     if not user.is_active:
@@ -178,9 +179,9 @@ def get_current_user(
 @router.post("/register", response_model=Token, status_code=201)
 @limiter.limit("5/minute")
 def register(request: Request, response: Response, payload: UserRegister, db: Session = Depends(get_db)):
-    if db.query(models.User).filter(models.User.email == payload.email).first():
+    if db.query(models.User).filter(func.lower(models.User.email) == payload.email.lower()).first():
         raise HTTPException(409, "Email already registered.")
-    if db.query(models.User).filter(models.User.username == payload.username).first():
+    if db.query(models.User).filter(func.lower(models.User.username) == payload.username.lower()).first():
         raise HTTPException(409, "Username already taken.")
 
     user = models.User(
@@ -255,7 +256,7 @@ def login(request: Request, response: Response, payload: UserLogin, db: Session 
         except JWTError:
             raise HTTPException(403, "Invalid or expired security code.")
 
-    user = db.query(models.User).filter(models.User.email == payload.email).first()
+    user = db.query(models.User).filter(func.lower(models.User.email) == payload.email.lower()).first()
 
     if not user or not pwd.verify(payload.password, user.hashed_password):
         failed_login_attempts[email_hash] = attempts + 1
@@ -360,7 +361,7 @@ def forgot_password(
     payload: ForgotPasswordRequest,
     db: Session = Depends(get_db),
 ):
-    user = db.query(models.User).filter(models.User.email == payload.email).first()
+    user = db.query(models.User).filter(func.lower(models.User.email) == payload.email.lower()).first()
     if not user:
         return {"message": "If the email exists, a reset link has been sent"}
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -59,6 +59,11 @@ class UserRegister(BaseModel):
     email:    EmailStr
     password: str = Field(min_length=8, max_length=128)
 
+    @field_validator("email")
+    @classmethod
+    def email_normalize(cls, v: str) -> str:
+        return v.strip().lower()
+
     @field_validator("password")
     @classmethod
     def password_complexity(cls, v: str) -> str:
@@ -80,6 +85,11 @@ class UserLogin(BaseModel):
     password: str
     captcha_answer: Optional[str] = None
     captcha_token:  Optional[str] = None
+
+    @field_validator("email")
+    @classmethod
+    def email_normalize(cls, v: str) -> str:
+        return v.strip().lower()
 
 
 # -- Response Schemas --
@@ -194,6 +204,11 @@ class PriceRange(BaseModel):
 
 class ForgotPasswordRequest(BaseModel):
     email: EmailStr
+
+    @field_validator("email")
+    @classmethod
+    def email_normalize(cls, v: str) -> str:
+        return v.strip().lower()
 
 
 class ResetPasswordRequest(BaseModel):

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -110,3 +110,67 @@ def test_me_rejects_deactivated_user(client):
 
     response = client.get(ME_URL, headers={"Authorization": f"Bearer {token}"})
     assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Case-insensitive email / username handling (#6053)
+# ---------------------------------------------------------------------------
+
+def test_register_normalizes_email_to_lowercase(client):
+    r = client.post(
+        REGISTER_URL,
+        json={**VALID_USER, "username": "caseuser", "email": "MixedCase@Example.com"},
+    )
+    assert r.status_code == 201
+    assert r.json()["user"]["email"] == "mixedcase@example.com"
+
+
+def test_register_duplicate_email_is_case_insensitive(client):
+    client.post(
+        REGISTER_URL,
+        json={**VALID_USER, "username": "caseone", "email": "CaseDup@Example.com"},
+    )
+    r = client.post(
+        REGISTER_URL,
+        json={**VALID_USER, "username": "casetwo", "email": "casedup@example.com"},
+    )
+    assert r.status_code == 409
+
+
+def test_register_duplicate_username_is_case_insensitive(client):
+    client.post(
+        REGISTER_URL,
+        json={**VALID_USER, "username": "CaseName", "email": "cn1@example.com"},
+    )
+    r = client.post(
+        REGISTER_URL,
+        json={**VALID_USER, "username": "casename", "email": "cn2@example.com"},
+    )
+    assert r.status_code == 409
+
+
+def test_login_works_with_different_email_case(client):
+    client.post(
+        REGISTER_URL,
+        json={**VALID_USER, "username": "loginmixed", "email": "LoginMixed@Example.com"},
+    )
+    r = client.post(
+        LOGIN_URL,
+        json={"email": "loginmixed@example.com", "password": "Secure123@"},
+    )
+    assert r.status_code == 200
+    assert "access_token" in r.json()
+
+
+def test_forgot_password_works_with_different_email_case(client):
+    client.post(
+        REGISTER_URL,
+        json={**VALID_USER, "username": "resetmixed", "email": "ResetMixed@Example.com"},
+    )
+    r = client.post(
+        "/api/auth/forgot-password",
+        json={"email": "resetmixed@example.com"},
+    )
+    assert r.status_code == 200
+    # SMTP is not configured, so the reset token is returned in the body.
+    assert "reset_token" in r.json()


### PR DESCRIPTION
﻿## Problem

Email and username are compared case-sensitively everywhere (register, login, password reset, token-to-user resolution), so `User@X.com` and `user@x.com` are distinct accounts. This produces duplicate accounts for the same mailbox, silent password-reset lockout whenever the typed case differs from registration, and username impersonation (`Admin` vs `admin`).

## Fix

- Normalize email to lowercase at the schema boundary (`field_validator`) in `UserRegister`, `UserLogin`, and `ForgotPasswordRequest`.
- Look users up case-insensitively (`lower(email) == lower(?)`) in `get_current_user`, register, login, and forgot-password so existing mixed-case rows still resolve.
- Register uniqueness checks (email and username) are now case-insensitive, preventing lookalike-handle squatting.

## Files changed

- `backend/app/schemas.py`
- `backend/app/api/auth.py`
- `backend/tests/test_auth.py`

## Testing

- Added regression tests: email lowercasing on register, case-insensitive duplicate email/username rejection, case-insensitive login, and case-insensitive forgot-password (`pytest backend/tests/test_auth.py` passes).
- Existing auth tests still pass.

Closes #6053
