### PR TITLE
fix: stop returning the raw access token in login/register bodies

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -8,7 +8,7 @@ import os
 from fastapi import Response
 from ..database import get_db
 from .. import models
-from ..schemas import UserRegister, UserLogin, Token, UserOut, ForgotPasswordRequest, ResetPasswordRequest
+from ..schemas import UserRegister, UserLogin, AuthResponse, UserOut, ForgotPasswordRequest, ResetPasswordRequest
 from ..limiter import limiter
 from PIL import Image, ImageDraw
 import io
@@ -175,7 +175,7 @@ def get_current_user(
 
 
 # -- Register --
-@router.post("/register", response_model=Token, status_code=201)
+@router.post("/register", response_model=AuthResponse, status_code=201)
 @limiter.limit("5/minute")
 def register(request: Request, response: Response, payload: UserRegister, db: Session = Depends(get_db)):
     if db.query(models.User).filter(models.User.email == payload.email).first():
@@ -198,11 +198,7 @@ def register(request: Request, response: Response, payload: UserRegister, db: Se
     
     set_auth_cookies(response, access_token, refresh_token)
 
-    return Token(
-        access_token = access_token,
-        token_type   = "bearer",
-        user         = UserOut.model_validate(user)
-    )
+    return AuthResponse(user=UserOut.model_validate(user))
 
 
 # -- Captcha --
@@ -236,7 +232,7 @@ def get_captcha():
 
 
 # -- Login --
-@router.post("/login", response_model=Token)
+@router.post("/login", response_model=AuthResponse)
 @limiter.limit("5/minute")
 def login(request: Request, response: Response, payload: UserLogin, db: Session = Depends(get_db)):
     email_hash = hashlib.sha256(payload.email.encode('utf-8')).hexdigest()
@@ -277,11 +273,7 @@ def login(request: Request, response: Response, payload: UserLogin, db: Session 
     
     set_auth_cookies(response, access_token, refresh_token)
 
-    return Token(
-        access_token = access_token,
-        token_type   = "bearer",
-        user         = UserOut.model_validate(user)
-    )
+    return AuthResponse(user=UserOut.model_validate(user))
 
 @router.post("/refresh")
 def refresh_access_token(request: Request, response: Response, db: Session = Depends(get_db)):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -119,10 +119,8 @@ class UserProfileResponse(UserOut):
     updated_at: Optional[datetime] = None
 
 
-class Token(BaseModel):
-    access_token: str
-    token_type:   str
-    user:         UserOut
+class AuthResponse(BaseModel):
+    user: UserOut
 
 
 class OrderItemResponse(BaseModel):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -39,6 +39,16 @@ def override_get_db():
         db.close()
 
 
+def bearer_token(client):
+    """Return the access-token httpOnly cookie as a usable Bearer header value.
+
+    Starlette quotes cookie values that contain spaces, and httpx keeps the
+    quotes in its jar, so the value must be unquoted before it is usable as an
+    Authorization header.
+    """
+    return client.cookies.get("access_token").strip('"')
+
+
 @pytest.fixture(scope="session", autouse=True)
 def setup_database():
     Base.metadata.create_all(bind=engine)
@@ -82,8 +92,9 @@ def auth_headers(client, db_session):
         "/api/auth/login",
         json={"email": "test@example.com", "password": "Test@1234"},
     )
-    token = response.json()["access_token"]
-    return {"Authorization": f"Bearer {token}"}
+    assert response.status_code == 200, response.text
+    # The server only sets the token as an httpOnly cookie now; read it from there.
+    return {"Authorization": bearer_token(client)}
 
 
 @pytest.fixture()
@@ -104,5 +115,6 @@ def admin_auth_headers(client, db_session):
         "/api/auth/login",
         json={"email": "admin@example.com", "password": "Admin@1234"},
     )
-    token = response.json()["access_token"]
-    return {"Authorization": f"Bearer {token}"}
+    assert response.status_code == 200, response.text
+    # The server only sets the token as an httpOnly cookie now; read it from there.
+    return {"Authorization": bearer_token(client)}

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -13,7 +13,7 @@ import pytest
 from fastapi.testclient import TestClient
 from app import models
 
-from tests.conftest import TestingSessionLocal
+from tests.conftest import TestingSessionLocal, bearer_token
 
 
 def _register_and_login(client: TestClient, role: str, suffix: str) -> None:
@@ -146,7 +146,8 @@ class TestAdminAnalytics:
         email = "admin_t_cancel@test.com"
         _register_and_login(client, "USER", "cancel")
         make_admin(email)
-        headers = {"Authorization": f"Bearer {client.post('/api/auth/login', json={'email': email, 'password': 'Password1@'}).json()['access_token']}"}
+        client.post('/api/auth/login', json={'email': email, 'password': 'Password1@'})
+        headers = {"Authorization": bearer_token(client)}
 
         db = TestingSessionLocal()
         _seed_product(db, name="Keep Shirt", price=100.0, category="summary-keep", stock=10)
@@ -171,7 +172,8 @@ class TestAdminAnalytics:
         email = "admin_t_catcancel@test.com"
         _register_and_login(client, "USER", "catcancel")
         make_admin(email)
-        headers = {"Authorization": f"Bearer {client.post('/api/auth/login', json={'email': email, 'password': 'Password1@'}).json()['access_token']}"}
+        client.post('/api/auth/login', json={'email': email, 'password': 'Password1@'})
+        headers = {"Authorization": bearer_token(client)}
 
         db = TestingSessionLocal()
         _seed_product(db, name="Active Cat Shirt", price=50.0, category="cat-sales-active", stock=10)
@@ -197,7 +199,8 @@ class TestAdminAnalytics:
         email = "admin_t_orphan@test.com"
         _register_and_login(client, "USER", "orphan")
         make_admin(email)
-        headers = {"Authorization": f"Bearer {client.post('/api/auth/login', json={'email': email, 'password': 'Password1@'}).json()['access_token']}"}
+        client.post('/api/auth/login', json={'email': email, 'password': 'Password1@'})
+        headers = {"Authorization": bearer_token(client)}
 
         db = TestingSessionLocal()
         product = _seed_product(db, name="Doomed Shirt", price=75.0, category="cat-sales-orphan", stock=10)

--- a/backend/tests/test_admin_products.py
+++ b/backend/tests/test_admin_products.py
@@ -2,7 +2,7 @@
 from passlib.context import CryptContext
 
 from app.models import User
-from tests.conftest import TestingSessionLocal
+from tests.conftest import TestingSessionLocal, bearer_token
 
 pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
@@ -26,7 +26,7 @@ def _admin_headers(client):
         json={"email": "admin-products@example.com", "password": "Admin@1234"},
     )
     assert response.status_code == 200, response.text
