### PR TITLE
fix: removed broken tooltip script reference on the register page

### DIFF
--- a/register.html
+++ b/register.html
@@ -269,7 +269,6 @@
 <script src="app.js"></script>
 <script src="js/fetch-timeout.js"></script>
 <script src="register.js"></script>
-<script src="js/describedby-tooltips.js" defer></script>
 
 </body>
 </html>


### PR DESCRIPTION
## 📄 Description
Removed the js/describedby-tooltips.js script tag from register.html. The file does not exist in the repository, so the reference produced a 404 on every page load. The aria-describedby attributes remain functional for assistive technology.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6114

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.