### PR TITLE
fix: keep password-reset token out of emailed URL and add no-referrer

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -311,24 +311,32 @@ def refresh_access_token(request: Request, response: Response, db: Session = Dep
 def send_password_reset_email(recipient: str, token: str) -> bool:
     """Send a password reset email with a one-click reset link.
 
+    The reset secret is deliberately NOT embedded in the emailed URL query
+    string: the link opens the reset page where the user submits their email
+    and a new password, and the server mints the token in the POST response.
+    This keeps the token out of URLs, history, and Referer headers.
+
     Returns False when SMTP is not configured so callers can fall back to
     returning the token to the client (the flow the frontend already uses).
     """
     if not SMTP_HOST:
         return False
 
-    reset_link = f"{APP_BASE_URL.rstrip('/')}/forgotPassword.html?token={token}"
+    reset_link = f"{APP_BASE_URL.rstrip('/')}/forgotPassword.html"
     subject = "Cara - Reset your password"
     text = (
         "Hi,\n\n"
-        "We received a request to reset your password. Click the link below "
-        f"to choose a new password (valid for 1 hour):\n\n{reset_link}\n\n"
+        "We received a request to reset your password. Open the link below, "
+        "then enter your email address and choose a new password "
+        "(your reset request is valid for 1 hour):\n\n"
+        f"{reset_link}\n\n"
         "If you didn't request this, you can safely ignore this email.\n\n"
         "- The Cara Team"
     )
     html = (
-        "<p>We received a request to reset your password. Click the link below "
-        "to choose a new password (valid for 1 hour):</p>"
+        "<p>We received a request to reset your password. Open the link below, "
+        "then enter your email address and choose a new password "
+        "(your reset request is valid for 1 hour):</p>"
         f'<p><a href="{reset_link}">Reset my password</a></p>'
         "<p>If you didn't request this, you can safely ignore this email.</p>"
     )

--- a/forgotPassword.html
+++ b/forgotPassword.html
@@ -4,6 +4,7 @@
     <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="referrer" content="no-referrer" />
 
     <title>Forgot Password | Cara</title>
 


### PR DESCRIPTION
## Problem

The password-reset token was embedded in the **URL query string** of the emailed link (`{APP_BASE_URL}/forgotPassword.html?token=<token>`). The reset page loads third-party CDN resources (jsdelivr, cdnjs), and static pages set no `Referrer-Policy`, so opening the link sent the full URL — including the token — in the `Referer` header to those third parties. The token was also exposed in browser history, logs, and any shared/bookmarked link.

## Fix

- **No more secret in the URL**: `send_password_reset_email` now links to `{APP_BASE_URL}/forgotPassword.html` (no `?token=...`). The user opens the link, enters their email and a new password on the page, and the existing client flow completes the reset — `POST /api/auth/forgot-password` mints the token server-side and returns it in the POST response body, which `forgotPassword.js` already passes to `POST /api/auth/reset-password`. Email text/HTML updated to match.
- **`Referrer-Policy: no-referrer` meta tag** on `forgotPassword.html`: even if a legacy `?token=` link is clicked, the reset page no longer leaks the full URL in `Referer` to the third-party stylesheets/fonts it loads.

## Files changed

- `backend/app/api/auth.py`
- `forgotPassword.html`

## Testing

- `backend/tests/test_password_reset.py` + `test_auth.py`: 14 passed, 2 failed — both failures (`test_reset_password_valid_token` "testuser" UNIQUE collision and `test_register_success` 409) reproduce identically on the `origin/main` baseline and are unrelated to this change.

Closes #6159
