### PR TITLE
fix: used rupee pricing on the cara page

### DIFF
--- a/cara.html
+++ b/cara.html
@@ -587,9 +587,9 @@
           </select>
           <select id="priceRange" class="filter-btn" aria-label="Select priceRange">
             <option value="any">Any price</option>
-            <option value="0-25">Under $25</option>
-            <option value="25-75">$25–75</option>
-            <option value="75-9999">$75+</option>
+            <option value="0-25">Under ₹25</option>
+            <option value="25-75">₹25–75</option>
+            <option value="75-9999">₹75+</option>
           </select>
           <button id="clearFilters" class="filter-btn" title="Clear all filters">Clear All Filters</button>
 
@@ -618,7 +618,7 @@
       <div style="margin-top:12px">
         <div style="display:flex;justify-content:space-between;align-items:center">
           <div class="muted">Subtotal</div>
-          <div id="subtotal" style="font-weight:800">$0.00</div>
+          <div id="subtotal" style="font-weight:800">₹0.00</div>
         </div>
         <button id="checkout" class="checkout">Proceed to Checkout</button>
       </div>
@@ -758,7 +758,7 @@ function changeQty(id, delta) {
 
   if (!ids.length) {
     cartList.innerHTML = '<div class="muted">Cart is empty</div>';
-    subtotalEl.textContent = '$0.00';
+    subtotalEl.textContent = '₹0.00';
     return;
   }
 


### PR DESCRIPTION
## 📄 Description
Converted hardcoded dollar pricing on cara.html to the rupee symbol: the price filter options, the subtotal placeholder, and the empty-cart subtotal text now all use the rupee sign, matching the store currency.

This PR is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6131

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code). Please assign this PR to the `tmdeveloper007` account when picking it up.
