### PR TITLE
fix: enforce stock limits with atomic conditional updates

### DIFF
--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
+from sqlalchemy import update
 from sqlalchemy.exc import IntegrityError
 from .. import models, schemas
 from ..database import get_db
@@ -28,6 +29,34 @@ def return_deadline(order: models.Order) -> datetime | None:
         return None
     return order.delivered_at.replace(tzinfo=timezone.utc) + timedelta(
         days=RETURN_WINDOW_DAYS
+    )
+
+
+def _try_decrement_stock(db: Session, product_id: int, quantity: int) -> int:
+    """Atomically decrement stock if enough is available.
+
+    This single conditional UPDATE is the authoritative stock guard. Unlike
+    `SELECT ... FOR UPDATE` (which SQLite silently ignores), the check runs
+    inside the same statement, so concurrent requests cannot oversell. Returns
+    the number of matched rows (0 = insufficient stock).
+    """
+    result = db.execute(
+        update(models.Product)
+        .where(
+            models.Product.id == product_id,
+            models.Product.stock >= quantity,
+        )
+        .values(stock=models.Product.stock - quantity)
+    )
+    return result.rowcount
+
+
+def _restore_stock(db: Session, product_id: int, quantity: int) -> None:
+    """Atomically return stock when an order is cancelled."""
+    db.execute(
+        update(models.Product)
+        .where(models.Product.id == product_id)
+        .values(stock=models.Product.stock + quantity)
     )
 
 
@@ -172,7 +201,6 @@ def create_order(
     db_products = (
         db.query(models.Product)
         .filter(models.Product.id.in_(product_ids))
-        .with_for_update()  # Apply row locks to all matching products simultaneously
         .all()
     )
 
@@ -188,14 +216,14 @@ def create_order(
                 detail=f"Product not found: id={item.product_id}",
             )
 
-        if db_product.stock < item.quantity:
+        # Atomic conditional decrement — enforced even on SQLite, where
+        # SELECT ... FOR UPDATE is silently ignored. A 0 rowcount means the
+        # stock was not sufficient at the moment of the write.
+        if _try_decrement_stock(db, item.product_id, item.quantity) == 0:
             raise HTTPException(
                 status_code=400,
                 detail=f"Insufficient stock for product: {db_product.name}",
             )
-
-        # Deduct stock in memory (will be committed later)
-        db_product.stock -= item.quantity
 
         real_price = db_product.price
         subtotal += real_price * item.quantity
@@ -291,7 +319,6 @@ def cancel_order(
             models.Order.id == order_id,
             models.Order.email == current_user.email,
         )
-        .with_for_update()
         .first()
     )
     if not order:
@@ -318,19 +345,10 @@ def cancel_order(
         .filter(models.OrderItem.order_id == order.id)
         .all()
     )
-    product_ids = [item.product_id for item in items if item.product_id is not None]
-    if product_ids:
-        products = (
-            db.query(models.Product)
-            .filter(models.Product.id.in_(product_ids))
-            .with_for_update()
-            .all()
-        )
-        product_map = {product.id: product for product in products}
-        for item in items:
-            product = product_map.get(item.product_id)
-            if product is not None:
-                product.stock += item.quantity
+    for item in items:
+        if item.product_id is not None:
+            # Atomic restore — never depends on a stale in-memory read.
+            _restore_stock(db, item.product_id, item.quantity)
 
     order.status = "CANCELLED"
     db.commit()