-    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+    return {"Authorization": bearer_token(client)}
 
 
 def _user_headers(client):
@@ -47,7 +47,7 @@ def _user_headers(client):
         json={"email": "user-products@example.com", "password": "Test@1234"},
     )
     assert response.status_code == 200, response.text
-    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+    return {"Authorization": bearer_token(client)}
 
 
 def test_admin_create_product(client):

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -20,8 +20,7 @@ def test_register_success(client):
     r = client.post(REGISTER_URL, json=VALID_USER)
     assert r.status_code == 201
     body = r.json()
-    assert "access_token" in body
-    assert body["token_type"] == "bearer"
+    assert "access_token" not in body
     assert body["user"]["email"] == VALID_USER["email"]
 
 
@@ -52,7 +51,8 @@ def test_login_success(client):
     client.post(REGISTER_URL, json={**VALID_USER, "username": "loginuser", "email": "login@example.com"})
     r = client.post(LOGIN_URL, json={"email": "login@example.com", "password": "Secure123@"})
     assert r.status_code == 200
-    assert "access_token" in r.json()
+    assert "access_token" not in r.json()
+    assert r.json()["user"]["email"] == "login@example.com"
 
 
 def test_login_wrong_password(client):
@@ -72,9 +72,8 @@ def test_login_nonexistent_user(client):
 
 def test_me_returns_user(client):
     client.post(REGISTER_URL, json={**VALID_USER, "username": "meuser", "email": "me@example.com"})
