### PR TITLE
fix: invalidate outstanding access tokens on password reset

### DIFF
--- a/backend/alembic/versions/3f5a7c9e1b2d_add_token_version_to_users.py
+++ b/backend/alembic/versions/3f5a7c9e1b2d_add_token_version_to_users.py
@@ -1,0 +1,31 @@
+"""add token_version to users
+
+Revision ID: 3f5a7c9e1b2d
+Revises: f1a2b3c4d5e6
+Create Date: 2026-08-09 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '3f5a7c9e1b2d'
+down_revision: Union[str, Sequence[str], None] = 'f1a2b3c4d5e6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add token_version so access tokens can be invalidated on password reset."""
+    op.add_column(
+        'users',
+        sa.Column('token_version', sa.Integer(), nullable=False, server_default='0'),
+    )
+
+
+def downgrade() -> None:
+    """Drop token_version."""
+    op.drop_column('users', 'token_version')

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -71,11 +71,12 @@ def cookie_secure() -> bool:
 
 
 # -- Helper: build JWT --
-def create_access_token(email: str) -> str:
+def create_access_token(email: str, token_version: int = 0) -> str:
     return jwt.encode(
         {
             "sub": email,
             "type": "access",
+            "token_version": token_version,
             "exp": datetime.now(timezone.utc) + timedelta(minutes=ACCESS_TOKEN_MINUTES)
         },
         SECRET_KEY,
@@ -171,6 +172,9 @@ def get_current_user(
         raise HTTPException(404, "User not found.")
     if not user.is_active:
         raise HTTPException(403, "Account is deactivated.")
+    if payload.get("token_version") != user.token_version:
+        # The token was issued before a password reset for this account.
+        raise HTTPException(401, "Token has been revoked.")
     return user
 
 
@@ -193,7 +197,7 @@ def register(request: Request, response: Response, payload: UserRegister, db: Se
     db.commit()
     db.refresh(user)
 
-    access_token = create_access_token(user.email)
+    access_token = create_access_token(user.email, user.token_version)
     refresh_token = create_refresh_token(user.email)
     
     set_auth_cookies(response, access_token, refresh_token)
@@ -272,7 +276,7 @@ def login(request: Request, response: Response, payload: UserLogin, db: Session 
 
     failed_login_attempts.pop(email_hash, None)
 
-    access_token = create_access_token(user.email)
+    access_token = create_access_token(user.email, user.token_version)
     refresh_token = create_refresh_token(user.email)
     
     set_auth_cookies(response, access_token, refresh_token)
@@ -303,7 +307,7 @@ def refresh_access_token(request: Request, response: Response, db: Session = Dep
     if not user or not user.is_active:
         raise HTTPException(401, "User not found or inactive.")
 
-    access_token = create_access_token(user.email)
+    access_token = create_access_token(user.email, user.token_version)
     new_refresh_token = create_refresh_token(user.email)
     set_auth_cookies(response, access_token, new_refresh_token)
     return {"message": "Token refreshed successfully"}
@@ -411,6 +415,7 @@ def reset_password(
         raise HTTPException(status_code=404, detail="User not found")
 
     user.hashed_password = pwd.hash(payload.new_password)
+    user.token_version += 1
     reset_token.used = True
     # Invalidate outstanding sessions so a stolen refresh token cannot outlive the reset.
     revoke_refresh_token(user.email)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -72,6 +72,9 @@ class User(Base):
     zip_code = Column(String, nullable=True)
     country = Column(String, nullable=True)
     updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+    # Bumped on every password reset so already-issued access tokens (which
+    # embed the version) are invalidated immediately.
+    token_version = Column(Integer, nullable=False, server_default="0", default=0)
 
 class Order(Base):
     __tablename__ = "orders"

--- a/backend/tests/test_password_reset.py
+++ b/backend/tests/test_password_reset.py
@@ -109,3 +109,56 @@ def test_reset_password_revokes_refresh_session(client):
     )
     assert response.status_code == 200
     assert "resetrevoke@example.com" not in auth_api.active_refresh_jtis
+
+
+def test_reset_password_invalidates_outstanding_access_tokens(client, db_session):
+    from backend.app.models import User, PasswordResetToken
+    from passlib.context import CryptContext
+    from datetime import datetime, timedelta, timezone
+    import secrets
+
+    pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+    user = User(
+        username="resetver",
+        email="resetver@example.com",
+        hashed_password=pwd.hash("OldPass@123"),
+    )
+    db_session.add(user)
+    db_session.commit()
+
+    login = client.post(
+        "/api/auth/login",
+        json={"email": "resetver@example.com", "password": "OldPass@123"},
+    )
+    old_access_token = login.json()["access_token"]
+    headers = {"Authorization": f"Bearer {old_access_token}"}
+    assert client.get("/api/auth/me", headers=headers).status_code == 200
+
+    token = secrets.token_urlsafe(32)
+    db_session.add(
+        PasswordResetToken(
+            user_id=user.id,
+            token=token,
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+    )
+    db_session.commit()
+
+    response = client.post(
+        "/api/auth/reset-password",
+        json={"token": token, "new_password": "NewPass@456"},
+    )
+    assert response.status_code == 200
+
+    # The pre-reset access token must no longer be accepted.
+    assert client.get("/api/auth/me", headers=headers).status_code == 401
+
+    # A freshly logged-in session works with the new password.
+    new_login = client.post(
+        "/api/auth/login",
+        json={"email": "resetver@example.com", "password": "NewPass@456"},
+    )
+    new_headers = {
+        "Authorization": f"Bearer {new_login.json()['access_token']}"
+    }
+    assert client.get("/api/auth/me", headers=new_headers).status_code == 200


### PR DESCRIPTION
## Problem

Access tokens are plain `sub + exp` JWTs with no way to invalidate them. When a user resets their password, all access tokens minted before the reset stay valid until they expire, so a stolen or already-issued token can still access the account after the password has been changed.

## Fix

- Added a `token_version` integer column to `users` (with an Alembic migration, `server_default='0'`).
- `create_access_token` now embeds the user's current `token_version` claim.
- `reset_password` increments `user.token_version`, and `get_current_user` rejects any access token whose embedded `token_version` no longer matches the user's current value (401).
- Register, login and refresh flows all mint tokens carrying the fresh version, so legitimate new logins keep working.

## Files changed

- `backend/app/models.py`
- `backend/app/api/auth.py`
- `backend/alembic/versions/3f5a7c9e1b2d_add_token_version_to_users.py`
- `backend/tests/test_password_reset.py`

## Testing

- Added `test_reset_password_invalidates_outstanding_access_tokens`: logs in, confirms `/api/auth/me` works, resets the password, then asserts the pre-reset token returns 401 while a fresh login with the new password returns 200.
- `backend/tests/test_password_reset.py`: 5 passed / 1 deselected (pre-existing fixture collision).
- `backend/tests/test_auth.py`, `backend/tests/test_refresh_logout.py`, `backend/tests/test_captcha.py`: 17 passed.
- `alembic heads` now resolves to `3f5a7c9e1b2d`.

Closes #6147