--- a/backend/tests/test_order_stock_atomicity.py
+++ b/backend/tests/test_order_stock_atomicity.py
@@ -1,0 +1,96 @@
+"""Stock must be guarded atomically (no oversell, never negative) even though
+SQLite ignores SELECT ... FOR UPDATE."""
+from passlib.context import CryptContext
+
+from app.models import Product, User
+from tests.conftest import TestingSessionLocal
+
+ORDERS_URL = "/api/orders/"
+pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+EMAIL = "stockatom@example.com"
+
+
+def _auth_headers(client):
+    db = TestingSessionLocal()
+    user = db.query(User).filter(User.email == EMAIL).first()
+    if user is None:
+        db.add(
+            User(
+                username="stockatom",
+                email=EMAIL,
+                hashed_password=pwd.hash("Test@1234"),
+            )
+        )
+        db.commit()
+    db.close()
+    response = client.post(
+        "/api/auth/login",
+        json={"email": EMAIL, "password": "Test@1234"},
+    )
+    assert response.status_code == 200, response.text
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+def _seed_product(stock=1):
+    db = TestingSessionLocal()
+    product = Product(
+        brand="TestBrand",
+        name="Atomic Tee",
+        price=100.0,
+        img="img.jpg",
+        rating=4,
+        category="minimal",
+        subcategory="top",
+        color="white",
+        style="casual",
+        stock=stock,
+    )
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+    product_id = product.id
+    db.close()
+    return product_id
+
+
+def _payload(product_id, quantity):
+    return {
+        "fullName": "Stock Atom",
+        "email": EMAIL,
+        "address": "1 Test St",
+        "city": "Testville",
+        "zip": "12345",
+        "items": [{"product_id": product_id, "quantity": quantity}],
+    }
+
+
+def test_oversell_rejected_and_stock_untouched(client):
+    headers = _auth_headers(client)
+    product_id = _seed_product(stock=1)
+
+    response = client.post(ORDERS_URL, json=_payload(product_id, 2), headers=headers)
+    assert response.status_code == 400, response.text
+    assert "Insufficient stock" in response.json()["detail"]
+
+    db = TestingSessionLocal()
+    assert db.query(Product).filter(Product.id == product_id).one().stock == 1
+    db.close()
+
+
+def test_partial_stock_never_goes_negative(client):
+    headers = _auth_headers(client)
+    product_id = _seed_product(stock=3)
+
+    assert (
+        client.post(ORDERS_URL, json=_payload(product_id, 3), headers=headers).status_code
+        == 201
+    )
+
+    # Exactly sold out — a further order must fail, not drive stock negative.
+    response = client.post(ORDERS_URL, json=_payload(product_id, 1), headers=headers)
+    assert response.status_code == 400, response.text
+
+    db = TestingSessionLocal()
+    assert db.query(Product).filter(Product.id == product_id).one().stock == 0
+    db.close()


### PR DESCRIPTION
## Problem

Order placement relied on `SELECT ... FOR UPDATE` row locks to serialize stock checks and deductions, but the **default database is SQLite** (`sqlite:///./cara.db`), and SQLite silently ignores `FOR UPDATE`. Two concurrent `POST /api/orders` requests could both read the same stock, both pass the `stock < quantity` check, and both deduct — overselling the product and driving stock negative. The same stale read-modify-write pattern existed in the cancellation paths.

## Fix

- Replaced the check-then-deduct sequence with an **atomic conditional update** in `backend/app/api/orders.py`:
  `UPDATE products SET stock = stock - :qty WHERE id = :id AND stock >= :qty`, checking `rowcount` (0 = insufficient stock → 400).
- Because the guard now lives inside a single statement, it is enforced identically on SQLite and PostgreSQL — no reliance on row locks.
- Cancellation restores stock with an atomic `stock = stock + :qty` update instead of a stale in-memory read-modify-write.
- Removed the ineffective `with_for_update()` calls (kept the products fetch for price/name metadata).

## Files changed

- `backend/app/api/orders.py`
- `backend/tests/test_order_stock_atomicity.py` (new)

## Testing

- New `backend/tests/test_order_stock_atomicity.py`: oversell rejected and stock untouched; stock never goes negative (sells out exactly then rejects).
- `test_order_stock_atomicity.py`, `test_order_cancel.py`, `test_order_create_validation.py`, `test_order_idempotency.py`, `test_order_detail.py`: 19 passed.
- The single `test_order_email_match.py` failure (uses a `product_name` field the schema rejects with 422) also fails on `main` — pre-existing, unrelated to this change (verified against the baseline).

Closes #6150
