### PR TITLE
fix: drive stock UI and restock alerts from real backend data

### DIFF
--- a/backend/alembic/versions/f3e5d7c9b1a2_add_restock_alerts.py
+++ b/backend/alembic/versions/f3e5d7c9b1a2_add_restock_alerts.py
@@ -1,0 +1,39 @@
+"""add restock_alerts table
+
+Revision ID: f3e5d7c9b1a2
+Revises: f1a2b3c4d5e6
+Create Date: 2026-08-09 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f3e5d7c9b1a2'
+down_revision: Union[str, Sequence[str], None] = 'f1a2b3c4d5e6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'restock_alerts',
+        sa.Column('id', sa.Integer(), primary_key=True, index=True),
+        sa.Column('email', sa.String(), nullable=False),
+        sa.Column('product_id', sa.Integer(), sa.ForeignKey('products.id'), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.UniqueConstraint('email', 'product_id', name='uq_restock_alerts_email_product'),
+    )
+    op.create_index(op.f('ix_restock_alerts_email'), 'restock_alerts', ['email'])
+    op.create_index(op.f('ix_restock_alerts_id'), 'restock_alerts', ['id'])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_restock_alerts_id'), table_name='restock_alerts')
+    op.drop_index(op.f('ix_restock_alerts_email'), table_name='restock_alerts')
+    op.drop_table('restock_alerts')

--- a/backend/app/api/newsletter.py
+++ b/backend/app/api/newsletter.py
@@ -16,6 +16,11 @@ class NewsletterUnsubscribeRequest(BaseModel):
     token: str
 
 
+class RestockAlertRequest(BaseModel):
+    email: EmailStr
+    product_id: int
+
+
 @router.post("/subscribe", status_code=201)
 def subscribe(payload: NewsletterSubscribeRequest, db: Session = Depends(get_db)):
     existing = (
@@ -55,3 +60,34 @@ def unsubscribe(payload: NewsletterUnsubscribeRequest, db: Session = Depends(get
     subscriber.is_active = False
     db.commit()
     return {"message": "Successfully unsubscribed"}
+
+
+@router.post("/restock", status_code=201)
+def restock_alert(payload: RestockAlertRequest, db: Session = Depends(get_db)):
+    product = (
+        db.query(models.Product)
+        .filter(models.Product.id == payload.product_id)
+        .first()
+    )
+    if not product:
+        raise HTTPException(status_code=404, detail="Product not found")
+
+    existing = (
+        db.query(models.RestockAlert)
+        .filter(
+            models.RestockAlert.email == payload.email,
+            models.RestockAlert.product_id == payload.product_id,
+        )
+        .first()
+    )
+    if existing is None:
+        db.add(
+            models.RestockAlert(
+                email=payload.email,
+                product_id=payload.product_id,
+            )
+        )
+        db.commit()
+    # Generic response regardless of prior state — avoids leaking whether
+    # this email was already registered for this product.
+    return {"message": "Restock alert registered"}

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -12,6 +12,19 @@ class NewsletterSubscriber(Base):
     unsubscribe_token = Column(String, unique=True, index=True, nullable=True)
 
 
+class RestockAlert(Base):
+    __tablename__ = "restock_alerts"
+    __table_args__ = (
+        UniqueConstraint("email", "product_id", name="uq_restock_alerts_email_product"),
+    )
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, index=True, nullable=False)
+    product_id = Column(Integer, ForeignKey("products.id"), nullable=False)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+
+    product = relationship("Product")
+
+
 class AmbassadorApplication(Base):
     __tablename__ = "ambassador_applications"
 

--- a/backend/tests/test_restock.py
+++ b/backend/tests/test_restock.py
@@ -1,0 +1,98 @@
+"""Tests for POST /api/newsletter/restock."""
+from app.models import Product, RestockAlert
+from tests.conftest import TestingSessionLocal
+
+RESTOCK_URL = "/api/newsletter/restock"
+
+
+def _seed_product(name="Restock Tee", stock=0):
+    db = TestingSessionLocal()
+    product = Product(
+        brand="Cara",
+        name=name,
+        price=100.0,
+        img="tee.jpg",
+        rating=4,
+        category="street",
+        stock=stock,
+    )
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+    pid = product.id
+    db.close()
+    return pid
+
+
+def test_restock_alert_registers(client):
+    pid = _seed_product()
+    r = client.post(RESTOCK_URL, json={"email": "restock@example.com", "product_id": pid})
+    assert r.status_code == 201
+    assert r.json()["message"] == "Restock alert registered"
+
+    db = TestingSessionLocal()
+    alert = (
+        db.query(RestockAlert)
+        .filter(
+            RestockAlert.email == "restock@example.com",
+            RestockAlert.product_id == pid,
+        )
+        .first()
+    )
+    db.close()
+    assert alert is not None
+
+
+def test_restock_alert_is_idempotent_per_product(client):
+    pid = _seed_product(name="Restock Idem Tee")
+    for _ in range(2):
+        r = client.post(
+            RESTOCK_URL,
+            json={"email": "restock-idem@example.com", "product_id": pid},
+        )
+        assert r.status_code == 201
+
+    db = TestingSessionLocal()
+    count = (
+        db.query(RestockAlert)
+        .filter(
+            RestockAlert.email == "restock-idem@example.com",
+            RestockAlert.product_id == pid,
+        )
+        .count()
+    )
+    db.close()
+    assert count == 1
+
+
+def test_restock_alert_allows_same_email_for_different_products(client):
+    pid_a = _seed_product(name="Restock A Tee")
+    pid_b = _seed_product(name="Restock B Tee")
+    for pid in (pid_a, pid_b):
+        r = client.post(
+            RESTOCK_URL,
+            json={"email": "restock-multi@example.com", "product_id": pid},
+        )
+        assert r.status_code == 201
+
+    db = TestingSessionLocal()
+    count = (
+        db.query(RestockAlert)
+        .filter(RestockAlert.email == "restock-multi@example.com")
+        .count()
+    )
+    db.close()
+    assert count == 2
+
+
+def test_restock_alert_rejects_unknown_product(client):
+    r = client.post(
+        RESTOCK_URL, json={"email": "restock-ghost@example.com", "product_id": 999999}
+    )
+    assert r.status_code == 404
+
+
+def test_restock_alert_rejects_invalid_email(client):
+    pid = _seed_product(name="Restock Bad Email Tee")
+    r = client.post(RESTOCK_URL, json={"email": "not-an-email", "product_id": pid})
+    assert r.status_code == 422

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -34,11 +34,25 @@ Formats a price in USD into a locale-formatted currency string with symbol.
 ### Stock Simulator
 Module path: `js/stock-simulator.js`
 
-#### `getStockInfo(size)`
-Retrieves real-time stock status and item quantity for a specific product size.
+Drives the product page stock/availability UI from the **real** `stock` value
+returned by `GET /api/products/{id}` — no hardcoded mock inventory. The
+"Notify Me" restock form persists the email server-side via
+`POST /api/newsletter/restock` (`{ email, product_id }`).
+
+#### `getStockInfo(stock)`
+Derives stock status from a numeric stock count.
 - **Parameters**:
-  - `size` (string): Size key (e.g., `'Small'`, `'Medium'`, `'Large'`, `'XL'`, `'XXL'`).
-- **Returns**: `Object` - `{ count: number, status: 'normal' | 'low' | 'out' }`.
+  - `stock` (number): The product's current stock count.
+- **Returns**: `Object` - `{ count: number, status: 'normal' | 'low' | 'out' | 'unknown' }`.
+
+#### `startStockReservationTimer(durationSeconds, onTick, onExpire)`
+Runs a countdown that invokes `onTick(remaining)` each second and
+`onExpire()` when it reaches zero.
+
+#### `initStockSimulator()`
+Binds the size selector to the stock-alert container and loads the real
+stock for the product in `localStorage['selectedProduct']`. When stock is 0
+it renders the restock form, whose submit calls `POST /api/newsletter/restock`.
 
 ---
 

--- a/js/stock-simulator.js
+++ b/js/stock-simulator.js
@@ -1,17 +1,18 @@
-// Size-specific Stock Level Tracker & Inventory Reservation Engine
+// Real stock level tracker & inventory reservation engine.
+//
+// Stock display is driven by the actual `stock` value served by
+// `GET /api/products/{id}` — no hardcoded mock inventory. The "Notify Me"
+// restock form persists the email server-side via `POST /api/newsletter/restock`.
 
-export const mockStockData = {
-  'Select Size': { count: 100, status: 'normal' },
-  XL: { count: 0, status: 'out' },
-  XXL: { count: 2, status: 'low' },
-  Small: { count: 15, status: 'normal' },
-  Medium: { count: 1, status: 'low' },
-  Large: { count: 0, status: 'out' },
-};
+const API_BASE_URL = window.API_BASE_URL || '';
+const LOW_STOCK_THRESHOLD = 5;
 
-export function getStockInfo(size) {
-  if (!size) return { count: 0, status: 'unknown' };
-  return mockStockData[size] || { count: 5, status: 'normal' };
+export function getStockInfo(stock) {
+  const count = Number(stock);
+  if (!Number.isFinite(count) || count < 0) return { count: 0, status: 'unknown' };
+  if (count <= 0) return { count: 0, status: 'out' };
+  if (count <= LOW_STOCK_THRESHOLD) return { count, status: 'low' };
+  return { count, status: 'normal' };
 }
 
 export function startStockReservationTimer(durationSeconds, onTick, onExpire) {
@@ -31,6 +32,116 @@ export function startStockReservationTimer(durationSeconds, onTick, onExpire) {
   return interval;
 }
 
+function getSelectedProductId() {
+  try {
+    const stored = JSON.parse(localStorage.getItem('selectedProduct') || 'null');
+    if (stored && stored.id) return stored.id;
+  } catch (error) {
+    console.warn('[StockSimulator] Could not read selected product:', error);
+  }
+  return null;
+}
+
+function fetchProductStock(productId) {
+  if (window.CaraAPI && typeof window.CaraAPI.fetchData === 'function') {
+    return window.CaraAPI.fetchData(`/api/products/${productId}`, {
+      headers: { Accept: 'application/json' },
+    }).then((product) => (product ? product.stock : null));
+  }
+  return fetch(`${API_BASE_URL}/api/products/${productId}`, {
+    headers: { Accept: 'application/json' },
+  })
+    .then((response) => (response.ok ? response.json() : null))
+    .then((product) => (product ? product.stock : null));
+}
+
+function postRestockAlert(productId, email) {
+  if (window.CaraAPI && typeof window.CaraAPI.fetchData === 'function') {
+    return window.CaraAPI.fetchData('/api/newsletter/restock', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, product_id: productId }),
+    });
+  }
+  return fetch(`${API_BASE_URL}/api/newsletter/restock`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, product_id: productId }),
+  }).then((response) => {
+    if (!response.ok) throw new Error('Restock alert request failed');
+    return response.json();
+  });
+}
+
+function renderOutOfStock(container, productId) {
+  container.innerHTML = `
+    <div class="stock-alert-box out-of-stock">
+      <span class="stock-title"><i class="ri-error-warning-fill"></i> Out of Stock!</span>
+      <p class="stock-desc">Get notified when this product returns:</p>
+      <div class="stock-notify-group">
+        <input type="email" id="restock-email" placeholder="Your Email" class="stock-email-input" />
+        <button id="notify-restock-btn" class="stock-notify-btn">Notify Me</button>
+      </div>
+      <span id="restock-feedback" class="stock-feedback"></span>
+    </div>
+  `;
+  const btn = document.getElementById('notify-restock-btn');
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    const emailInput = document.getElementById('restock-email');
+    const feedback = document.getElementById('restock-feedback');
+    const email = emailInput ? emailInput.value.trim() : '';
+
+    if (!email || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
+      if (feedback) {
+        feedback.textContent = 'Please provide a valid email address.';
+        feedback.className = 'stock-feedback error';
+      }
+      return;
+    }
+
+    btn.disabled = true;
+    postRestockAlert(productId, email)
+      .then(() => {
+        if (feedback) {
+          feedback.textContent = 'Successfully subscribed to Restock alert!';
+          feedback.className = 'stock-feedback success';
+        }
+      })
+      .catch(() => {
+        if (feedback) {
+          feedback.textContent = 'Could not register the alert. Please try again.';
+          feedback.className = 'stock-feedback error';
+        }
+      })
+      .finally(() => {
+        btn.disabled = false;
+      });
+  });
+}
+
+function renderStock(container, stock) {
+  const info = getStockInfo(stock);
+
+  if (info.status === 'out') {
+    renderOutOfStock(container, getSelectedProductId());
+  } else if (info.status === 'low') {
+    container.innerHTML = `
+      <div class="stock-alert-box low-stock">
+        <i class="ri-alert-fill"></i> Only ${info.count} item(s) left in stock! Order soon.
+      </div>
+    `;
+  } else if (info.status === 'normal') {
+    container.innerHTML = `
+      <div class="stock-alert-box in-stock">
+        <i class="ri-checkbox-circle-fill"></i> In stock! Ready to ship.
+      </div>
+    `;
+  } else {
+    container.innerHTML = '';
+  }
+}
+
 export function initStockSimulator() {
   if (typeof document === 'undefined') return;
   const sizeSelect =
@@ -39,49 +150,25 @@ export function initStockSimulator() {
 
   if (!sizeSelect || !stockContainer) return;
 
-  sizeSelect.addEventListener('change', (e) => {
-    const size = e.target.value;
-    const info = getStockInfo(size);
+  const productId = getSelectedProductId();
 
-    if (info.status === 'out') {
-      stockContainer.innerHTML = `
-        <div class="stock-alert-box out-of-stock">
-          <span class="stock-title"><i class="ri-error-warning-fill"></i> Out of Stock!</span>
-          <p class="stock-desc">Get notified when this size returns:</p>
-          <div class="stock-notify-group">
-            <input type="email" id="restock-email" placeholder="Your Email" class="stock-email-input" />
-            <button id="notify-restock-btn" class="stock-notify-btn">Notify Me</button>
-          </div>
-          <span id="restock-feedback" class="stock-feedback"></span>
-        </div>
-      `;
-      const btn = document.getElementById('notify-restock-btn');
-      if (btn) {
-        btn.addEventListener('click', () => {
-          const emailInput = document.getElementById('restock-email');
-          const feedback = document.getElementById('restock-feedback');
-          const email = emailInput ? emailInput.value.trim() : '';
-          if (email && feedback) {
-            feedback.textContent = 'Successfully subscribed to Restock alert!';
-            feedback.className = 'stock-feedback success';
-          } else if (feedback) {
-            feedback.textContent = 'Please provide a valid email address.';
-            feedback.className = 'stock-feedback error';
-          }
-        });
-      }
-    } else if (info.status === 'low') {
-      stockContainer.innerHTML = `
-        <div class="stock-alert-box low-stock">
-          <i class="ri-alert-fill"></i> Only ${info.count} item(s) left in stock! Order soon.
-        </div>
-      `;
-    } else {
-      stockContainer.innerHTML = `
-        <div class="stock-alert-box in-stock">
-          <i class="ri-checkbox-circle-fill"></i> Size available! Ready to ship.
-        </div>
-      `;
+  if (productId) {
+    fetchProductStock(productId)
+      .then((stock) => renderStock(stockContainer, stock))
+      .catch(() => {
+        stockContainer.innerHTML = '';
+      });
+  } else {
+    stockContainer.innerHTML = '';
+  }
+
+  sizeSelect.addEventListener('change', () => {
+    // The backend tracks per-product stock (not per size); keep the status box
+    // in sync with the real count on every change.
+    if (productId) {
+      fetchProductStock(productId)
+        .then((stock) => renderStock(stockContainer, stock))
+        .catch(() => {});
     }
   });
 }

--- a/singleProduct.html
+++ b/singleProduct.html
@@ -42,6 +42,7 @@
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="recently-viewed.css">
     <link rel="stylesheet" href="reviews.css">
+    <link rel="stylesheet" href="stock-alert.css">
     <link href="https://cdn.jsdelivr.net/npm/remixicon@4.5.0/fonts/remixicon.css" rel="stylesheet" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css"
         integrity="sha512-Kc323vGBEqzTmouAECnVceyQqyqdsSiqLQISBL29aUW4U/M7pSPA/gEUZQqv1cwx4OnYxTxve5UMg5GT6L4JJg=="
@@ -120,6 +121,7 @@
                 <option>XXL</option>
                 <option>XXXL</option>
             </select>
+            <div id="stock-alert-container" aria-live="polite"></div>
             <div class="product-size-guide-container" style="margin: 10px 0;">
               <button id="btn-size-fit-guide" type="button" class="normal" style="background: #088178; color: #fff; border: none; padding: 8px 12px; border-radius: 4px; cursor: pointer;">
                 📏 Find My Fit Size
@@ -346,6 +348,7 @@
 
     <script type="module" src="products.js?v=1779120917220"></script>
     <script type="module" src="js/product-review-aggregator.js"></script>
+    <script type="module" src="js/stock-simulator.js"></script>
     <script type="module" src="app.js?v=1779120917220"></script>
 <!-- csritik-max -->
 <div class="toast" id="toast">

--- a/tests/unit/stock-simulator.test.js
+++ b/tests/unit/stock-simulator.test.js
@@ -1,27 +1,37 @@
-import { describe, it, expect, vi } from 'vitest';
-import { getStockInfo, startStockReservationTimer, mockStockData } from '../../js/stock-simulator.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  getStockInfo,
+  startStockReservationTimer,
+} from '../../js/stock-simulator.js';
 
 describe('Stock Simulator Unit Tests', () => {
-  it('should return stock details for a valid size', () => {
-    const info = getStockInfo('Small');
+  it('should return normal stock info for a plentiful count', () => {
+    const info = getStockInfo(15);
     expect(info).toEqual({ count: 15, status: 'normal' });
   });
 
-  it('should return low stock info for XXL size', () => {
-    const info = getStockInfo('XXL');
+  it('should return low stock info for a low count', () => {
+    const info = getStockInfo(2);
     expect(info.status).toBe('low');
     expect(info.count).toBe(2);
   });
 
-  it('should return out of stock status for XL size', () => {
-    const info = getStockInfo('XL');
+  it('should return out of stock status for a zero count', () => {
+    const info = getStockInfo(0);
     expect(info.status).toBe('out');
     expect(info.count).toBe(0);
   });
 
-  it('should return default stock info for unknown size', () => {
-    const info = getStockInfo('UnknownSize');
-    expect(info).toEqual({ count: 5, status: 'normal' });
+  it('should return out of stock for negative counts', () => {
+    const info = getStockInfo(-3);
+    expect(info.status).toBe('out');
+  });
+
+  it('should return unknown status for non-numeric stock', () => {
+    const info = getStockInfo(null);
+    expect(info).toEqual({ count: 0, status: 'unknown' });
+    const infoEmpty = getStockInfo(undefined);
+    expect(infoEmpty).toEqual({ count: 0, status: 'unknown' });
   });
 
   it('should execute stock reservation timer callback correctly', () => {
@@ -30,7 +40,7 @@ describe('Stock Simulator Unit Tests', () => {
     const onExpire = vi.fn();
 
     const interval = startStockReservationTimer(3, onTick, onExpire);
-    
+
     vi.advanceTimersByTime(1000);
     expect(onTick).toHaveBeenCalledWith(2);
 
@@ -39,13 +49,6 @@ describe('Stock Simulator Unit Tests', () => {
 
     clearInterval(interval);
     vi.useRealTimers();
-  });
-
-  it('should return unknown status when size parameter is empty or null', () => {
-    const infoNull = getStockInfo(null);
-    expect(infoNull).toEqual({ count: 0, status: 'unknown' });
-    const infoEmpty = getStockInfo('');
-    expect(infoEmpty).toEqual({ count: 0, status: 'unknown' });
   });
 
   it('should expire immediately for a zero or negative duration', () => {


### PR DESCRIPTION
## Problem

The product page's stock/availability UI was driven by a **hardcoded client-side mock** (`js/stock-simulator.js`) with no relationship to the real `products.stock` the backend serves — every product showed the same fictional per-size counts. The "Notify Me" restock form only flipped DOM text; no request was made and no email was persisted anywhere.

## Fix

- **`js/stock-simulator.js`**: removed `mockStockData`. Stock status is now derived from the real `stock` value fetched from `GET /api/products/{id}` (via the existing `window.CaraAPI`/`fetch`); `getStockInfo(stock)` is a pure function of the actual count.
- **Restock alerts are real now**: the "Notify Me" form POSTs `{ email, product_id }` to the new `POST /api/newsletter/restock` endpoint and reflects success/failure in the DOM (with email validation).
- **Backend**: added the `restock_alerts` table (`RestockAlert` model + Alembic migration `f3e5d7c9b1a2`) with a unique `(email, product_id)` constraint and a new `POST /api/newsletter/restock` handler that verifies the product exists and upserts the alert (idempotent, generic response).
- **`singleProduct.html`**: wired the module in — added `js/stock-simulator.js`, the `stock-alert.css` stylesheet, and the `#stock-alert-container` element so the feature actually runs.
- Updated `tests/unit/stock-simulator.test.js` to the real-count API and `docs/API_REFERENCE.md`.

> Note: the backend tracks per-product stock only (not per-size), so the status box reflects the product's real stock regardless of the selected size; the size dropdown is left intact for cart selection.

## Files changed

- `js/stock-simulator.js`
- `singleProduct.html`
- `backend/app/api/newsletter.py`
- `backend/app/models.py`
- `backend/alembic/versions/f3e5d7c9b1a2_add_restock_alerts.py` (new)
- `backend/tests/test_restock.py` (new)
- `tests/unit/stock-simulator.test.js`
- `docs/API_REFERENCE.md`

## Testing

- New `backend/tests/test_restock.py` (5 tests): registers an alert; idempotent per product; same email for multiple products; rejects unknown products (404); rejects invalid emails (422) — all pass.
- Full backend suite: 106 passed / 13 failed / 5 errors — the failures/errors are identical to the pre-existing `origin/main` baseline.
- `node --check` passes for `stock-simulator.js` and its unit test. (Vitest workers cannot start in this environment — a pre-existing limitation, also why `npm test`/husky already fails.)

Closes #6156
