### PR TITLE
fix: fixed recently-viewed script path on the product page

### DIFF
--- a/singleProduct.html
+++ b/singleProduct.html
@@ -355,7 +355,7 @@
 <script>
     document.getElementById("Current-Year").textContent=new Date().getFullYear();
 </script>
-<script src="../js/recently-viewed.js"></script>
+<script src="js/recently-viewed.js"></script>
 
 </body>
 


### PR DESCRIPTION
## 📄 Description
Fixed singleProduct.html which loaded the recently-viewed module from the wrong relative path (../js/recently-viewed.js). The page is at the repo root, so the correct path is js/recently-viewed.js. This removes a 404 and restores the recently-viewed carousel.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6110

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.