### PR TITLE
fix: used rupee symbol in promo discount minimum spend message

### DIFF
--- a/js/promo-discount-calculator.js
+++ b/js/promo-discount-calculator.js
@@ -29,7 +29,7 @@ class PromoDiscountCalculator {
     if (subtotal < coupon.minSpend) {
       return {
         valid: false,
-        message: `Coupon '${cleanCode}' requires a minimum spend of $${coupon.minSpend.toFixed(2)}.`
+        message: `Coupon '${cleanCode}' requires a minimum spend of ₹${coupon.minSpend.toFixed(2)}.`
       };
     }
 

--- a/tests/unit/promo-discount-calculator.test.js
+++ b/tests/unit/promo-discount-calculator.test.js
@@ -20,6 +20,12 @@ describe('PromoDiscountCalculator Unit Tests', () => {
     expect(res.message).toContain('minimum spend');
   });
 
+  it('should report the minimum spend in the store currency (rupees)', () => {
+    const res = calc.validateCoupon('CARA20', 25);
+    expect(res.message).toContain('₹50.00');
+    expect(res.message).not.toContain('$');
+  });
+
   it('should calculate percentage discount correctly', () => {
     const summary = calc.calculateTotal(100, 'WELCOME10', 10);
     expect(summary.subtotal).toBe(100);


### PR DESCRIPTION
## 📄 Description
Fixed the minimum-spend message in js/promo-discount-calculator.js to use the rupee symbol instead of a hardcoded dollar sign, matching the store currency. Added a unit test verifying the message uses rupees and contains no dollar sign.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6123

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.