### PR TITLE
test: added preservation and type coverage to coupon-config tests

### DIFF
--- a/tests/unit/coupon-config.test.js
+++ b/tests/unit/coupon-config.test.js
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 describe('coupon-config.js — window.CARA_COUPONS initialization', () => {
   beforeEach(() => {
     delete window.CARA_COUPONS;
+    vi.resetModules();
   });
 
   afterEach(() => {
@@ -20,5 +21,19 @@ describe('coupon-config.js — window.CARA_COUPONS initialization', () => {
     window.CARA_COUPONS = { CUSTOM50: 50 };
     await import('../../js/coupon-config.js');
     expect(window.CARA_COUPONS.CUSTOM50).toBe(50);
+  });
+
+  it('keeps custom codes when CARA_COUPONS already has values', async () => {
+    window.CARA_COUPONS = { SAVE5: 5 };
+    await import('../../js/coupon-config.js');
+    expect(window.CARA_COUPONS.SAVE5).toBe(5);
+    expect(window.CARA_COUPONS.CARA20).toBeUndefined();
+  });
+
+  it('provides numeric discount percentages for the default codes', async () => {
+    await import('../../js/coupon-config.js');
+    expect(typeof window.CARA_COUPONS.CARA20).toBe('number');
+    expect(typeof window.CARA_COUPONS.WELCOME10).toBe('number');
+    expect(window.CARA_COUPONS.WELCOME10).toBe(10);
   });
 });


### PR DESCRIPTION
## 📄 Description
Added vi.resetModules to the beforeEach and tests covering custom-code preservation and the numeric discount percentage types in tests/unit/coupon-config.test.js.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6108

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.