### PR TITLE
fix: purge used and expired password-reset tokens

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -367,6 +367,12 @@ def forgot_password(
     token = secrets.token_urlsafe(32)
     expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
 
+    # Keep the table bounded: drop rows that can no longer be used before
+    # inserting the new token (cheap maintenance on an already-limited route).
+    db.query(models.PasswordResetToken).filter(
+        models.PasswordResetToken.expires_at < datetime.now(timezone.utc)
+    ).delete(synchronize_session=False)
+
     reset_token = models.PasswordResetToken(
         user_id=user.id,
         token=token,
@@ -411,14 +417,16 @@ def reset_password(
         raise HTTPException(status_code=404, detail="User not found")
 
     user.hashed_password = pwd.hash(payload.new_password)
-    reset_token.used = True
     # Invalidate outstanding sessions so a stolen refresh token cannot outlive the reset.
     revoke_refresh_token(user.email)
+    # Purge every row that can no longer be used: this user's tokens (used or
+    # outstanding) and any globally expired tokens. Prevents unbounded growth.
     db.query(models.PasswordResetToken).filter(
         models.PasswordResetToken.user_id == user.id,
-        models.PasswordResetToken.used == False,
-        models.PasswordResetToken.id != reset_token.id,
-    ).update({"used": True})
+    ).delete(synchronize_session=False)
+    db.query(models.PasswordResetToken).filter(
+        models.PasswordResetToken.expires_at < datetime.now(timezone.utc)
+    ).delete(synchronize_session=False)
     db.commit()
 
     return {"message": "Password has been reset successfully"}

--- a/backend/tests/test_reset_purge.py
+++ b/backend/tests/test_reset_purge.py
@@ -1,0 +1,74 @@
+"""Password-reset token rows must be purged so the table does not grow
+without bound."""
+from datetime import datetime, timedelta, timezone
+
+from passlib.context import CryptContext
+
+from app.models import PasswordResetToken, User
+
+pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def _user(db, username, email):
+    user = User(
+        username=username,
+        email=email,
+        hashed_password=pwd.hash("OldPass@123"),
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _token(db, user, *, expired=False):
+    token = PasswordResetToken(
+        user_id=user.id,
+        token=__import__("secrets").token_urlsafe(32),
+        expires_at=datetime.now(timezone.utc)
+        + (timedelta(minutes=-30) if expired else timedelta(hours=1)),
+    )
+    db.add(token)
+    db.commit()
+    db.refresh(token)
+    return token
+
+
+def test_reset_purges_used_and_outstanding_tokens(client, db_session):
+    user = _user(db_session, "purgeuser", "purge@example.com")
+    used_token = _token(db_session, user)
+    outstanding = _token(db_session, user)
+
+    response = client.post(
+        "/api/auth/reset-password",
+        json={"token": used_token.token, "new_password": "NewPass@456"},
+    )
+    assert response.status_code == 200
+
+    db_session.expire_all()
+    remaining = (
+        db_session.query(PasswordResetToken)
+        .filter(PasswordResetToken.user_id == user.id)
+        .all()
+    )
+    assert remaining == []
+
+
+def test_forgot_password_purges_expired_tokens(client, db_session):
+    user = _user(db_session, "expireduser", "expired@example.com")
+    expired = _token(db_session, user, expired=True)
+    expired_token = expired.token  # snapshot before the row can be purged/reused
+
+    response = client.post(
+        "/api/auth/forgot-password",
+        json={"email": user.email},
+    )
+    assert response.status_code == 200
+
+    db_session.expire_all()
+    still_there = (
+        db_session.query(PasswordResetToken)
+        .filter(PasswordResetToken.token == expired_token)
+        .first()
+    )
+    assert still_there is None


### PR DESCRIPTION
## Problem

Password-reset token rows were **never purged**. Every `POST /api/auth/forgot-password` inserted a new row (up to the 5/min rate limit), and neither the reset flow nor any maintenance job deleted expired or used tokens, so the table grew without bound and every lookup scanned a growing table.

## Fix

- `reset_password` now deletes every row that can no longer be used: all tokens for the user (used or outstanding) plus any globally expired rows — all in the same transaction as the reset.
- `forgot_password` purges globally expired rows before inserting the new token, so repeated requests also keep the table bounded without needing a separate scheduler.

## Files changed

- `backend/app/api/auth.py`
- `backend/tests/test_reset_purge.py` (new)

## Testing

- New `backend/tests/test_reset_purge.py`:
  - After a successful reset, the used and outstanding token rows are gone.
  - After `forgot-password`, previously expired rows are purged.
- `test_reset_purge.py`, `test_password_reset.py`: 6 passed / 1 deselected (pre-existing fixture collision).
- `test_auth.py`, `test_captcha.py`, `test_refresh_logout.py`: 17 passed.

Closes #6152
