### PR TITLE
fix(admin): enforce order status state machine and restore stock on cancel (#6058)

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -125,9 +125,20 @@ def update_order_status(
     the Estimated Return Date policy engine then exposes the immutable
     return deadline (delivered_at + 30 days) to the buyer.
     """
-    from .orders import ORDER_STATUSES, return_deadline, set_order_status
+    from .orders import (
+        ORDER_STATUSES,
+        STATUS_TRANSITIONS,
+        restore_order_stock,
+        return_deadline,
+        set_order_status,
+    )
 
-    order = db.query(models.Order).filter(models.Order.id == order_id).first()
+    order = (
+        db.query(models.Order)
+        .filter(models.Order.id == order_id)
+        .with_for_update()
+        .first()
+    )
     if not order:
         raise HTTPException(status_code=404, detail="Order not found")
 
@@ -137,9 +148,26 @@ def update_order_status(
             detail=f"Invalid order status: {payload.status}",
         )
 
-    set_order_status(order, payload.status)
-    db.commit()
-    db.refresh(order)
+    if payload.status == order.status:
+        # Same-status is a no-op; safe (never double-restores stock).
+        db.commit()
+        db.refresh(order)
+    else:
+        allowed = STATUS_TRANSITIONS.get(order.status, set())
+        if payload.status not in allowed:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid status transition: {order.status} -> {payload.status}",
+            )
+
+        # Cancellation returns purchased units to inventory, matching the
+        # buyer-cancel path, so cancelled orders never leak stock.
+        if payload.status == "CANCELLED":
+            restore_order_stock(db, order.id)
+
+        set_order_status(order, payload.status)
+        db.commit()
+        db.refresh(order)
 
     return {
         "message": "Order status updated",

--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -17,6 +17,17 @@ RETURN_WINDOW_DAYS = 30
 # Statuses a carrier/admin may move an order through.
 ORDER_STATUSES = {"PENDING", "CONFIRMED", "SHIPPED", "DELIVERED", "CANCELLED"}
 
+# Forward-only fulfillment flow. Orders are created as CONFIRMED but may be
+# seeded as PENDING. Cancellation is only allowed from pre-shipping states so
+# stock can always be restored exactly once.
+STATUS_TRANSITIONS: dict[str, set[str]] = {
+    "PENDING": {"CONFIRMED", "SHIPPED", "DELIVERED", "CANCELLED"},
+    "CONFIRMED": {"SHIPPED", "DELIVERED", "CANCELLED"},
+    "SHIPPED": {"DELIVERED"},
+    "DELIVERED": set(),
+    "CANCELLED": set(),
+}
+
 
 def return_deadline(order: models.Order) -> datetime | None:
     """Algorithmically compute the immutable return deadline.
@@ -279,6 +290,33 @@ CANCELLABLE_WINDOW_HOURS = 24
 # simple status flip, so those states are intentionally excluded.
 CANCELLABLE_STATUSES = {"PENDING", "CONFIRMED"}
 
+
+def restore_order_stock(db: Session, order_id: int) -> None:
+    """Return purchased quantities to product stock (used on cancellation).
+
+    Only restores items that still reference a product; orphaned items
+    (deleted products) have no stock to give back.
+    """
+    items = (
+        db.query(models.OrderItem)
+        .filter(models.OrderItem.order_id == order_id)
+        .all()
+    )
+    product_ids = [item.product_id for item in items if item.product_id is not None]
+    if not product_ids:
+        return
+    products = (
+        db.query(models.Product)
+        .filter(models.Product.id.in_(product_ids))
+        .with_for_update()
+        .all()
+    )
+    product_map = {product.id: product for product in products}
+    for item in items:
+        product = product_map.get(item.product_id)
+        if product is not None:
+            product.stock += item.quantity
+
 @router.post("/{order_id}/cancel")
 def cancel_order(
     order_id: int,
@@ -313,26 +351,8 @@ def cancel_order(
             detail=f"Orders can only be cancelled within {CANCELLABLE_WINDOW_HOURS} hours of placing them.",
         )
 
-    items = (
-        db.query(models.OrderItem)
-        .filter(models.OrderItem.order_id == order.id)
-        .all()
-    )
-    product_ids = [item.product_id for item in items if item.product_id is not None]
-    if product_ids:
-        products = (
-            db.query(models.Product)
-            .filter(models.Product.id.in_(product_ids))
-            .with_for_update()
-            .all()
-        )
-        product_map = {product.id: product for product in products}
-        for item in items:
-            product = product_map.get(item.product_id)
-            if product is not None:
-                product.stock += item.quantity
+    restore_order_stock(db, order.id)
 
     order.status = "CANCELLED"
     db.commit()
-
     return {"message": "Order cancelled successfully", "status": order.status}

--- a/backend/tests/test_admin_order_status.py
+++ b/backend/tests/test_admin_order_status.py
@@ -1,0 +1,206 @@
+"""Admin order-status state machine and stock restoration."""
+from passlib.context import CryptContext
+
+from app import models
+from tests.conftest import TestingSessionLocal
+
+STATUS_URL = "/api/admin/orders/{}/status"
+pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def _make_admin(client, *, email="admin_status@example.com", username="adminstatus"):
+    db = TestingSessionLocal()
+    if db.query(models.User).filter(models.User.email == email).first() is None:
+        db.add(
+            models.User(
+                username=username,
+                email=email,
+                hashed_password=pwd.hash("Admin@1234"),
+                role="ADMIN",
+            )
+        )
+        db.commit()
+    db.close()
+
+    resp = client.post(
+        "/api/auth/login",
+        json={"email": email, "password": "Admin@1234"},
+    )
+    assert resp.status_code == 200, resp.text
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+def _make_buyer(client, *, email="buyer_status@example.com", username="buyerstatus"):
+    db = TestingSessionLocal()
+    if db.query(models.User).filter(models.User.email == email).first() is None:
+        db.add(
+            models.User(
+                username=username,
+                email=email,
+                hashed_password=pwd.hash("Buyer@1234"),
+            )
+        )
+        db.commit()
+    db.close()
+
+    resp = client.post(
+        "/api/auth/login",
+        json={"email": email, "password": "Buyer@1234"},
+    )
+    assert resp.status_code == 200, resp.text
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+def _seed_product(db, *, name, stock=10) -> int:
+    product = models.Product(
+        brand="StatusBrand",
+        name=name,
+        price=100.0,
+        img="img.jpg",
+        rating=4,
+        category="minimal",
+        subcategory="top",
+        color="white",
+        style="casual",
+        stock=stock,
+    )
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+    return product.id
+
+
+def _create_order(client, headers, *, email, items) -> int:
+    resp = client.post(
+        "/api/orders/",
+        headers=headers,
+        json={
+            "fullName": "Status User",
+            "email": email,
+            "address": "1 Status St",
+            "city": "Statusville",
+            "zip": "12345",
+            "items": items,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["order_id"]
+
+
+def _set_status(client, headers, order_id, status):
+    return client.post(STATUS_URL.format(order_id), headers=headers, json={"status": status})
+
+
+def test_admin_progresses_order_through_fulfillment(client):
+    admin_headers = _make_admin(client)
+    buyer_headers = _make_buyer(client)
+    db = TestingSessionLocal()
+    product_id = _seed_product(db, name="Fulfillment Tee", stock=10)
+    db.close()
+
+    order_id = _create_order(
+        client, buyer_headers, email="buyer_status@example.com",
+        items=[{"product_id": product_id, "quantity": 2}],
+    )
+
+    shipped = _set_status(client, admin_headers, order_id, "SHIPPED")
+    assert shipped.status_code == 200, shipped.text
+    assert shipped.json()["status"] == "SHIPPED"
+
+    delivered = _set_status(client, admin_headers, order_id, "DELIVERED")
+    assert delivered.status_code == 200, delivered.text
+    assert delivered.json()["status"] == "DELIVERED"
+    assert delivered.json()["delivered_at"] is not None
+
+
+def test_admin_cannot_cancel_shipped_or_delivered_order(client):
+    admin_headers = _make_admin(client)
+    buyer_headers = _make_buyer(client)
+    db = TestingSessionLocal()
+    product_id = _seed_product(db, name="Ship Then Cancel Tee", stock=5)
+    db.close()
+
+    order_id = _create_order(
+        client, buyer_headers, email="buyer_status@example.com",
+        items=[{"product_id": product_id, "quantity": 1}],
+    )
+    assert _set_status(client, admin_headers, order_id, "SHIPPED").status_code == 200
+
+    cancelled = _set_status(client, admin_headers, order_id, "CANCELLED")
+    assert cancelled.status_code == 400
+    db = TestingSessionLocal()
+    order = db.query(models.Order).filter(models.Order.id == order_id).one()
+    assert order.status == "SHIPPED"
+    assert db.query(models.Product).filter(models.Product.id == product_id).one().stock == 4
+    db.close()
+
+
+def test_admin_cannot_revert_a_terminal_state(client):
+    admin_headers = _make_admin(client)
+    buyer_headers = _make_buyer(client)
+    db = TestingSessionLocal()
+    product_id = _seed_product(db, name="Deliver Then Revert Tee", stock=5)
+    db.close()
+
+    order_id = _create_order(
+        client, buyer_headers, email="buyer_status@example.com",
+        items=[{"product_id": product_id, "quantity": 1}],
+    )
+    _set_status(client, admin_headers, order_id, "SHIPPED")
+    assert _set_status(client, admin_headers, order_id, "DELIVERED").status_code == 200
+
+    backward = _set_status(client, admin_headers, order_id, "SHIPPED")
+    assert backward.status_code == 400
+    db = TestingSessionLocal()
+    assert db.query(models.Order).filter(models.Order.id == order_id).one().status == "DELIVERED"
+    db.close()
+
+
+def test_admin_cancel_restores_stock_once(client):
+    admin_headers = _make_admin(client)
+    buyer_headers = _make_buyer(client)
+    db = TestingSessionLocal()
+    product_id = _seed_product(db, name="Cancel Restore Tee", stock=10)
+    db.close()
+
+    order_id = _create_order(
+        client, buyer_headers, email="buyer_status@example.com",
+        items=[{"product_id": product_id, "quantity": 3}],
+    )
+
+    db = TestingSessionLocal()
+    assert db.query(models.Product).filter(models.Product.id == product_id).one().stock == 7
+    db.close()
+
+    first = _set_status(client, admin_headers, order_id, "CANCELLED")
+    assert first.status_code == 200, first.text
+
+    db = TestingSessionLocal()
+    product = db.query(models.Product).filter(models.Product.id == product_id).one()
+    assert product.stock == 10
+    db.close()
+
+    # Same-status call is a no-op and must not restore stock a second time.
+    second = _set_status(client, admin_headers, order_id, "CANCELLED")
+    assert second.status_code == 200
+    db = TestingSessionLocal()
+    assert db.query(models.Product).filter(models.Product.id == product_id).one().stock == 10
+    assert db.query(models.Order).filter(models.Order.id == order_id).one().status == "CANCELLED"
+    db.close()
+
+
+def test_admin_cannot_un_cancel_an_order(client):
+    admin_headers = _make_admin(client)
+    buyer_headers = _make_buyer(client)
+    db = TestingSessionLocal()
+    product_id = _seed_product(db, name="Uncancel Tee", stock=5)
+    db.close()
+
+    order_id = _create_order(
+        client, buyer_headers, email="buyer_status@example.com",
+        items=[{"product_id": product_id, "quantity": 1}],
+    )
+    assert _set_status(client, admin_headers, order_id, "CANCELLED").status_code == 200
+
+    revive = _set_status(client, admin_headers, order_id, "CONFIRMED")
+    assert revive.status_code == 400


### PR DESCRIPTION
﻿## Problem

The admin POST /api/admin/orders/{id}/status endpoint accepts any status from ORDER_STATUSES with no transition validation, and ? unlike the buyer cancel path ? never restores stock. A delivered order can be marked CANCELLED (dropping it from revenue analytics) while the purchased units are never returned to inventory.

## Fix

- Added a forward-only state machine STATUS_TRANSITIONS in orders.py: PENDING -> {CONFIRMED, SHIPPED, DELIVERED, CANCELLED}, CONFIRMED -> {SHIPPED, DELIVERED, CANCELLED}, SHIPPED -> {DELIVERED}, terminal DELIVERED/CANCELLED cannot transition. Admin can no longer cancel shipped/delivered orders or revert terminal states.
- Extracted estore_order_stock(db, order_id) in orders.py (used by both the buyer cancel path and the admin path) so admin cancellations return purchased units to inventory exactly once.
- Same-status calls are a no-op and never double-restore stock.

## Files changed

- ackend/app/api/orders.py - STATUS_TRANSITIONS, estore_order_stock helper; buyer cancel path now reuses it
- ackend/app/api/admin.py - enforces transitions, locks the order row, restores stock on cancel
- ackend/tests/test_admin_order_status.py - new state-machine and stock-restore regression tests

## Testing

pytest backend/tests/test_admin_order_status.py backend/tests/test_order_cancel.py backend/tests/test_return_date.py backend/tests/test_admin.py - 20 passed (the 3 remaining failures are pre-existing test-isolation issues, confirmed identical on origin/main).

Closes #6058
