### PR TITLE
fix(seed): make seed_data.py non-destructive with --force guard (#6059)

### DIFF
--- a/backend/scripts/seed_data.py
+++ b/backend/scripts/seed_data.py
@@ -1,16 +1,12 @@
+import argparse
 import os
 import sys
-import json
 
 # Add parent dir to sys path to import app modules
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from app.database import SessionLocal, engine
 from app import models
-
-# Recreate DB
-models.Base.metadata.drop_all(bind=engine)
-models.Base.metadata.create_all(bind=engine)
 
 products_data = [
   { "id": 1,  "brand": "adidas", "name": "Tropical Hibiscus Summer Shirt", "price": 78.0, "img": "images/products/f1.jpg", "rating": 5, "category": "street", "subcategory": "top", "style": "summer", "color": "multi" },
@@ -31,14 +27,43 @@ products_data = [
   { "id": 16, "brand": "adidas", "name": "Deep Charcoal Casual Shirt", "price": 78.0, "img": "images/products/n8.jpg", "rating": 5, "category": "minimal", "subcategory": "top", "style": "casual", "color": "charcoal" }
 ]
 
-def seed():
+def _has_products(db) -> bool:
+    return db.query(models.Product).first() is not None
+
+
+def seed(force: bool = False) -> None:
+    # Create any missing tables. create_all is non-destructive: it never drops
+    # or modifies existing tables, so running the seed against an existing
+    # database cannot wipe users, orders, or any other data.
+    models.Base.metadata.create_all(bind=engine)
+
     db = SessionLocal()
-    for p_data in products_data:
-        p = models.Product(**p_data)
-        db.add(p)
-    db.commit()
-    db.close()
-    print("Database seeded successfully.")
+    try:
+        if _has_products(db) and not force:
+            print(
+                "Refusing to seed: the products table already contains data. "
+                "Use --force to upsert the catalog instead."
+            )
+            return
+
+        # Upsert by explicit id: existing products are updated, new ones are
+        # inserted. Never deletes or duplicates data.
+        seeded = 0
+        for p_data in products_data:
+            db.merge(models.Product(**p_data))
+            seeded += 1
+        db.commit()
+        print(f"Database seeded successfully ({seeded} products upserted).")
+    finally:
+        db.close()
+
 
 if __name__ == "__main__":
-    seed()
+    parser = argparse.ArgumentParser(description="Seed the product catalog.")
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Upsert the catalog even if products already exist (never deletes data).",
+    )
+    args = parser.parse_args()
+    seed(force=args.force)

--- a/backend/tests/test_seed_data.py
+++ b/backend/tests/test_seed_data.py
@@ -1,0 +1,107 @@
+"""seed_data.py must never drop tables; it guards and upserts instead."""
+import importlib.util
+import os
+
+import sqlalchemy
+from sqlalchemy.orm import sessionmaker
+
+from app import models
+
+_SEED_PATH = os.path.join(os.path.dirname(__file__), "..", "scripts", "seed_data.py")
+
+
+def _load_seed_data():
+    spec = importlib.util.spec_from_file_location("seed_data", _SEED_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+seed_data = _load_seed_data()
+
+
+def _tmp_session():
+    engine = sqlalchemy.create_engine(
+        "sqlite://",
+        poolclass=sqlalchemy.pool.StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    TestSession = sessionmaker(bind=engine)
+    return engine, TestSession
+
+
+def _patch(monkeypatch):
+    engine, TestSession = _tmp_session()
+    models.Base.metadata.create_all(bind=engine)
+    monkeypatch.setattr(seed_data, "engine", engine)
+    monkeypatch.setattr(seed_data, "SessionLocal", TestSession)
+    return TestSession
+
+
+def test_seed_does_not_duplicate_without_force(monkeypatch):
+    TestSession = _patch(monkeypatch)
+
+    seed_data.seed()
+    assert TestSession().query(models.Product).count() == len(seed_data.products_data)
+
+    seed_data.seed()
+    assert TestSession().query(models.Product).count() == len(seed_data.products_data)
+
+
+def test_seed_force_upserts_instead_of_duplicating(monkeypatch):
+    TestSession = _patch(monkeypatch)
+
+    seed_data.seed(force=True)
+    seed_data.seed(force=True)
+    assert TestSession().query(models.Product).count() == len(seed_data.products_data)
+
+
+def test_seed_upsert_updates_existing_product(monkeypatch):
+    TestSession = _patch(monkeypatch)
+
+    db = TestSession()
+    db.add(
+        models.Product(
+            id=1,
+            brand="old",
+            name="Old Name",
+            price=1.0,
+            img="x.jpg",
+            rating=1,
+            category="street",
+            subcategory="top",
+            stock=1,
+        )
+    )
+    db.commit()
+    db.close()
+
+    seed_data.seed(force=True)
+
+    db = TestSession()
+    updated = db.query(models.Product).filter(models.Product.id == 1).first()
+    assert updated.name == "Tropical Hibiscus Summer Shirt"
+    db.close()
+
+
+def test_seed_creates_tables_without_dropping(monkeypatch):
+    """Non-product tables must survive a seed run untouched."""
+    TestSession = _patch(monkeypatch)
+
+    db = TestSession()
+    db.add(
+        models.User(
+            username="keepme",
+            email="keepme@example.com",
+            hashed_password="x",
+        )
+    )
+    db.commit()
+    db.close()
+
+    seed_data.seed(force=True)
+
+    db = TestSession()
+    assert db.query(models.User).filter(models.User.email == "keepme@example.com").count() == 1
+    assert db.query(models.Product).count() == len(seed_data.products_data)
+    db.close()


### PR DESCRIPTION
﻿## Problem

ackend/scripts/seed_data.py calls Base.metadata.drop_all(bind=engine) on every table before seeding. Running the documented seed script against a non-trivial database silently destroys users, orders, interactions, newsletter subscribers, and ambassador applications.

## Fix

- Removed the destructive drop_all. create_all is kept but is non-destructive (creates only missing tables).
- Seeding is now an idempotent upsert by explicit product id (db.merge) ? existing products are updated, never duplicated or deleted.
- Added a guard: without --force, the script refuses to run when the products table already contains data; --force performs the upsert.

## Files changed

- ackend/scripts/seed_data.py - non-destructive seeding, --force flag, upsert
- ackend/tests/test_seed_data.py - new regression tests (no duplicate seeding, force upsert updates in place, non-product tables survive)

## Testing

pytest backend/tests/test_seed_data.py - 4 passed.

Closes #6059
