### PR TITLE
fix(orders): add length/pattern limits to OrderCreate fields (#6062)

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -162,16 +162,16 @@ class OrderItemCreate(BaseModel):
     quantity: int = Field(gt=0, le=99)
 
 class OrderCreate(BaseModel):
-    fullName: str
+    fullName: str = Field(min_length=1, max_length=100)
     email: EmailStr
-    address: str
-    city: str
-    zip: str
+    address: str = Field(min_length=1, max_length=255)
+    city: str = Field(min_length=1, max_length=100)
+    zip: str = Field(min_length=1, max_length=10, pattern=r"^[0-9A-Za-z -]+$")
     # Reject empty carts at the API boundary: an order must contain at least
     # one line item, and a sane maximum prevents junk/mega-bulk payloads.
     items: list[OrderItemCreate] = Field(min_length=1, max_length=50)
-    coupon: Optional[str] = None
-    idempotency_key: Optional[str] = None
+    coupon: Optional[str] = Field(default=None, max_length=50)
+    idempotency_key: Optional[str] = Field(default=None, max_length=100)
 
 
 # -- Product Search / Filter Response Schemas --

--- a/backend/tests/test_order_create_validation.py
+++ b/backend/tests/test_order_create_validation.py
@@ -116,6 +116,86 @@ def test_too_many_line_items_rejected(client):
     assert response.status_code == 422, response.text
 
 
+def _field_limits(base, overrides):
+    payload = dict(base)
+    payload.update(overrides)
+    return payload
+
+
+def test_overlong_full_name_rejected(client):
+    headers = _auth_headers(client)
+    response = client.post(
+        ORDERS_URL,
+        json=_field_limits(_payload([]), {"fullName": "x" * 101}),
+        headers=headers,
+    )
+    assert response.status_code == 422, response.text
+
+
+def test_overlong_address_rejected(client):
+    headers = _auth_headers(client)
+    response = client.post(
+        ORDERS_URL,
+        json=_field_limits(_payload([]), {"address": "x" * 256}),
+        headers=headers,
+    )
+    assert response.status_code == 422, response.text
+
+
+def test_overlong_city_rejected(client):
+    headers = _auth_headers(client)
+    response = client.post(
+        ORDERS_URL,
+        json=_field_limits(_payload([]), {"city": "x" * 101}),
+        headers=headers,
+    )
+    assert response.status_code == 422, response.text
+
+
+def test_overlong_zip_rejected(client):
+    headers = _auth_headers(client)
+    response = client.post(
+        ORDERS_URL,
+        json=_field_limits(_payload([]), {"zip": "1" * 11}),
+        headers=headers,
+    )
+    assert response.status_code == 422, response.text
+
+
+def test_zip_with_garbage_characters_rejected(client):
+    headers = _auth_headers(client)
+    response = client.post(
+        ORDERS_URL,
+        json=_field_limits(_payload([]), {"zip": "12345; DROP TABLE"}),
+        headers=headers,
+    )
+    assert response.status_code == 422, response.text
+
+
+def test_zip_with_letters_still_accepted(client):
+    headers = _auth_headers(client)
+    product_id = _seed_product()
+    response = client.post(
+        ORDERS_URL,
+        json=_field_limits(
+            _payload([{"product_id": product_id, "quantity": 1}]),
+            {"zip": "SW1A 1AA"},
+        ),
+        headers=headers,
+    )
+    assert response.status_code == 201, response.text
+
+
+def test_empty_full_name_rejected(client):
+    headers = _auth_headers(client)
+    response = client.post(
+        ORDERS_URL,
+        json=_field_limits(_payload([]), {"fullName": ""}),
+        headers=headers,
+    )
+    assert response.status_code == 422, response.text
+
+
 def test_valid_order_still_succeeds(client):
     headers = _auth_headers(client)
     product_id = _seed_product()


### PR DESCRIPTION
﻿## Problem

OrderCreate placed no length limits on ullName, ddress, city, or zip, and no format check on zip. An authenticated caller could submit arbitrarily large strings that were persisted verbatim into the orders table (sa.String() columns with no size), bloating the database and downstream rendering.

## Fix

ackend/app/schemas.py ? OrderCreate now bounds every free-text field:
- ullName: min_length=1, max_length=100
- ddress: min_length=1, max_length=255
- city: min_length=1, max_length=100
- zip: min_length=1, max_length=10 with pattern ^[0-9A-Za-z -]+$ (accepts 5-digit US, 6-digit Indian PINs, and alphanumeric formats while rejecting control/injection characters)
- coupon: max_length=50; idempotency_key: max_length=100

## Files changed

- ackend/app/schemas.py
- ackend/tests/test_order_create_validation.py

## Testing

New tests assert 422 for overlong ullName/ddress/city/zip, empty ullName, and garbage zip characters, plus 201 for a valid alphanumeric zip (SW1A 1AA). pytest backend/tests/test_order_create_validation.py -q ? 13 passed. The one failure in 	est_order_email_match.py is pre-existing on origin/main (confirmed in the baseline worktree).

Closes #6062
