### PR TITLE
fix(auth): store one refresh token per session, allow concurrent logins (#6055)

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -37,9 +37,10 @@ ACCESS_TOKEN_MINUTES = 15
 REFRESH_TOKEN_DAYS = 7
 COOKIE_SAMESITE = "lax"
 COOKIE_PATH = "/"
+MAX_REFRESH_TOKENS_PER_EMAIL = 20
 
-# email -> currently valid refresh token jti (rotation / revoke store)
-active_refresh_jtis: dict[str, str] = {}
+# email -> set of currently valid refresh token jtis (one per active session)
+active_refresh_jtis: dict[str, set[str]] = {}
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +95,11 @@ def create_refresh_token(email: str) -> str:
         SECRET_KEY,
         algorithm=ALGORITHM,
     )
-    active_refresh_jtis[email] = jti
+    sessions = active_refresh_jtis.setdefault(email, set())
+    sessions.add(jti)
+    # Cap concurrent sessions per account; evict an arbitrary one beyond the limit.
+    if len(sessions) > MAX_REFRESH_TOKENS_PER_EMAIL:
+        sessions.pop()
     return token
 
 def set_auth_cookies(response: Response, access_token: str, refresh_token: str):
@@ -129,13 +134,22 @@ def clear_auth_cookies(response: Response):
             samesite=COOKIE_SAMESITE,
         )
 
-def revoke_refresh_token(email: str | None):
-    if email:
+def revoke_refresh_token(email: str | None, jti: str | None = None):
+    if not email:
+        return
+    if jti is None:
+        # No specific session given: revoke every session for the account.
         active_refresh_jtis.pop(email, None)
+        return
+    sessions = active_refresh_jtis.get(email)
+    if sessions:
+        sessions.discard(jti)
+        if not sessions:
+            active_refresh_jtis.pop(email, None)
 
 def assert_refresh_jti(email: str, jti: str | None):
-    expected = active_refresh_jtis.get(email)
-    if not jti or not expected or not hmac.compare_digest(expected, jti):
+    sessions = active_refresh_jtis.get(email)
+    if not jti or not sessions or jti not in sessions:
         raise HTTPException(401, "Invalid or revoked refresh token.")
 
 # -- Helper: get current user from token --
