### PR TITLE
security(auth): rate limit POST /api/auth/refresh (#6056)

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -284,6 +284,7 @@ def login(request: Request, response: Response, payload: UserLogin, db: Session 
     )
 
 @router.post("/refresh")
+@limiter.limit("10/minute")
 def refresh_access_token(request: Request, response: Response, db: Session = Depends(get_db)):
     token = request.cookies.get("refresh_token")
     if not token:

--- a/backend/tests/test_refresh_rate_limit.py
+++ b/backend/tests/test_refresh_rate_limit.py
@@ -1,0 +1,26 @@
+"""Rate limiting on POST /api/auth/refresh."""
+from app.limiter import limiter
+
+
+def test_refresh_endpoint_is_rate_limited(client):
+    email = "ratelimit@example.com"
+    client.post(
+        "/api/auth/register",
+        json={"username": "ratelimituser", "email": email, "password": "Secure123@"},
+    )
+    refresh_token = client.cookies.get("refresh_token")
+    assert refresh_token
+
+    limiter.enabled = True
+    try:
+        for _ in range(10):
+            client.cookies.set("refresh_token", refresh_token)
+            resp = client.post("/api/auth/refresh")
+            assert resp.status_code == 200, resp.text
+            refresh_token = resp.cookies.get("refresh_token")
+
+        client.cookies.set("refresh_token", refresh_token)
+        blocked = client.post("/api/auth/refresh")
+        assert blocked.status_code == 429
+    finally:
+        limiter.enabled = False


### PR DESCRIPTION
﻿## Problem

POST /api/auth/refresh is the only auth endpoint without a rate limit. Every other auth endpoint is throttled (egister 5/minute, login 5/minute, orgot-password 5/minute, eset-password 5/minute). It performs JWT verification and a users-table lookup per request with no throttle.

## Fix

- Added @limiter.limit("10/minute") to efresh_access_token, keyed per-IP via the app's existing get_remote_address key function (consistent with the other auth endpoints).

## Files changed

- ackend/app/api/auth.py - rate limit decorator on /api/auth/refresh
- ackend/tests/test_refresh_rate_limit.py - new regression test (10 refreshes allowed, 11th returns 429)

## Testing

pytest backend/tests/test_refresh_rate_limit.py backend/tests/test_refresh_logout.py - 4 passed.

Closes #6056
