### PR TITLE
fix: enforce idle timeout on the server via last_active tracking

### DIFF
--- a/backend/alembic/versions/5b7c9d1e3f4a_add_last_active_at_to_users.py
+++ b/backend/alembic/versions/5b7c9d1e3f4a_add_last_active_at_to_users.py
@@ -1,0 +1,28 @@
+"""add last_active_at to users
+
+Revision ID: 5b7c9d1e3f4a
+Revises: f1a2b3c4d5e6
+Create Date: 2026-08-09 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '5b7c9d1e3f4a'
+down_revision: Union[str, Sequence[str], None] = 'f1a2b3c4d5e6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add a sliding last_active_at marker for server-side idle enforcement."""
+    op.add_column('users', sa.Column('last_active_at', sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop last_active_at."""
+    op.drop_column('users', 'last_active_at')

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -52,6 +52,11 @@ SMTP_FROM = os.environ.get("SMTP_FROM", "Cara <noreply@cara.example.com>")
 SMTP_USE_TLS = os.environ.get("SMTP_USE_TLS", "true").lower() in ("1", "true", "yes")
 APP_BASE_URL = os.environ.get("APP_BASE_URL", "http://localhost:8000")
 
+# Server-side idle timeout (minutes). The client-side session lock is a UX
+# nicety; enforcement happens here, in get_current_user and refresh.
+SESSION_IDLE_TIMEOUT_MINUTES = int(os.environ.get("SESSION_IDLE_TIMEOUT_MINUTES", "15"))
+SESSION_LAST_ACTIVE_WRITE_INTERVAL_SECONDS = 60
+
 pwd    = CryptContext(schemes=["bcrypt"], deprecated="auto")
 router = APIRouter()
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/login", auto_error=False)
@@ -138,6 +143,32 @@ def assert_refresh_jti(email: str, jti: str | None):
     if not jti or not expected or not hmac.compare_digest(expected, jti):
         raise HTTPException(401, "Invalid or revoked refresh token.")
 
+
+def _as_utc(dt):
+    # SQLite stores DateTime columns as naive UTC; normalize for comparisons.
+    if dt is None:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def enforce_idle_timeout(user: models.User, db: Session) -> None:
+    """Reject the session when the user has been inactive too long; otherwise
+    slide the last-active marker forward (throttled writes)."""
+    now = datetime.now(timezone.utc)
+    last_active = _as_utc(user.last_active_at)
+    if last_active is None:
+        user.last_active_at = now
+        db.commit()
+        return
+    if now - last_active > timedelta(minutes=SESSION_IDLE_TIMEOUT_MINUTES):
+        revoke_refresh_token(user.email)
+        raise HTTPException(401, "Session expired due to inactivity.")
+    if (
+        now - last_active
+    ).total_seconds() >= SESSION_LAST_ACTIVE_WRITE_INTERVAL_SECONDS:
+        user.last_active_at = now
+        db.commit()
+
 # -- Helper: get current user from token --
 def get_current_user(
     request: Request,
@@ -171,6 +202,7 @@ def get_current_user(
         raise HTTPException(404, "User not found.")
     if not user.is_active:
         raise HTTPException(403, "Account is deactivated.")
+    enforce_idle_timeout(user, db)
     return user
 
 
@@ -192,6 +224,9 @@ def register(request: Request, response: Response, payload: UserRegister, db: Se
     db.add(user)
     db.commit()
     db.refresh(user)
+
+    user.last_active_at = datetime.now(timezone.utc)
+    db.commit()
 
     access_token = create_access_token(user.email)
     refresh_token = create_refresh_token(user.email)
@@ -272,6 +307,9 @@ def login(request: Request, response: Response, payload: UserLogin, db: Session 
 
     failed_login_attempts.pop(email_hash, None)
 
+    user.last_active_at = datetime.now(timezone.utc)
+    db.commit()
+
     access_token = create_access_token(user.email)
     refresh_token = create_refresh_token(user.email)
     
@@ -302,6 +340,10 @@ def refresh_access_token(request: Request, response: Response, db: Session = Dep
     user = db.query(models.User).filter(models.User.email == email).first()
     if not user or not user.is_active:
         raise HTTPException(401, "User not found or inactive.")
+
+    # Enforce the idle timeout here too — a session that has been inactive for
+    # longer than the window cannot mint fresh tokens, regardless of cookies.
+    enforce_idle_timeout(user, db)
 
     access_token = create_access_token(user.email)
     new_refresh_token = create_refresh_token(user.email)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -72,6 +72,9 @@ class User(Base):
     zip_code = Column(String, nullable=True)
     country = Column(String, nullable=True)
     updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+    # Sliding last-activity marker so the server can enforce an idle timeout
+    # even when client-side lock scripts are disabled or bypassed.
+    last_active_at = Column(DateTime, nullable=True)
 
 class Order(Base):
     __tablename__ = "orders"

--- a/backend/tests/test_idle_timeout.py
+++ b/backend/tests/test_idle_timeout.py
@@ -1,0 +1,62 @@
+"""Server-side idle timeout must reject access and refresh after inactivity,
+independent of the client-side session lock script."""
+from datetime import datetime, timedelta, timezone
+
+from passlib.context import CryptContext
+
+
+def _login(client, email, password):
+    return client.post("/api/auth/login", json={"email": email, "password": password})
+
+
+def test_idle_timeout_rejects_stale_session(client, db_session):
+    from backend.app.models import User
+
+    pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+    email = "idle@example.com"
+    db_session.add(
+        User(
+            username="idleuser",
+            email=email,
+            hashed_password=pwd.hash("Idle@1234"),
+        )
+    )
+    db_session.commit()
+
+    login = _login(client, email, "Idle@1234")
+    assert login.status_code == 200
+    token = login.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+    assert client.get("/api/auth/me", headers=headers).status_code == 200
+
+    # Simulate 16 minutes of inactivity (timeout is 15).
+    user = db_session.query(User).filter(User.email == email).first()
+    db_session.refresh(user)
+    user.last_active_at = datetime.now(timezone.utc) - timedelta(minutes=16)
+    db_session.commit()
+
+    # Both access and refresh must now be rejected by the server.
+    assert client.get("/api/auth/me", headers=headers).status_code == 401
+    assert client.post("/api/auth/refresh").status_code == 401
+
+
+def test_fresh_login_resets_last_active(client, db_session):
+    from backend.app.models import User
+
+    pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+    email = "idle-fresh@example.com"
+    db_session.add(
+        User(
+            username="idlefresh",
+            email=email,
+            hashed_password=pwd.hash("Idle@1234"),
+        )
+    )
+    db_session.commit()
+
+    login = _login(client, email, "Idle@1234")
+    assert login.status_code == 200
+
+    user = db_session.query(User).filter(User.email == email).first()
+    db_session.refresh(user)
+    assert user.last_active_at is not None


### PR DESCRIPTION
## Problem

There was **no server-enforced idle timeout**. The "15 minutes of inactivity" lockout lived entirely in client-side JavaScript (`js/session-lock.js`): it clears localStorage and opportunistically calls `POST /api/auth/logout`. If JS is disabled, a second tab is left open, or the tab's timers are starved, the httpOnly session (access + 7-day refresh cookie) stays valid on the server indefinitely.

## Fix

- Added a sliding `last_active_at` column to `users` (Alembic migration `5b7c9d1e3f4a`).
- Login and register stamp `last_active_at`; `get_current_user` and `POST /api/auth/refresh` now enforce `SESSION_IDLE_TIMEOUT_MINUTES` (default 15, configurable via env):
  - If the user's last activity is older than the window, the request is rejected with 401 **and** the refresh token family is revoked.
  - Otherwise the marker is slid forward (writes throttled to one per 60s to keep the hot path cheap).
- The client-side `session-lock.js` timer remains purely as a UX nicety; enforcement is now server-side and cannot be bypassed by disabling JS.

## Files changed

- `backend/app/models.py`
- `backend/app/api/auth.py`
- `backend/alembic/versions/5b7c9d1e3f4a_add_last_active_at_to_users.py`
- `backend/tests/test_idle_timeout.py` (new)

## Testing

- New `backend/tests/test_idle_timeout.py`: access and refresh both rejected after back-dating `last_active_at` past the window; fresh login stamps the marker.
- `backend/tests/test_idle_timeout.py`, `backend/tests/test_refresh_logout.py`, `backend/tests/test_auth.py`: 16 passed.
- `alembic heads` resolves to `5b7c9d1e3f4a`.

Closes #6149