@@ -305,6 +319,8 @@ def refresh_access_token(request: Request, response: Response, db: Session = Dep
 
     access_token = create_access_token(user.email)
     new_refresh_token = create_refresh_token(user.email)
+    # Rotate the refreshed session only; other devices' sessions stay valid.
+    revoke_refresh_token(email, payload.get("jti"))
     set_auth_cookies(response, access_token, new_refresh_token)
     return {"message": "Token refreshed successfully"}
 
@@ -431,7 +447,8 @@ def logout(request: Request, response: Response):
         try:
             payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
             if payload.get("type") == "refresh":
-                revoke_refresh_token(payload.get("sub"))
+                # Revoke only the session that is logging out.
+                revoke_refresh_token(payload.get("sub"), payload.get("jti"))
         except JWTError:
             pass
     clear_auth_cookies(response)

--- a/backend/tests/test_password_reset.py
+++ b/backend/tests/test_password_reset.py
@@ -91,7 +91,7 @@ def test_reset_password_revokes_refresh_session(client):
     db.commit()
     db.refresh(user)
 
-    auth_api.active_refresh_jtis[user.email] = "stolen-jti"
+    auth_api.active_refresh_jtis[user.email] = {"stolen-jti"}
     token = secrets.token_urlsafe(32)
     db.add(
         PasswordResetToken(

--- a/backend/tests/test_refresh_logout.py
+++ b/backend/tests/test_refresh_logout.py
@@ -11,13 +11,12 @@ from app.api.auth import (
 
 def _register_and_login(client, email="rotate@example.com", username="rotateuser"):
     password = "Secure123@"
-    client.post(
+    resp = client.post(
         "/api/auth/register",
         json={"username": username, "email": email, "password": password},
     )
-    login = client.post("/api/auth/login", json={"email": email, "password": password})
-    assert login.status_code == 200
-    return login
+    assert resp.status_code == 201
+    return resp
 
 
 def test_refresh_rotates_refresh_token(client):
@@ -33,12 +32,70 @@ def test_refresh_rotates_refresh_token(client):
     assert new_refresh != old_refresh
     new_jti = jwt.decode(new_refresh, SECRET_KEY, algorithms=[ALGORITHM])["jti"]
     assert new_jti != old_jti
-    assert active_refresh_jtis["rotate@example.com"] == new_jti
+    assert active_refresh_jtis["rotate@example.com"] == {new_jti}
 
     # Old refresh token must no longer work after rotation.
     client.cookies.set("refresh_token", old_refresh)
     reuse = client.post("/api/auth/refresh")
     assert reuse.status_code == 401
+
+
+def test_refresh_keeps_other_sessions_valid(client):
+    """Refreshing one device must not invalidate another device's session."""
+    email = "multi@example.com"
+    _register_and_login(client, email=email, username="multiuser")
+    session_a = client.cookies.get("refresh_token")
+    assert session_a
+    jti_a = jwt.decode(session_a, SECRET_KEY, algorithms=[ALGORITHM])["jti"]
+
+    # Second device logs in -> a new session JTI is added to the same account.
+    login_b = client.post("/api/auth/login", json={"email": email, "password": "Secure123@"})
+    assert login_b.status_code == 200
+    session_b = login_b.cookies.get("refresh_token")
+    jti_b = jwt.decode(session_b, SECRET_KEY, algorithms=[ALGORITHM])["jti"]
+    assert {jti_a, jti_b} == set(active_refresh_jtis[email])
+
+    # Device A refreshes; its own old JTI is rotated away.
+    client.cookies.set("refresh_token", session_a)
+    refreshed = client.post("/api/auth/refresh")
+    assert refreshed.status_code == 200
+    assert jti_a not in active_refresh_jtis[email]
+    assert jti_b in active_refresh_jtis[email]
+
+    # Device B's session still works.
+    client.cookies.set("refresh_token", session_b)
+    still_valid = client.post("/api/auth/refresh")
+    assert still_valid.status_code == 200
+
+
+def test_logout_revokes_only_that_session(client):
+    """Logging out on one device must not revoke the other device's session."""
+    email = "multilogout@example.com"
+    _register_and_login(client, email=email, username="multilogoutuser")
+    session_a = client.cookies.get("refresh_token")
+    jti_a = jwt.decode(session_a, SECRET_KEY, algorithms=[ALGORITHM])["jti"]
+
+    login_b = client.post("/api/auth/login", json={"email": email, "password": "Secure123@"})
+    session_b = login_b.cookies.get("refresh_token")
+    jti_b = jwt.decode(session_b, SECRET_KEY, algorithms=[ALGORITHM])["jti"]
+
+    # Device A logs out -> only A's JTI is revoked.
+    client.cookies.set("refresh_token", session_a)
+    logout = client.post("/api/auth/logout")
+    assert logout.status_code == 200
+    assert jti_a not in active_refresh_jtis[email]
+    assert jti_b in active_refresh_jtis[email]
+
+    # Device B's session still works.
+    client.cookies.set("refresh_token", session_b)
+    still_valid = client.post("/api/auth/refresh")
+    assert still_valid.status_code == 200
+
+    # Device B logs out -> account has no active sessions left.
+    refreshed_b = still_valid.cookies.get("refresh_token")
+    client.cookies.set("refresh_token", refreshed_b)
+    client.post("/api/auth/logout")
+    assert email not in active_refresh_jtis
 
 
 def test_logout_revokes_refresh_and_clears_cookies(client):
@@ -63,4 +120,4 @@ def test_logout_revokes_refresh_and_clears_cookies(client):
 def test_create_refresh_token_registers_jti():
     token = create_refresh_token("jti-check@example.com")
     payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-    assert payload["jti"] == active_refresh_jtis["jti-check@example.com"]
+    assert payload["jti"] in active_refresh_jtis["jti-check@example.com"]


### PR DESCRIPTION
﻿## Problem

ctive_refresh_jtis is a dict[str, str] that stores a single current JTI per email. Every login, register, and refresh overwrites the previous JTI, so a second device's login or any refresh silently revokes all other sessions. Logging out also kills the shared session for every device at once.

## Fix

- Store a set of valid JTIs per email (dict[str, set[str]]), one per active session, so multiple devices can stay logged in concurrently.
- efresh now rotates only the session that refreshed (removes that token's JTI) while leaving other sessions valid.
- logout revokes only the session that logged out instead of every session.
- Password reset still revokes all sessions (a deliberate security measure, unchanged).
- Added MAX_REFRESH_TOKENS_PER_EMAIL (20) so the per-account set stays bounded.

## Files changed

- ackend/app/api/auth.py - set-based JTI store, per-session rotation/revocation
- ackend/tests/test_refresh_logout.py - adapted tests + new concurrent-session and per-session-logout regressions
- ackend/tests/test_password_reset.py - store now holds a set

## Testing

pytest backend/tests/test_refresh_logout.py backend/tests/test_password_reset.py backend/tests/test_auth.py - 19 passed (the 2 remaining failures are pre-existing test-isolation issues, confirmed identical on origin/main).

Closes #6055
