### PR TITLE
fix: add server_default to products.stock migration

### DIFF
--- a/backend/alembic/versions/b814e9e02ce7_create_orders_order_items_users_.py
+++ b/backend/alembic/versions/b814e9e02ce7_create_orders_order_items_users_.py
@@ -91,7 +91,12 @@ def upgrade() -> None:
     op.create_index(op.f('ix_password_reset_tokens_id'), 'password_reset_tokens', ['id'], unique=False)
     op.create_index(op.f('ix_password_reset_tokens_token'), 'password_reset_tokens', ['token'], unique=True)
     op.drop_index(op.f('ix_interactions_user_id_type'), table_name='interactions')
-    op.add_column('products', sa.Column('stock', sa.Integer(), nullable=False))
+    # server_default keeps this NOT NULL add safe on non-empty products tables
+    # (SQLite/PostgreSQL/MySQL all reject adding NOT NULL without a default).
+    op.add_column(
+        'products',
+        sa.Column('stock', sa.Integer(), nullable=False, server_default='0'),
+    )
     # ### end Alembic commands ###
 
 


### PR DESCRIPTION
## Problem

Alembic migration `b814e9e02ce7` adds `products.stock` as `INTEGER NOT NULL` with **no `server_default`** and no backfill. On any database where `products` already has rows, `alembic upgrade head` fails with a NOT NULL constraint violation (`Cannot add a NOT NULL column with default value NULL`), breaking the documented setup path for anyone with a populated catalog.

## Fix

- Added `server_default='0'` to the `products.stock` column in migration `b814e9e02ce7` so the NOT NULL column can be added safely on non-empty tables:
  ```python
  op.add_column(
      'products',
      sa.Column('stock', sa.Integer(), nullable=False, server_default='0'),
  )
  ```

## Files changed

- `backend/alembic/versions/b814e9e02ce7_create_orders_order_items_users_.py`

## Testing

Reproduced and verified against real SQLite databases:

- **Before fix (baseline):** migrate to `b2c3d4e5f6a7`, insert a product row, then `alembic upgrade b814e9e02ce7` → fails with `Cannot add a NOT NULL column with default value NULL`.
- **After fix:** same sequence succeeds; the `stock` column is created and the pre-existing product row is backfilled to `stock = 0`.

Note: `alembic upgrade head` on SQLite still stops later at `d8e4f1a2b3c4` (ALTER of a constraint, which needs Alembic batch mode) — that failure reproduces identically on `main` with a fresh empty database and is unrelated to this change.

Closes #6151
