### PR TITLE
test: added state handling coverage to order-history-cancel tests

### DIFF
--- a/tests/unit/order-history-cancel.test.js
+++ b/tests/unit/order-history-cancel.test.js
@@ -66,4 +66,45 @@ describe('order-history cancel button visibility', () => {
     expect(tbody.querySelector('tr:nth-child(4) .cancel-btn')).toBeNull();
     expect(tbody.querySelector('tr:nth-child(5) .cancel-btn')).toBeNull();
   });
+
+  it('shows the empty state when there are no orders', async () => {
+    stubOrdersFetch([]);
+
+    await import('../../order-history.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const emptyState = document.getElementById('emptyState');
+    expect(emptyState.style.display).not.toBe('none');
+  });
+
+  it('treats statuses case-insensitively when deciding cancellability', async () => {
+    const orders = [
+      { id: 1, status: 'pending', created_at: '2026-08-01', total_amount: 100 },
+      { id: 2, status: 'Confirmed', created_at: '2026-08-02', total_amount: 100 },
+      { id: 3, status: 'SHIPPED', created_at: '2026-08-03', total_amount: 100 },
+    ];
+    stubOrdersFetch(orders);
+
+    await import('../../order-history.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const tbody = document.getElementById('ordersTableBody');
+    const cancellableIds = [...tbody.querySelectorAll('.cancel-btn')].map(
+      (btn) => btn.dataset.orderId,
+    );
+    expect(cancellableIds).toEqual(['1', '2']);
+  });
+
+  it('renders the error state when the orders fetch fails', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+
+    await import('../../order-history.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const errorState = document.getElementById('errorState');
+    expect(errorState.style.display).not.toBe('none');
+  });
 });


### PR DESCRIPTION
## 📄 Description
Added tests to tests/unit/order-history-cancel.test.js covering the empty-orders state, case-insensitive status handling for cancellability, and the error state when the fetch fails.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6104

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.