### PR TITLE
fix: fixed wishlist notes script reference on the wishlist page

### DIFF
--- a/wishlist.html
+++ b/wishlist.html
@@ -770,7 +770,7 @@
         renderWishlist();
     </script>
 
-<script src="js/wishlist-notes.js" defer></script>
+<script src="js/wishlist-notes-tag-manager.js" defer></script>
 </main>
 </body>
 </html>


### PR DESCRIPTION
## 📄 Description
Fixed wishlist.html which loaded a nonexistent js/wishlist-notes.js. Replaced it with the real js/wishlist-notes-tag-manager.js module, removing a 404 and restoring the wishlist notes and tags feature.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6112

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.