### PR TITLE
fix(orders): store money as Numeric(10,2) and price with Decimal (#6057)

### DIFF
--- a/backend/alembic/versions/a5b6c7d8e9f0_store_money_as_numeric_10_2.py
+++ b/backend/alembic/versions/a5b6c7d8e9f0_store_money_as_numeric_10_2.py
@@ -1,0 +1,49 @@
+"""store money as numeric(10,2) instead of float
+
+Revision ID: a5b6c7d8e9f0
+Revises: f1a2b3c4d5e6
+Create Date: 2026-08-09 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a5b6c7d8e9f0'
+down_revision: Union[str, Sequence[str], None] = 'f1a2b3c4d5e6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Store monetary values as exact 2-decimal numerics instead of binary floats."""
+    op.alter_column('products', 'price',
+                    existing_type=sa.Float(),
+                    type_=sa.Numeric(10, 2),
+                    existing_nullable=True)
+    op.alter_column('orders', 'total_amount',
+                    existing_type=sa.Float(),
+                    type_=sa.Numeric(10, 2),
+                    existing_nullable=False)
+    op.alter_column('order_items', 'price',
+                    existing_type=sa.Float(),
+                    type_=sa.Numeric(10, 2),
+                    existing_nullable=False)
+
+
+def downgrade() -> None:
+    op.alter_column('orders', 'total_amount',
+                    existing_type=sa.Numeric(10, 2),
+                    type_=sa.Float(),
+                    existing_nullable=False)
+    op.alter_column('order_items', 'price',
+                    existing_type=sa.Numeric(10, 2),
+                    type_=sa.Float(),
+                    existing_nullable=False)
+    op.alter_column('products', 'price',
+                    existing_type=sa.Numeric(10, 2),
+                    type_=sa.Float(),
+                    existing_nullable=True)

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -51,7 +51,7 @@ def get_analytics_summary(
     total_users = db.query(func.count(models.User.id)).scalar() or 0
 
     return {
-        "total_revenue": float(total_revenue),
+        "total_revenue": round(float(total_revenue), 2),
         "total_orders": int(total_orders),
         "total_customers": int(total_users),
     }
@@ -85,7 +85,7 @@ def get_sales_by_category(
         {
             "category": r[0] or "Unknown",
             "units_sold": int(r[1] or 0),
-            "revenue": float(r[2] or 0.0)
+            "revenue": round(float(r[2] or 0.0), 2)
         }
         for r in results
     ]

--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -7,6 +7,7 @@ from ..database import get_db
 from .auth import get_current_user
 from ..limiter import limiter
 from datetime import datetime, timezone, timedelta
+from decimal import Decimal
 
 router = APIRouter()
 
@@ -163,7 +164,7 @@ def create_order(
             detail="Order must contain at least one item",
         )
 
-    subtotal = 0.0
+    subtotal = Decimal("0.00")
     db_items = []
 
     # --- Fetch all products in a single query to prevent N+1 issue ---
@@ -197,7 +198,7 @@ def create_order(
         # Deduct stock in memory (will be committed later)
         db_product.stock -= item.quantity
 
-        real_price = db_product.price
+        real_price = Decimal(str(db_product.price))
         subtotal += real_price * item.quantity
 
         db_items.append(
@@ -209,9 +210,9 @@ def create_order(
             )
         )
 
-    shipping = 0.0 if subtotal >= 3000 else 150.0
-    tax = round(subtotal * 0.18, 2)
-    discount = 0.0
+    shipping = Decimal("0.00") if subtotal >= Decimal("3000.00") else Decimal("150.00")
+    tax = (subtotal * Decimal("0.18")).quantize(Decimal("0.01"))
+    discount = Decimal("0.00")
 
     # --- Coupon Validation ---
     # Coupons are percentage-off codes defined in a static map that mirrors
@@ -230,9 +231,9 @@ def create_order(
                 detail="Invalid or inactive coupon code"
             )
 
-        discount = round(subtotal * discount_percentage / 100, 2)
+        discount = (subtotal * Decimal(discount_percentage) / Decimal("100")).quantize(Decimal("0.01"))
 
-    grand_total = max(0, subtotal + tax + shipping - discount)
+    grand_total = (subtotal + tax + shipping - discount).max(Decimal("0.00"))
 
     new_order = models.Order(
         full_name=order_data.fullName,

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Float, ForeignKey, JSON, Boolean, DateTime, UniqueConstraint
+from sqlalchemy import Column, Integer, String, ForeignKey, JSON, Boolean, DateTime, UniqueConstraint, Numeric
 from sqlalchemy.orm import relationship
 from .database import Base
 from datetime import datetime, timezone
@@ -31,7 +31,7 @@ class Product(Base):
     id = Column(Integer, primary_key=True, index=True)
     brand = Column(String, index=True)
     name = Column(String, index=True)
-    price = Column(Float)
+    price = Column(Numeric(10, 2))
     img = Column(String)
     rating = Column(Integer)
     category = Column(String, index=True) # street, minimal, formal
@@ -88,7 +88,7 @@ class Order(Base):
     address = Column(String, nullable=False)
     city = Column(String, nullable=False)
     zip_code = Column(String, nullable=False)
-    total_amount = Column(Float, nullable=False)
+    total_amount = Column(Numeric(10, 2), nullable=False)
     status = Column(String, default="PENDING")
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     # Captured exactly once when the carrier marks the order DELIVERED; the
@@ -127,6 +127,6 @@ class OrderItem(Base):
     # Denormalized snapshot kept for order history after renames/deletes.
     product_name = Column(String, nullable=False)
     quantity = Column(Integer, nullable=False)
-    price = Column(Float, nullable=False)
+    price = Column(Numeric(10, 2), nullable=False)
     order = relationship("Order")
     product = relationship("Product")

--- a/backend/tests/test_order_decimal.py
+++ b/backend/tests/test_order_decimal.py
@@ -1,0 +1,99 @@
+"""Monetary values are stored as exact decimals and priced with Decimal math."""
+from decimal import Decimal
+
+from passlib.context import CryptContext
+
+from app.models import Order, OrderItem, Product, User
+from tests.conftest import TestingSessionLocal
+
+ORDERS_URL = "/api/orders/"
+pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def _auth_headers(client, *, username="decimaluser", email="decimal@example.com"):
+    db = TestingSessionLocal()
+    if db.query(User).filter(User.email == email).first() is None:
+        db.add(
+            User(
+                username=username,
+                email=email,
+                hashed_password=pwd.hash("Test@1234"),
+            )
+        )
+        db.commit()
+    db.close()
+
+    resp = client.post(
+        "/api/auth/login",
+        json={"email": email, "password": "Test@1234"},
+    )
+    assert resp.status_code == 200, resp.text
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+def _seed_product(db, *, name, price, stock=10) -> int:
+    product = Product(
+        brand="DecimalBrand",
+        name=name,
+        price=price,
+        img="img.jpg",
+        rating=4,
+        category="minimal",
+        subcategory="top",
+        color="white",
+        style="casual",
+        stock=stock,
+    )
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+    return product.id
+
+
+def test_order_total_uses_exact_decimal_arithmetic(client):
+    """0.10 + 0.20 must total exactly 150.35, not a float approximation."""
+    headers = _auth_headers(client)
+    db = TestingSessionLocal()
+    cheap_id = _seed_product(db, name="Fraction 0.1", price=Decimal("0.10"))
+    pricier_id = _seed_product(db, name="Fraction 0.2", price=Decimal("0.20"))
+    db.close()
+
+    create = client.post(
+        ORDERS_URL,
+        headers=headers,
+        json={
+            "fullName": "Decimal User",
+            "email": "decimal@example.com",
+            "address": "1 Decimal St",
+            "city": "Decimalville",
+            "zip": "12345",
+            "items": [
+                {"product_id": cheap_id, "quantity": 1},
+                {"product_id": pricier_id, "quantity": 1},
+            ],
+        },
+    )
+    assert create.status_code == 201, create.text
+    order_id = create.json()["order_id"]
+
+    db = TestingSessionLocal()
+    order = db.query(Order).filter(Order.id == order_id).one()
+    assert isinstance(order.total_amount, Decimal)
+    assert order.total_amount == Decimal("150.35")
+
+    items = (
+        db.query(OrderItem)
+        .filter(OrderItem.order_id == order_id)
+        .order_by(OrderItem.id.asc())
+        .all()
+    )
+    assert all(isinstance(item.price, Decimal) for item in items)
+    db.close()
+
+
+def test_money_columns_are_numeric_not_float():
+    from app.models import OrderItem, Product
+
+    assert str(Product.__table__.c.price.type) == "NUMERIC(10, 2)"
+    assert str(Order.__table__.c.total_amount.type) == "NUMERIC(10, 2)"
+    assert str(OrderItem.__table__.c.price.type) == "NUMERIC(10, 2)"


### PR DESCRIPTION
﻿## Problem

Monetary values (Product.price, OrderItem.price, Order.total_amount) are stored as Float and checkout totals are accumulated with binary floating-point arithmetic. This produces rounding/precision errors (e.g. .1 + 0.2 != 0.3) that compound over line items and mis-price orders, and leak into admin revenue analytics.

## Fix

- Store money as Numeric(10, 2) in Product.price, Order.total_amount, and OrderItem.price.
- Compute subtotal/tax/discount/grand-total in orders.py with decimal.Decimal and quantize to 2 places; floats are only used for JSON serialization.
- Round admin analytics revenue sums to 2 decimals (dmin.py).
- Added Alembic migration 5b6c7d8e9f0 (loat -> Numeric(10, 2) for the three columns).

## Files changed

- ackend/app/models.py - money columns now Numeric(10, 2)
- ackend/app/api/orders.py - Decimal-based pricing
- ackend/app/api/admin.py - rounded revenue aggregates
- ackend/alembic/versions/a5b6c7d8e9f0_store_money_as_numeric_10_2.py - new migration
- ackend/tests/test_order_decimal.py - regression tests

## Testing

pytest backend/tests/test_order_decimal.py - 2 passed. Order/admin/product suites: 58 passed; the 4 remaining failures are pre-existing test-isolation issues, confirmed identical on origin/main.

Closes #6057