-    login = client.post(LOGIN_URL, json={"email": "me@example.com", "password": "Secure123@"})
-    token = login.json()["access_token"]
-    r = client.get(ME_URL, cookies={"access_token": f"Bearer {token}"})
+    client.post(LOGIN_URL, json={"email": "me@example.com", "password": "Secure123@"})
+    r = client.get(ME_URL)
     assert r.status_code == 200
     assert r.json()["email"] == "me@example.com"
 
@@ -97,7 +96,6 @@ def test_me_rejects_deactivated_user(client):
     }
     register = client.post(REGISTER_URL, json=payload)
     assert register.status_code == 201
-    token = register.json()["access_token"]
 
     from tests.conftest import TestingSessionLocal
     from app.models import User
@@ -108,5 +106,5 @@ def test_me_rejects_deactivated_user(client):
     db.commit()
     db.close()
 
-    response = client.get(ME_URL, headers={"Authorization": f"Bearer {token}"})
+    response = client.get(ME_URL)
     assert response.status_code == 403

--- a/backend/tests/test_captcha.py
+++ b/backend/tests/test_captcha.py
@@ -59,7 +59,8 @@ def test_login_accepts_valid_captcha_after_failure(client):
         },
     )
     assert ok.status_code == 200
-    assert "access_token" in ok.json()
+    assert "access_token" not in ok.json()
+    assert ok.json()["user"]["email"] == email
 
 
 def test_login_rejects_wrong_captcha_answer(client):

--- a/backend/tests/test_order_cancel.py
+++ b/backend/tests/test_order_cancel.py
@@ -2,7 +2,7 @@
 from passlib.context import CryptContext
 
 from app.models import Product, Order, User
-from tests.conftest import TestingSessionLocal
+from tests.conftest import TestingSessionLocal, bearer_token
 
 ORDERS_URL = "/api/orders/"
 pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -26,8 +26,7 @@ def _auth_headers(client, *, username="canceluser", email="cancel@example.com"):
         json={"email": email, "password": "Test@1234"},
     )
     assert response.status_code == 200, response.text
-    token = response.json()["access_token"]
-    return {"Authorization": f"Bearer {token}"}
+    return {"Authorization": bearer_token(client)}
 
 
 def _seed_product(db, **kwargs) -> Product:

--- a/backend/tests/test_order_create_validation.py
+++ b/backend/tests/test_order_create_validation.py
@@ -7,7 +7,7 @@ POST /api/orders/ previously accepted `items: []` and created a shipping-only
 from passlib.context import CryptContext
 
 from app.models import Product, User
-from tests.conftest import TestingSessionLocal
+from tests.conftest import TestingSessionLocal, bearer_token
 
 ORDERS_URL = "/api/orders/"
 pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -33,7 +33,7 @@ def _auth_headers(client):
         json={"email": USER_EMAIL, "password": "Test@1234"},
     )
     assert response.status_code == 200, response.text
-    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+    return {"Authorization": bearer_token(client)}
 
 
 def _seed_product(name="Validation Tee", stock=100):

--- a/backend/tests/test_order_detail.py
+++ b/backend/tests/test_order_detail.py
@@ -2,7 +2,7 @@
 from passlib.context import CryptContext
 
 from app.models import Order, OrderItem, User
-from tests.conftest import TestingSessionLocal
+from tests.conftest import TestingSessionLocal, bearer_token
 
 ORDERS_URL = "/api/orders/"
 pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -26,7 +26,7 @@ def _auth_headers(client, *, username="detailuser", email="detail@example.com"):
         json={"email": email, "password": "Test@1234"},
     )
     assert response.status_code == 200, response.text
-    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+    return {"Authorization": bearer_token(client)}
 
 
 def _seed_order(*, email: str, product_name: str = "Detail Shirt", product_id: int | None = None) -> Order:

--- a/backend/tests/test_order_email_match.py
+++ b/backend/tests/test_order_email_match.py
@@ -2,7 +2,7 @@
 from passlib.context import CryptContext
 
 from app.models import Product, User
