### PR TITLE
feat(recommendation): catalog fallback + index status endpoint when FAISS uninitialized (#6065)

### DIFF
--- a/backend/app/api/recommendation.py
+++ b/backend/app/api/recommendation.py
@@ -5,7 +5,7 @@ import hashlib
 import os
 from .. import models, schemas
 from ..database import get_db
-from ..vector_search.faiss_index import get_similar_product_ids
+from ..vector_search.faiss_index import get_similar_product_ids, is_initialized
 from ..rules.engine import filter_by_rules
 from ..limiter import limiter
 
@@ -37,7 +37,21 @@ def recommend_outfit(request: Request, req: schemas.RecommendationRequest, db: S
     
     # Apply strict business rules
     filtered_candidates = filter_by_rules(base_product, ordered_candidates)
-    
+
+    if not filtered_candidates:
+        # The FAISS index may be uninitialized (fresh deployment) or the query
+        # product may have no embedding. Fall back to a deterministic,
+        # catalog-based list (top-rated, in-stock) so the endpoint never
+        # returns a bare empty list with no signal.
+        filtered_candidates = (
+            db.query(models.Product)
+            .filter(models.Product.id != base_product.id)
+            .filter(models.Product.stock > 0)
+            .order_by(models.Product.rating.desc(), models.Product.id)
+            .limit(fetch_top_k)
+            .all()
+        )
+
     # Apply personalization re-ranking based on user historical interactions
     hashed_user_id = None
     if req.user_id:
@@ -48,6 +62,19 @@ def recommend_outfit(request: Request, req: schemas.RecommendationRequest, db: S
     
     # Return up to the requested limit
     return reranked_candidates[:limit]
+
+
+@router.get("/recommend/status")
+def recommend_status():
+    """Report whether the vector index is initialized for recommendations.
+
+    Lets operators know when a fresh deployment has no FAISS artifacts yet and
+    the endpoint is serving catalog-based fallback recommendations.
+    """
+    return {
+        "index_initialized": is_initialized(),
+        "fallback_enabled": True,
+    }
 
 @router.post("/feedback")
 @limiter.limit("30/minute")

--- a/backend/app/vector_search/faiss_index.py
+++ b/backend/app/vector_search/faiss_index.py
@@ -97,6 +97,20 @@ index = _load_index(faiss)
 embedding_ids, embeddings = _load_embeddings()
 
 
+def is_initialized() -> bool:
+    """Whether a usable FAISS index + persisted embeddings are available.
+
+    Returns False on fresh deployments where precompute_embeddings.py has not
+    run yet (the .bin/.npz artifacts are gitignored and generated offline).
+    """
+    return (
+        faiss is not None
+        and index is not None
+        and embedding_ids is not None
+        and len(embedding_ids) > 0
+    )
+
+
 def rebuild_index(db):
     """Rebuild the persisted FAISS index + embeddings from the current catalog.
 

--- a/backend/tests/test_recommendation_fallback.py
+++ b/backend/tests/test_recommendation_fallback.py
@@ -1,0 +1,82 @@
+"""Recommendation fallback + status when the FAISS index is uninitialized.
+
+Regression tests for https://github.com/janavipandole/Cara/issues/6065 —
+POST /api/outfit/recommend returned a bare empty list on fresh deployments
+where the FAISS artifacts do not exist yet.
+"""
+from app.models import Product
+from app.vector_search import faiss_index
+from tests.conftest import TestingSessionLocal
+
+RECOMMEND_URL = "/api/outfit/recommend"
+STATUS_URL = "/api/outfit/recommend/status"
+
+
+def _force_uninitialized(monkeypatch):
+    """Simulate a fresh deployment with no FAISS artifacts.
+
+    Other tests (test_recommendation.py) rebuild the shared module-level
+    index, so we must explicitly reset it to exercise the fallback path.
+    """
+    monkeypatch.setattr(faiss_index, "faiss", None)
+    monkeypatch.setattr(faiss_index, "index", None)
+    monkeypatch.setattr(faiss_index, "embedding_ids", None)
+    monkeypatch.setattr(faiss_index, "embeddings", None)
+
+
+def _seed_products():
+    db = TestingSessionLocal()
+    products = [
+        Product(
+            brand="FallbackBrand",
+            name=f"Fallback Tee {i}",
+            price=50.0 + i,
+            img=f"f{i}.jpg",
+            rating=rating,
+            category="minimal",
+            subcategory="top",
+            color="white",
+            style="casual",
+            stock=stock,
+        )
+        for i, (rating, stock) in enumerate([(5, 10), (4, 10), (3, 0), (4, 10)])
+    ]
+    db.add_all(products)
+    db.commit()
+    ids = [p.id for p in products]
+    db.close()
+    return ids
+
+
+def test_status_reports_uninitialized_index(client, monkeypatch):
+    _force_uninitialized(monkeypatch)
+    resp = client.get(STATUS_URL)
+    assert resp.status_code == 200
+    assert resp.json()["index_initialized"] is False
+    assert resp.json()["fallback_enabled"] is True
+
+
+def test_recommend_falls_back_to_catalog_when_index_missing(client, monkeypatch):
+    _force_uninitialized(monkeypatch)
+    # ids[0]=rating 5, ids[1]=rating 4, ids[2]=rating 3 (out of stock),
+    # ids[3]=rating 4. Base = the rating-5 product.
+    ids = _seed_products()
+    base_id, four_a, out_of_stock_id, four_b = ids
+
+    resp = client.post(
+        RECOMMEND_URL,
+        json={"product_id": base_id, "limit": 20},
+    )
+    assert resp.status_code == 200
+    results = resp.json()
+    assert len(results) >= 1
+    result_ids = [item["id"] for item in results]
+    assert base_id not in result_ids
+    # Out-of-stock products are excluded by the fallback query.
+    assert out_of_stock_id not in result_ids
+    # Among the seeded products, the rating-4 in-stock items are present and
+    # ordered by (rating desc, id asc): four_a before four_b.
+    assert four_a in result_ids
+    assert four_b in result_ids
+    rank = {item["id"]: idx for idx, item in enumerate(results)}
+    assert rank[four_a] < rank[four_b]


### PR DESCRIPTION
﻿## Problem

On a fresh deployment POST /api/outfit/recommend silently returns an empty list: the FAISS artifacts (aiss_index.bin, aiss_embeddings.npz) are gitignored and only produced by the separate manual precompute_embeddings.py. There was no fallback and no signal that the feature is uninitialized.

## Fix

- ackend/app/vector_search/faiss_index.py ? new is_initialized() helper reporting whether a usable index + persisted embeddings are available.
- ackend/app/api/recommendation.py ? when vector candidates come back empty (index missing or the query product has no embedding), the endpoint now falls back to a deterministic catalog-based list: in-stock products ordered by ating DESC, id, excluding the base product. The endpoint no longer returns a bare [] on fresh deployments.
- New GET /api/outfit/recommend/status endpoint exposing index_initialized and allback_enabled so operators can tell when a fresh deployment is serving fallback recommendations.

## Files changed

- ackend/app/vector_search/faiss_index.py
- ackend/app/api/recommendation.py
- ackend/tests/test_recommendation_fallback.py (new)

## Testing

2 new tests: status reports index_initialized: false when artifacts are absent (module state forced uninitialized since other tests rebuild the shared index), and recommend returns the catalog fallback (excludes base and out-of-stock, orders rating-4 in-stock items correctly). pytest backend/tests/test_recommendation.py backend/tests/test_recommendation_fallback.py -q ? 11 passed.

Closes #6065
