### PR TITLE
fix(profile): validate avatar_url scheme and bound profile string fields (#6063)

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -95,15 +95,27 @@ class UserOut(BaseModel):
 
 
 class UserProfileUpdate(BaseModel):
-    full_name: Optional[str] = None
-    phone: Optional[str] = None
-    avatar_url: Optional[str] = None
-    address_line1: Optional[str] = None
-    address_line2: Optional[str] = None
-    city: Optional[str] = None
-    state: Optional[str] = None
-    zip_code: Optional[str] = None
-    country: Optional[str] = None
+    full_name: Optional[str] = Field(default=None, max_length=100)
+    phone: Optional[str] = Field(default=None, max_length=20, pattern=r"^[0-9+()\-\s]*$")
+    avatar_url: Optional[str] = Field(default=None, max_length=2048)
+    address_line1: Optional[str] = Field(default=None, max_length=255)
+    address_line2: Optional[str] = Field(default=None, max_length=255)
+    city: Optional[str] = Field(default=None, max_length=100)
+    state: Optional[str] = Field(default=None, max_length=100)
+    zip_code: Optional[str] = Field(default=None, max_length=10, pattern=r"^[0-9A-Za-z\-\s]*$")
+    country: Optional[str] = Field(default=None, max_length=100)
+
+    @field_validator("avatar_url")
+    @classmethod
+    def _validate_avatar_url(cls, value):
+        if value is None or value == "":
+            return value
+        lowered = value.lower()
+        if lowered.startswith("http://") or lowered.startswith("https://"):
+            return value
+        if value.startswith("/") or value.startswith("./") or value.startswith("../"):
+            return value
+        raise ValueError("avatar_url must be an http(s) URL or a relative path")
 
 
 class UserProfileResponse(UserOut):

--- a/backend/tests/test_profile.py
+++ b/backend/tests/test_profile.py
@@ -54,3 +54,128 @@ def test_get_profile_after_update(client, auth_headers):
     assert response.status_code == 200
     assert response.json()["full_name"] == "Jane Doe"
     assert response.json()["phone"] == "+1-555-0200"
+
+
+def _auth_headers_for(client, email):
+    """Create a fresh, uniquely-named user and return login headers.
+
+    The shared `auth_headers` fixture always inserts username "testuser", which
+    collides across tests within a file run; these validation tests use a
+    unique user per call so each runs standalone.
+    """
+    from passlib.context import CryptContext
+    from sqlalchemy.orm import Session
+
+    from app.models import User
+    from tests.conftest import TestingSessionLocal
+
+    db = TestingSessionLocal()
+    if db.query(User).filter(User.email == email).first() is None:
+        db.add(
+            User(
+                username=email.split("@")[0] + "_u",
+                email=email,
+                hashed_password=CryptContext(schemes=["bcrypt"], deprecated="auto").hash("Test@1234"),
+            )
+        )
+        db.commit()
+    db.close()
+
+    login = client.post(
+        "/api/auth/login",
+        json={"email": email, "password": "Test@1234"},
+    )
+    assert login.status_code == 200, login.text
+    return {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+
+def test_update_profile_avatar_https_accepted(client):
+    headers = _auth_headers_for(client, "avatar-https@example.com")
+    response = client.put(
+        "/api/profile/",
+        json={"avatar_url": "https://example.com/avatar.png"},
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["avatar_url"] == "https://example.com/avatar.png"
+
+
+def test_update_profile_avatar_relative_path_accepted(client):
+    headers = _auth_headers_for(client, "avatar-relative@example.com")
+    response = client.put(
+        "/api/profile/",
+        json={"avatar_url": "/uploads/avatar.png"},
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["avatar_url"] == "/uploads/avatar.png"
+
+
+def test_update_profile_avatar_javascript_scheme_rejected(client):
+    headers = _auth_headers_for(client, "avatar-js@example.com")
+    response = client.put(
+        "/api/profile/",
+        json={"avatar_url": "javascript:alert(1)"},
+        headers=headers,
+    )
+    assert response.status_code == 422
+
+
+def test_update_profile_avatar_data_scheme_rejected(client):
+    headers = _auth_headers_for(client, "avatar-data@example.com")
+    response = client.put(
+        "/api/profile/",
+        json={"avatar_url": "data:text/html,<script>alert(1)</script>"},
+        headers=headers,
+    )
+    assert response.status_code == 422
+
+
+def test_update_profile_avatar_file_scheme_rejected(client):
+    headers = _auth_headers_for(client, "avatar-file@example.com")
+    response = client.put(
+        "/api/profile/",
+        json={"avatar_url": "file:///etc/passwd"},
+        headers=headers,
+    )
+    assert response.status_code == 422
+
+
+def test_update_profile_overlong_full_name_rejected(client):
+    headers = _auth_headers_for(client, "profile-long-name@example.com")
+    response = client.put(
+        "/api/profile/",
+        json={"full_name": "x" * 101},
+        headers=headers,
+    )
+    assert response.status_code == 422
+
+
+def test_update_profile_overlong_avatar_url_rejected(client):
+    headers = _auth_headers_for(client, "profile-long-avatar@example.com")
+    response = client.put(
+        "/api/profile/",
+        json={"avatar_url": "https://example.com/" + "a" * 2048},
+        headers=headers,
+    )
+    assert response.status_code == 422
+
+
+def test_update_profile_phone_with_bad_chars_rejected(client):
+    headers = _auth_headers_for(client, "profile-bad-phone@example.com")
+    response = client.put(
+        "/api/profile/",
+        json={"phone": "123; DROP TABLE users"},
+        headers=headers,
+    )
+    assert response.status_code == 422
+
+
+def test_update_profile_zip_with_bad_chars_rejected(client):
+    headers = _auth_headers_for(client, "profile-bad-zip@example.com")
+    response = client.put(
+        "/api/profile/",
+        json={"zip_code": "10001<script>"},
+        headers=headers,
+    )
+    assert response.status_code == 422


### PR DESCRIPTION
﻿## Problem

PUT /api/profile accepted an arbitrary vatar_url (any scheme: javascript:, data:, ile:) and unbounded strings for phone/address fields with no validation. Stored values are served back on every GET /api/profile; a javascript: URL interpolated into markup is a stored XSS vector, and unbounded fields let users persist arbitrarily large blobs.

## Fix

ackend/app/schemas.py ? UserProfileUpdate now validates every field:
- vatar_url: max_length=2048 plus a ield_validator allow-listing http:///https:// URLs and relative paths (/, ./, ../); other schemes rejected with 422.
- ull_name: max_length=100; ddress_line1/ddress_line2: max_length=255; city/state/country: max_length=100.
- phone: max_length=20 + pattern ^[0-9+()\-\\s]*$.
- zip_code: max_length=10 + pattern ^[0-9A-Za-z\\-\\s]*$.

## Files changed

- ackend/app/schemas.py
- ackend/tests/test_profile.py

## Testing

9 new tests: https:// and relative-path avatars accepted; javascript:, data:, ile: schemes rejected (422); overlong ull_name/vatar_url rejected; bad characters in phone/zip_code rejected. Each test creates its own uniquely-named user (the shared uth_headers fixture always inserts 	estuser, which collides on a whole-file run ? a pre-existing baseline issue confirmed in the origin/main worktree, where 4 of 5 baseline tests already error when run as a file).

Closes #6063
