### PR TITLE
fix(auth): handle IntegrityError race as 409 in register and subscribe (#6061)

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta, timezone
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
 from passlib.context import CryptContext
 from jose import jwt, JWTError
 import os
@@ -190,7 +191,13 @@ def register(request: Request, response: Response, payload: UserRegister, db: Se
         role            = "USER",
     )
     db.add(user)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        # Unique-constraint race (duplicate email/username): return 409 instead
+        # of leaking an unhandled 500 to the client.
+        db.rollback()
+        raise HTTPException(409, "Email or username already registered.")
     db.refresh(user)
 
     access_token = create_access_token(user.email)

--- a/backend/app/api/newsletter.py
+++ b/backend/app/api/newsletter.py
@@ -1,6 +1,7 @@
 import secrets
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
 from pydantic import BaseModel, EmailStr
 from .. import models
 from ..database import get_db
@@ -38,7 +39,14 @@ def subscribe(payload: NewsletterSubscribeRequest, db: Session = Depends(get_db)
         unsubscribe_token=secrets.token_urlsafe(32),
     )
     db.add(subscriber)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        # Unique-constraint race on the email: another request subscribed
+        # first. Roll back and respond with the same generic message rather
+        # than an unhandled 500.
+        db.rollback()
+        return {"message": "Subscription request processed"}
     return {"message": "Subscription request processed"}
 
 

--- a/backend/tests/test_integrity_error_409.py
+++ b/backend/tests/test_integrity_error_409.py
@@ -1,0 +1,32 @@
+"""Unique-constraint races in register/subscribe must not leak 500s."""
+import sqlalchemy.orm
+from sqlalchemy.exc import IntegrityError
+
+
+def _boom_commit(self):
+    raise IntegrityError("INSERT", {}, Exception("unique constraint"))
+
+
+def test_register_returns_409_on_integrity_error(client, monkeypatch):
+    """A concurrent duplicate insert surfaces as 409, not an unhandled 500."""
+    monkeypatch.setattr(sqlalchemy.orm.Session, "commit", _boom_commit)
+
+    resp = client.post(
+        "/api/auth/register",
+        json={
+            "username": "raceuser",
+            "email": "race@example.com",
+            "password": "Secure123@",
+        },
+    )
+    assert resp.status_code == 409
+    assert "already" in resp.json()["detail"].lower()
+
+
+def test_newsletter_subscribe_handles_integrity_error(client, monkeypatch):
+    """A concurrent duplicate subscription is treated as processed, not 500."""
+    monkeypatch.setattr(sqlalchemy.orm.Session, "commit", _boom_commit)
+
+    resp = client.post("/api/newsletter/subscribe", json={"email": "race@example.com"})
+    assert resp.status_code == 201
+    assert resp.json()["message"] == "Subscription request processed"


### PR DESCRIPTION
﻿## Problem

Registration and newsletter subscription use a **check-then-insert** pattern with no IntegrityError handling. Under concurrency (two requests with the same email/username in quick succession), the DB-level unique constraint fires and the request ends in an unhandled 500 instead of a clean 409 (or the generic subscription response).

## Fix

- ackend/app/api/auth.py ? wrapped the egister commit in 	ry/except IntegrityError with db.rollback() and HTTPException(409, "Email or username already registered."), mirroring the existing pre-check response.
- ackend/app/api/newsletter.py ? wrapped the subscribe commit in 	ry/except IntegrityError with db.rollback() and the same generic "Subscription request processed" message the pre-check path returns (avoids leaking subscription state, matching existing behavior).

## Files changed

- ackend/app/api/auth.py
- ackend/app/api/newsletter.py
- ackend/tests/test_integrity_error_409.py (new)

## Testing

New regression tests simulate the constraint race by making the session commit raise IntegrityError and assert register returns 409 and subscribe returns 201 with the generic message. pytest backend/tests/test_integrity_error_409.py backend/tests/test_auth.py -q ? 13 passed.

Closes #6061
