### PR TITLE
fix(auth): single-use captcha tokens and login lockout (#6054)

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -22,9 +22,18 @@ import smtplib
 from email.message import EmailMessage
 import hmac
 
-# In-memory tracking of failed attempts with an LRU bound to prevent OOM DOS attacks
+# In-memory tracking of failed attempts with an LRU bound to prevent OOM DOS attacks.
+# Each entry records the consecutive-failure count and, once the threshold is hit,
+# the lockout window end time so a bounded number of attempts cannot be brute-forced.
 failed_login_attempts = OrderedDict()
 MAX_TRACKED_EMAILS = 1000
+MAX_LOGIN_ATTEMPTS = 5
+LOGIN_LOCKOUT_SECONDS = 15 * 60
+
+# Captcha JWTs are single-use: once a solved token is accepted it is recorded
+# here (LRU bounded) so the same token cannot unlock unlimited password guesses.
+used_captcha_tokens = OrderedDict()
+MAX_USED_CAPTCHA_TOKENS = 10000
 
 SECRET_KEY = os.environ.get("SECRET_KEY")
 if not SECRET_KEY:
@@ -68,6 +77,18 @@ def captcha_answer_digest(answer: str) -> str:
 
 def cookie_secure() -> bool:
     return os.environ.get("COOKIE_SECURE", "true").lower() in ("1", "true", "yes")
+
+
+def _consume_captcha_token(token: str) -> bool:
+    """Mark a captcha token as used; returns False if it was already consumed."""
+    digest = hashlib.sha256(token.encode("utf-8")).hexdigest()
+    if digest in used_captcha_tokens:
+        return False
+    used_captcha_tokens[digest] = True
+    used_captcha_tokens.move_to_end(digest)
+    if len(used_captcha_tokens) > MAX_USED_CAPTCHA_TOKENS:
+        used_captcha_tokens.popitem(last=False)
+    return True
 
 
 # -- Helper: build JWT --
@@ -207,7 +228,8 @@ def register(request: Request, response: Response, payload: UserRegister, db: Se
 
 # -- Captcha --
 @router.get("/captcha")
-def get_captcha():
+@limiter.limit("30/minute")
+def get_captcha(request: Request):
     chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
     code = ''.join(random.choices(chars, k=5))
     
@@ -240,8 +262,13 @@ def get_captcha():
 @limiter.limit("5/minute")
 def login(request: Request, response: Response, payload: UserLogin, db: Session = Depends(get_db)):
     email_hash = hashlib.sha256(payload.email.encode('utf-8')).hexdigest()
-    attempts = failed_login_attempts.get(email_hash, 0)
-    
+    entry = failed_login_attempts.get(email_hash, {"count": 0, "locked_until": None})
+    attempts = entry["count"]
+    locked_until = entry["locked_until"]
+
+    if locked_until and locked_until > datetime.now(timezone.utc):
+        raise HTTPException(429, "Too many failed attempts. Please try again later.")
+
     if attempts >= 1:
         if not payload.captcha_token or not payload.captcha_answer:
             raise HTTPException(403, "Security captcha required.")
@@ -255,10 +282,19 @@ def login(request: Request, response: Response, payload: UserLogin, db: Session 
         except JWTError:
             raise HTTPException(403, "Invalid or expired security code.")
 
+        # Single-use captcha: a solved token must not enable unlimited guessing.
+        if not _consume_captcha_token(payload.captcha_token):
+            raise HTTPException(403, "Invalid or expired security code.")
+
     user = db.query(models.User).filter(models.User.email == payload.email).first()
 
     if not user or not pwd.verify(payload.password, user.hashed_password):
-        failed_login_attempts[email_hash] = attempts + 1
+        next_attempts = attempts + 1
+        next_locked_until = None
+        if next_attempts >= MAX_LOGIN_ATTEMPTS:
+            next_locked_until = datetime.now(timezone.utc) + timedelta(seconds=LOGIN_LOCKOUT_SECONDS)
+            next_attempts = 0
+        failed_login_attempts[email_hash] = {"count": next_attempts, "locked_until": next_locked_until}
         failed_login_attempts.move_to_end(email_hash)
         
         # Enforce LRU bounds to prevent memory leaks from massive bot networks

--- a/backend/tests/test_captcha.py
+++ b/backend/tests/test_captcha.py
@@ -82,3 +82,101 @@ def test_login_rejects_wrong_captcha_answer(client):
         },
     )
     assert bad.status_code == 403
+
+
+def test_captcha_token_is_single_use(client):
+    """A solved captcha token must not enable unlimited password guesses."""
+    email = "singleuse@example.com"
+    password = "Secure123@"
+    client.post(
+        "/api/auth/register",
+        json={"username": "singleuse", "email": email, "password": password},
+    )
+    # First failure forces the captcha on the next attempt.
+    assert (
+        client.post("/api/auth/login", json={"email": email, "password": "WrongPass1"}).status_code
+        == 401
+    )
+
+    captcha = client.get("/api/auth/captcha").json()
+    claims = jwt.decode(captcha["captcha_token"], SECRET_KEY, algorithms=[ALGORITHM])
+    known = "AB12C"
+    forged = jwt.encode(
+        {"captcha_hash": captcha_answer_digest(known), "exp": claims["exp"]},
+        SECRET_KEY,
+        algorithm=ALGORITHM,
+    )
+
+    # Using the token with a wrong password consumes it even though login fails.
+    failed = client.post(
+        "/api/auth/login",
+        json={
+            "email": email,
+            "password": "WrongPass2",
+            "captcha_token": forged,
+            "captcha_answer": known,
+        },
+    )
+    assert failed.status_code == 401
+
+    # Reusing the same solved token is rejected.
+    reuse = client.post(
+        "/api/auth/login",
+        json={
+            "email": email,
+            "password": password,
+            "captcha_token": forged,
+            "captcha_answer": known,
+        },
+    )
+    assert reuse.status_code == 403
+
+
+def test_login_lockout_after_max_failed_attempts(client):
+    """Repeated failures trigger a temporary lockout independent of the captcha."""
+    from datetime import datetime, timedelta, timezone
+
+    from app.api.auth import MAX_LOGIN_ATTEMPTS
+
+    email = "lockout@example.com"
+    password = "Secure123@"
+    client.post(
+        "/api/auth/register",
+        json={"username": "lockoutuser", "email": email, "password": password},
+    )
+
+    # First failure forces the captcha on the next attempt.
+    assert (
+        client.post("/api/auth/login", json={"email": email, "password": "WrongPass1"}).status_code
+        == 401
+    )
+
+    # Each subsequent failure needs a fresh single-use captcha; forge one per attempt.
+    known = "AB12C"
+    exp = datetime.now(timezone.utc) + timedelta(minutes=5)
+    for nonce in range(MAX_LOGIN_ATTEMPTS - 1):
+        forged = jwt.encode(
+            {
+                "captcha_hash": captcha_answer_digest(known),
+                "exp": exp,
+                "nonce": nonce,
+            },
+            SECRET_KEY,
+            algorithm=ALGORITHM,
+        )
+        assert (
+            client.post(
+                "/api/auth/login",
+                json={
+                    "email": email,
+                    "password": "WrongPass1",
+                    "captcha_token": forged,
+                    "captcha_answer": known,
+                },
+            ).status_code
+            == 401
+        )
+
+    # The next attempt — even with the correct password — is blocked during the lockout.
+    blocked = client.post("/api/auth/login", json={"email": email, "password": password})
+    assert blocked.status_code == 429


### PR DESCRIPTION
﻿## Problem

An attacker can brute-force a password after solving the captcha once, because a captcha token stays valid across unlimited attempts. In addition, repeated failures have no upper bound, so there is no lockout to slow down targeted password guessing.

## Fix

- Make captcha tokens single-use: the login handler records the SHA-256 digest of every consumed token in an in-memory LRU map and rejects tokens that were already used. A solved captcha now only grants a single password attempt.
- Cap the number of stored used tokens (MAX_USED_CAPTCHA_TOKENS, LRU eviction) to avoid unbounded memory growth.
- Add an account lockout: after MAX_LOGIN_ATTEMPTS (5) consecutive failures the email is blocked for LOGIN_LOCKOUT_SECONDS (15 minutes), independent of the captcha flow. The ailed_login_attempts entries now carry {count, locked_until}.
- Rate-limit the captcha endpoint itself (30/minute) so it cannot be used to mint unlimited tokens.

## Files changed

- ackend/app/api/auth.py - single-use captcha consumption, lockout state, captcha rate limit
- ackend/tests/test_captcha.py - regression tests for single-use tokens and lockout

## Testing

pytest backend/tests/test_captcha.py backend/tests/test_auth.py - 16 passed.

Closes #6054