-from tests.conftest import TestingSessionLocal
+from tests.conftest import TestingSessionLocal, bearer_token
 
 ORDERS_URL = "/api/orders/"
 pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -25,7 +25,7 @@ def _auth_headers(client):
         json={"email": "emailmatch@example.com", "password": "Test@1234"},
     )
     assert login.status_code == 200
-    return {"Authorization": f"Bearer {login.json()['access_token']}"}
+    return {"Authorization": bearer_token(client)}
 
 
 def test_create_order_rejects_mismatched_email(client):

--- a/backend/tests/test_order_idempotency.py
+++ b/backend/tests/test_order_idempotency.py
@@ -2,7 +2,7 @@
 from passlib.context import CryptContext
 
 from app.models import Product, User, Order
-from tests.conftest import TestingSessionLocal
+from tests.conftest import TestingSessionLocal, bearer_token
 
 pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
@@ -22,7 +22,7 @@ def _login_headers(client, email, password, username):
 
     response = client.post("/api/auth/login", json={"email": email, "password": password})
     assert response.status_code == 200, response.text
-    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+    return {"Authorization": bearer_token(client)}
 
 
 def _seed_product(name="Idempotency Tee", stock=20):

--- a/backend/tests/test_return_date.py
+++ b/backend/tests/test_return_date.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from passlib.context import CryptContext
 
 from app.models import Order, Product, User
-from tests.conftest import TestingSessionLocal
+from tests.conftest import TestingSessionLocal, bearer_token
 
 ORDERS_URL = "/api/orders/"
 pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -39,7 +39,7 @@ def _auth_headers(client, *, email=USER_EMAIL, username="returnuser"):
         json={"email": email, "password": "Test@1234"},
     )
     assert response.status_code == 200, response.text
-    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+    return {"Authorization": bearer_token(client)}
 
 
 def _admin_headers(client):
@@ -49,7 +49,7 @@ def _admin_headers(client):
         json={"email": ADMIN_EMAIL, "password": "Test@1234"},
     )
     assert response.status_code == 200, response.text
-    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+    return {"Authorization": bearer_token(client)}
 
 
 def _seed_product(name="Return Tee", stock=20):


### PR DESCRIPTION
## Problem

`register` and `login` returned the raw `access_token` (JWT) in the **response body** while also setting the same token as an httpOnly cookie. That made the token visible to any page JS (XSS), to network/proxy logs, and copyable to another device where cookie flags no longer apply — undermining the httpOnly hardening.

## Fix

- `register` and `login` no longer include `access_token`/`token_type` in the body. They now return only the non-sensitive user metadata (`AuthResponse` = `{ "user": UserOut }`). Authentication continues to be carried exclusively by the httpOnly cookies set via `set_auth_cookies`.
- Replaced the `Token` response schema with `AuthResponse`.
- Updated the frontend-affecting test suite: all test helpers now read the bearer token from the login/register httpOnly cookie instead of the response body (via a new `bearer_token(client)` conftest helper that unquotes the cookie value Starlette writes into `Set-Cookie`).
- The static frontend (`login.js`, `register.js`) already used the httpOnly cookies and never read `access_token` from the body — no frontend change needed.

## Files changed

- `backend/app/api/auth.py`
- `backend/app/schemas.py`
- `backend/tests/conftest.py`
- `backend/tests/test_auth.py`
- `backend/tests/test_captcha.py`
- `backend/tests/test_admin.py`
- `backend/tests/test_admin_products.py`
- `backend/tests/test_order_cancel.py`
- `backend/tests/test_order_create_validation.py`
- `backend/tests/test_order_detail.py`
- `backend/tests/test_order_email_match.py`
- `backend/tests/test_order_idempotency.py`
- `backend/tests/test_return_date.py`

## Testing

- `test_auth.py`/`test_captcha.py` now assert `"access_token" not in body` for register and login.
- Full backend suite: 101 passed / 13 failed / 5 errors — identical to the pre-existing `origin/main` baseline (the 13 failures and 5 errors all also fail on `origin/main`).

Closes #6155
