### PR TITLE
fix(recommendation): add interaction retention policy and admin purge (#6064)

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -11,6 +11,7 @@ from typing import List
 from .. import models, schemas
 from ..database import get_db
 from .auth import get_current_user
+from .recommendation import prune_interactions
 
 router = APIRouter()
 
@@ -148,3 +149,17 @@ def update_order_status(
         "delivered_at": order.delivered_at,
         "return_deadline": return_deadline(order),
     }
+
+
+@router.post("/interactions/purge")
+def purge_old_interactions(
+    db: Session = Depends(get_db),
+    admin_user: models.User = Depends(_enforce_admin),
+) -> dict:
+    """Delete interactions past the retention window / per-user cap.
+
+    Runs the same retention policy that feedback writes trigger, on demand.
+    """
+    prune_interactions(db)
+    remaining = db.query(models.Interaction).count()
+    return {"message": "Interactions purged", "remaining": remaining}

--- a/backend/app/api/recommendation.py
+++ b/backend/app/api/recommendation.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import Session
 from typing import List
 import hashlib
 import os
+from datetime import datetime, timedelta, timezone
 from .. import models, schemas
 from ..database import get_db
 from ..vector_search.faiss_index import get_similar_product_ids
@@ -11,6 +12,44 @@ from ..limiter import limiter
 
 router = APIRouter()
 SALT = os.environ.get("SECRET_KEY", "fallback_secret_key_for_dev").encode('utf-8')
+
+# Retention policy for the interactions table. The personalized reranker only
+# ever reads the newest 100 interactions per user, so older rows are dead
+# weight; prune them so the table cannot grow without bound.
+INTERACTION_RETENTION_DAYS = 90
+MAX_INTERACTIONS_PER_USER = 200
+
+
+def prune_interactions(db: Session) -> None:
+    """Enforce the interaction retention policy.
+
+    Deletes rows older than INTERACTION_RETENTION_DAYS and trims each user's
+    history to the newest MAX_INTERACTIONS_PER_USER rows. Runs on every
+    feedback insert and is also exposed via the admin purge endpoint.
+    """
+    cutoff = datetime.now(timezone.utc) - timedelta(days=INTERACTION_RETENTION_DAYS)
+    db.query(models.Interaction).filter(
+        models.Interaction.created_at < cutoff
+    ).delete(synchronize_session=False)
+
+    users = db.query(models.Interaction.user_id).distinct().all()
+    for (user_id,) in users:
+        keep_ids = [
+            row[0]
+            for row in (
+                db.query(models.Interaction.id)
+                .filter(models.Interaction.user_id == user_id)
+                .order_by(models.Interaction.created_at.desc())
+                .limit(MAX_INTERACTIONS_PER_USER)
+                .all()
+            )
+        ]
+        if keep_ids:
+            db.query(models.Interaction).filter(
+                models.Interaction.user_id == user_id,
+                ~models.Interaction.id.in_(keep_ids),
+            ).delete(synchronize_session=False)
+    db.commit()
 
 @router.post("/recommend", response_model=List[schemas.Product])
 @limiter.limit("20/minute")
@@ -66,4 +105,13 @@ def track_feedback(request: Request, interaction: schemas.InteractionCreate, db:
     )
     db.add(new_interaction)
     db.commit()
+
+    # Enforce the retention policy now that the new row is durable.
+    try:
+        prune_interactions(db)
+    except Exception:
+        # Pruning is best-effort maintenance; a failure must not break the
+        # feedback recording itself.
+        db.rollback()
+
     return {"status": "success"}

--- a/backend/tests/test_interactions_retention.py
+++ b/backend/tests/test_interactions_retention.py
@@ -1,0 +1,118 @@
+"""Interaction retention: rows past the window / per-user cap are pruned."""
+from datetime import datetime, timedelta, timezone
+from hashlib import sha256
+
+from app.models import Interaction, Product
+from tests.conftest import TestingSessionLocal
+
+FEEDBACK_URL = "/api/outfit/feedback"
+PURGE_URL = "/api/admin/interactions/purge"
+
+MAX_PER_USER = 200
+
+
+def _hash(user_id):
+    return sha256((user_id + "test-secret-key-1234567890abcdef").encode()).hexdigest()
+
+
+def _seed_product():
+    db = TestingSessionLocal()
+    product = Product(
+        brand="RetentionBrand",
+        name="Retention Tee",
+        price=50.0,
+        img="r.jpg",
+        rating=4,
+        category="minimal",
+        subcategory="top",
+        color="white",
+        style="casual",
+        stock=100,
+    )
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+    product_id = product.id
+    db.close()
+    return product_id
+
+
+def _insert_interactions(user_id, count, days_old=0):
+    db = TestingSessionLocal()
+    product_id = _seed_product()
+    created = datetime.now(timezone.utc) - timedelta(days=days_old)
+    for _ in range(count):
+        db.add(
+            Interaction(
+                user_id=_hash(user_id),
+                product_id=product_id,
+                interaction_type="view",
+                created_at=created,
+            )
+        )
+    db.commit()
+    db.close()
+
+
+def _count_for_user(user_id):
+    db = TestingSessionLocal()
+    count = (
+        db.query(Interaction)
+        .filter(Interaction.user_id == _hash(user_id))
+        .count()
+    )
+    db.close()
+    return count
+
+
+def test_feedback_trims_history_to_per_user_cap(client):
+    # Seed 205 rows for the user, then one more through the API which prunes.
+    _insert_interactions("cap-user", MAX_PER_USER + 5)
+    _seed_product()  # product_id for the feedback call below
+
+    db = TestingSessionLocal()
+    product = db.query(Product).filter(Product.brand == "RetentionBrand").first()
+    db.close()
+
+    resp = client.post(
+        FEEDBACK_URL,
+        json={"user_id": "cap-user", "product_id": product.id, "interaction_type": "view"},
+    )
+    assert resp.status_code == 200
+    assert _count_for_user("cap-user") == MAX_PER_USER
+
+
+def test_feedback_prunes_rows_past_retention_window(client):
+    _insert_interactions("old-user", 5, days_old=120)
+    _insert_interactions("new-user", 1, days_old=1)
+    _seed_product()
+
+    db = TestingSessionLocal()
+    product = db.query(Product).filter(Product.brand == "RetentionBrand").first()
+    db.close()
+
+    resp = client.post(
+        FEEDBACK_URL,
+        json={"user_id": "new-user", "product_id": product.id, "interaction_type": "view"},
+    )
+    assert resp.status_code == 200
+    assert _count_for_user("old-user") == 0
+    assert _count_for_user("new-user") == 2
+
+
+def _count_all():
+    db = TestingSessionLocal()
+    count = db.query(Interaction).count()
+    db.close()
+    return count
+
+
+def test_admin_purge_endpoint(client, admin_auth_headers):
+    _insert_interactions("purge-user", 3, days_old=200)
+    before = _count_all()
+
+    resp = client.post(PURGE_URL, headers=admin_auth_headers)
+    assert resp.status_code == 200
+    # Only the three stale purge-user rows are removed; other users' recent
+    # rows are untouched.
+    assert resp.json()["remaining"] == before - 3


### PR DESCRIPTION
﻿## Problem

The interactions table grows without bound: every POST /api/outfit/feedback inserts a row with no retention or per-user cap. The personalized reranker only ever reads the newest 100 interactions per user, so history beyond that is dead weight that still costs storage and full-table scans.

## Fix

- ackend/app/api/recommendation.py ? new prune_interactions(db) enforcing the retention policy: deletes rows older than INTERACTION_RETENTION_DAYS = 90 (indexed on created_at) and trims each user's history to the newest MAX_INTERACTIONS_PER_USER = 200 rows. It runs after every feedback insert (best-effort; a prune failure rolls back and never breaks feedback recording).
- ackend/app/api/admin.py ? new POST /api/admin/interactions/purge endpoint (admin-only) that triggers the same retention policy on demand and reports the remaining row count.

## Files changed

- ackend/app/api/recommendation.py
- ackend/app/api/admin.py
- ackend/tests/test_interactions_retention.py (new)

## Testing

3 new tests: seeding 205 rows for a user then posting feedback trims the history to exactly 200; rows older than the 90-day window are removed while recent rows survive; the admin purge endpoint removes only stale rows. pytest backend/tests/test_interactions_retention.py -q ? 3 passed.

Closes #6064
