### PR TITLE
fix: promo codes can no longer stack on site-wide sales (#6296)

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,6 +11,12 @@
       POINTS_PER_RUPEE: 10,
       DEFAULT_BALANCE: 150,
     },
+    // Site-wide sales auto-applied to matching product categories at checkout.
+    // Promo codes are exclusive and can NEVER stack on top of these
+    // ("Best Offer Only", #6296).
+    SITE_WIDE_SALES: {
+      formal: 20,
+    },
   };
   window.CARA_COUPONS = {
     CARA20: 20,

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -2,5 +2,6 @@ venv/
 __pycache__/
 *.pyc
 cara.db
+test.db
 faiss_index.bin
 faiss_embeddings.npz

--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -17,6 +17,12 @@ RETURN_WINDOW_DAYS = 30
 # Statuses a carrier/admin may move an order through.
 ORDER_STATUSES = {"PENDING", "CONFIRMED", "SHIPPED", "DELIVERED", "CANCELLED"}
 
+# Site-wide sales auto-applied to matching product categories. These are
+# exclusive: a promo code can NEVER stack on top of them ("Best Offer Only").
+# This blocks the discount-stacking exploit that let a promo code eat into
+# the margin of an item already discounted by a site-wide sale (#6296).
+SITE_WIDE_SALES = {"formal": 20}
+
 
 def return_deadline(order: models.Order) -> datetime | None:
     """Algorithmically compute the immutable return deadline.
@@ -164,6 +170,7 @@ def create_order(
         )
 
     subtotal = 0.0
+    sale_discount = 0.0
     db_items = []
 
     # --- Fetch all products in a single query to prevent N+1 issue ---
@@ -200,6 +207,11 @@ def create_order(
         real_price = db_product.price
         subtotal += real_price * item.quantity
 
+        # Accumulate the auto-applied site-wide sale discount per category.
+        sale_pct = SITE_WIDE_SALES.get((db_product.category or "").lower())
+        if sale_pct:
+            sale_discount += real_price * item.quantity * sale_pct / 100
+
         db_items.append(
             models.OrderItem(
                 product_id=db_product.id,
@@ -212,6 +224,7 @@ def create_order(
     shipping = 0.0 if subtotal >= 3000 else 150.0
     tax = round(subtotal * 0.18, 2)
     discount = 0.0
+    discount_source = None
 
     # --- Coupon Validation ---
     # Coupons are percentage-off codes defined in a static map that mirrors
@@ -230,7 +243,23 @@ def create_order(
                 detail="Invalid or inactive coupon code"
             )
 
-        discount = round(subtotal * discount_percentage / 100, 2)
+        promo_discount = round(subtotal * discount_percentage / 100, 2)
+
+        # Strict exclusivity (#6296): never stack a promo code on top of an
+        # active site-wide sale. Apply only the better offer.
+        if sale_discount > 0:
+            if promo_discount > sale_discount:
+                discount = promo_discount
+                discount_source = "promo"
+            else:
+                discount = round(sale_discount, 2)
+                discount_source = "site-wide-sale"
+        else:
+            discount = promo_discount
+            discount_source = "promo"
+    elif sale_discount > 0:
+        discount = round(sale_discount, 2)
+        discount_source = "site-wide-sale"
 
     grand_total = max(0, subtotal + tax + shipping - discount)
 
@@ -270,7 +299,13 @@ def create_order(
 
     return {
         "message": "Order created successfully",
-        "order_id": new_order.id
+        "order_id": new_order.id,
+        "subtotal": subtotal,
+        "shipping": shipping,
+        "tax": tax,
+        "discount": discount,
+        "discount_source": discount_source,
+        "grand_total": grand_total,
     }
 
 CANCELLABLE_WINDOW_HOURS = 24

--- a/backend/tests/test_order_discount_exclusivity.py
+++ b/backend/tests/test_order_discount_exclusivity.py
@@ -1,0 +1,135 @@
+"""Discount exclusivity: promo codes can never stack on site-wide sales.
+
+Regression tests for https://github.com/janavipandole/Cara/issues/6296 —
+POST /api/orders/ previously applied a promo code on top of the auto-applied
+site-wide sale, giving the customer BOTH discounts and eroding margin. The
+backend must now apply only the better offer ("Best Offer Only").
+
+Totals for the seeded cart (2x formal Tee @ ₹500, subtotal ₹1000):
+  shipping ₹150, tax ₹180 (18%). A 20% discount gives ₹200 off → grand ₹1130.
+  The old stacking bug would apply ₹200 sale + ₹200 promo = ₹400 → grand ₹930.
+"""
+import app.api.orders as orders_api
+from passlib.context import CryptContext
+
+from app.models import Product, User
+from tests.conftest import TestingSessionLocal
+
+ORDERS_URL = "/api/orders/"
+pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+USER_EMAIL = "discountexclusivity@example.com"
+
+PRICE = 500.0
+QTY = 2
+SALE_DISCOUNT = round(PRICE * QTY * 20 / 100, 2)  # 200.0
+
+
+def _auth_headers(client):
+    db = TestingSessionLocal()
+    user = db.query(User).filter(User.email == USER_EMAIL).first()
+    if user is None:
+        user = User(
+            username="discountexclusivity",
+            email=USER_EMAIL,
+            hashed_password=pwd.hash("Test@1234"),
+        )
+        db.add(user)
+        db.commit()
+    db.close()
+
+    response = client.post(
+        "/api/auth/login",
+        json={"email": USER_EMAIL, "password": "Test@1234"},
+    )
+    assert response.status_code == 200, response.text
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+def _seed_product(name, category, price=PRICE, stock=100):
+    db = TestingSessionLocal()
+    product = Product(
+        brand="TestBrand",
+        name=name,
+        price=price,
+        img="img.jpg",
+        rating=4,
+        category=category,
+        subcategory="top",
+        color="white",
+        style="casual",
+        stock=stock,
+    )
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+    product_id = product.id
+    db.close()
+    return product_id
+
+
+def _create_order(client, product_id, coupon=None):
+    headers = _auth_headers(client)
+    payload = {
+        "fullName": "Exclusivity User",
+        "email": USER_EMAIL,
+        "address": "1 Test St",
+        "city": "Testville",
+        "zip": "12345",
+        "items": [{"product_id": product_id, "quantity": QTY}],
+    }
+    if coupon:
+        payload["coupon"] = coupon
+    response = client.post(ORDERS_URL, json=payload, headers=headers)
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+def test_site_wide_sale_applied_without_coupon(client):
+    product_id = _seed_product("Formal Sale Tee", category="formal")
+    data = _create_order(client, product_id)
+
+    assert data["discount"] == SALE_DISCOUNT
+    assert data["discount_source"] == "site-wide-sale"
+    assert data["grand_total"] == 1130.0
+
+
+def test_promo_not_stacked_on_site_wide_sale(client):
+    product_id = _seed_product("Formal Stack Tee", category="formal")
+    data = _create_order(client, product_id, coupon="CARA20")
+
+    # CARA20 (20%) ties the site-wide sale (20%) — sale wins the tie. Total
+    # discount must be ₹200 (ONE offer), never ₹400 (stacked).
+    assert data["discount"] == SALE_DISCOUNT
+    assert data["discount_source"] == "site-wide-sale"
+    assert data["grand_total"] == 1130.0
+
+
+def test_weaker_promo_loses_to_site_wide_sale(client):
+    product_id = _seed_product("Formal Weak Promo Tee", category="formal")
+    data = _create_order(client, product_id, coupon="WELCOME10")
+
+    # WELCOME10 (10% = ₹100) is worse than the 20% sale (₹200).
+    assert data["discount"] == SALE_DISCOUNT
+    assert data["discount_source"] == "site-wide-sale"
+    assert data["grand_total"] == 1130.0
+
+
+def test_promo_wins_when_better_than_sale(client, monkeypatch):
+    # A smaller sale (5%) makes the CARA20 promo the better offer.
+    monkeypatch.setattr(orders_api, "SITE_WIDE_SALES", {"formal": 5})
+    product_id = _seed_product("Formal Promo Wins Tee", category="formal")
+    data = _create_order(client, product_id, coupon="CARA20")
+
+    assert data["discount"] == 200.0
+    assert data["discount_source"] == "promo"
+    assert data["grand_total"] == 1130.0
+
+
+def test_promo_applies_normally_outside_sale_category(client):
+    product_id = _seed_product("Minimal Tee", category="minimal")
+    data = _create_order(client, product_id, coupon="CARA20")
+
+    assert data["discount"] == 200.0
+    assert data["discount_source"] == "promo"
+    assert data["grand_total"] == 1130.0

--- a/cart.html
+++ b/cart.html
@@ -64,6 +64,7 @@
     }
   </script>
     <script type="module" src="js/config.js"></script>
+    <script type="module" src="js/promo-exclusivity-engine.js"></script>
   <script src="assets/js/skip-link.js" defer></script>
 </head>
 

--- a/checkout.html
+++ b/checkout.html
@@ -33,6 +33,7 @@
   </script>
   <meta name="description" content="Cara - The best ecommerce store for modern fashion and clothing.">
     <script type="module" src="js/config.js"></script>
+    <script type="module" src="js/promo-exclusivity-engine.js"></script>
   <script src="assets/js/skip-link.js" defer></script>
 </head>
 <body>

--- a/checkout.js
+++ b/checkout.js
@@ -2,6 +2,9 @@ import { createFocusTrap } from './js/a11y-focus-trap.js';
 let checkoutIdempotencyKey = null;
 let checkoutWakeLock = null;
 let isCheckoutProcessing = false;
+// Lazily-loaded product catalog (id/name -> category) used to resolve which
+// cart items are affected by an active site-wide sale (#6296).
+let productCatalog = null;
 
 async function requestWakeLock() {
   if ('wakeLock' in navigator && isCheckoutProcessing) {
@@ -602,7 +605,16 @@ window.updateCheckoutSummary = function () {
   const couponCode = localStorage.getItem('appliedCoupon') || '';
   const COUPONS = window.CARA_COUPONS || {};
   const couponPct = COUPONS[couponCode] || 0;
-  const couponDiscountCents = Math.round(subtotalCents * couponPct / 100);
+
+  // Strict exclusivity validation (#6296): a promo code can never stack on top
+  // of an automatically-applied site-wide sale. The engine resolves each cart
+  // item's category from the product catalog and keeps only the better offer.
+  const catalog = productCatalog || { byId: new Map(), byName: new Map() };
+  const exclusivity = new PromoExclusivityEngine({ catalog }).evaluate(cart, couponPct);
+  const siteWideDiscountCents = Math.round(exclusivity.siteWideDiscount * 100);
+  const promoRejected = exclusivity.rejectedSource === 'promo';
+  const couponDiscountCents = promoRejected ? 0 : Math.round(exclusivity.promoDiscount * 100);
+  const appliedDiscountCents = Math.round(exclusivity.appliedDiscount * 100);
 
   // Check urgency discount if the timer is running
   const hasUrgency =
@@ -633,7 +645,7 @@ window.updateCheckoutSummary = function () {
     subtotalCents +
       taxCents +
       giftChargeCents -
-      couponDiscountCents -
+      appliedDiscountCents -
       urgencyDiscountCents -
       loyaltyDiscountCents,
   );
@@ -645,9 +657,10 @@ window.updateCheckoutSummary = function () {
   const taxEl = document.getElementById('summary-tax');
   if (taxEl) taxEl.textContent = formatCurrency(taxCents);
 
-  // Update Coupon Row
+  // Update Coupon Row — hidden when the promo code was rejected by the
+  // exclusivity engine so the customer sees the site-wide sale applied instead.
   let couponRow = document.getElementById('summaryDiscountRow');
-  if (couponCode) {
+  if (couponCode && !promoRejected) {
     if (!couponRow) {
       couponRow = document.createElement('div');
       couponRow.className = 'total-row summary-row discount';
@@ -684,6 +697,50 @@ window.updateCheckoutSummary = function () {
     }
   } else {
     if (couponRow) couponRow.remove();
+  }
+
+  // Update Site-Wide Sale Row (auto-applied, never stacked with a promo code)
+  let siteWideSaleRow = document.getElementById('site-wide-sale-row');
+  const salePct =
+    exclusivity.categories.length > 0
+      ? exclusivity.categories
+          .map((category) => (window.CARA_CONFIG && window.CARA_CONFIG.SITE_WIDE_SALES[category]) || 0)
+          .reduce((max, pct) => Math.max(max, pct), 0)
+      : 0;
+  if (siteWideDiscountCents > 0 && exclusivity.appliedSource === 'sale') {
+    if (!siteWideSaleRow) {
+      siteWideSaleRow = document.createElement('div');
+      siteWideSaleRow.id = 'site-wide-sale-row';
+      siteWideSaleRow.className = 'total-row summary-row discount';
+      siteWideSaleRow.style.cssText =
+        'display:flex; justify-content:space-between; margin-bottom: 8px; color: #ef4444; font-weight: 600;';
+      const grandRow = document.querySelector('.total-row.grand');
+      if (grandRow) grandRow.parentNode.insertBefore(siteWideSaleRow, grandRow);
+    }
+    const saleLabel =
+      salePct > 0
+        ? `Site-wide sale (${salePct}% off ${exclusivity.categories.join(', ')})`
+        : 'Site-wide sale';
+    siteWideSaleRow.innerHTML = `<span>${saleLabel}</span><span>-${formatCurrency(siteWideDiscountCents)}</span>`;
+  } else {
+    if (siteWideSaleRow) siteWideSaleRow.remove();
+  }
+
+  // Exclusivity notice — shown when a promo code was rejected because a
+  // site-wide sale already applies to the cart (#6296).
+  let exclusivityNotice = document.getElementById('summary-exclusivity-notice');
+  if (promoRejected && exclusivity.message) {
+    if (!exclusivityNotice) {
+      exclusivityNotice = document.createElement('div');
+      exclusivityNotice.id = 'summary-exclusivity-notice';
+      exclusivityNotice.style.cssText =
+        'display:flex; margin-bottom: 8px; color: #b45309; font-size: 12px; font-weight: 600; line-height: 1.4;';
+      const divider = document.querySelector('.summary-divider');
+      if (divider) divider.parentNode.insertBefore(exclusivityNotice, divider);
+    }
+    exclusivityNotice.innerHTML = `<span>${exclusivity.message}</span>`;
+  } else if (exclusivityNotice) {
+    exclusivityNotice.remove();
   }
 
   // Update Urgency Row
@@ -771,6 +828,22 @@ function highlightError(el) {
   }
 }
 
+// Load the product catalog once so cart items can be resolved to their
+// category for site-wide sale matching (#6296). Re-renders the summary when
+// the catalog arrives so the auto-applied sale discount appears live.
+function loadProductCatalogForCheckout() {
+  if (productCatalog || !window.PromoExclusivityEngine) return;
+  PromoExclusivityEngine.loadProductCatalog()
+    .then((catalog) => {
+      productCatalog = catalog;
+      window.updateCheckoutSummary();
+    })
+    .catch(() => {
+      // Best-effort only — offline/API failures fall back to no sale discount.
+      productCatalog = {};
+    });
+}
+
 // Call init on DOM ready
 function initCheckoutPage() {
   initCheckoutValidation();
@@ -780,6 +853,7 @@ function initCheckoutPage() {
     renderCheckoutItems();
     window.updateCheckoutSummary();
   });
+  loadProductCatalogForCheckout();
 }
 
 function prefillAccountEmail() {

--- a/js/cart-coupon.js
+++ b/js/cart-coupon.js
@@ -76,12 +76,25 @@
 
       const result = calculator.validateCoupon(code, subtotal);
       if (result.valid) {
-        window.appliedCoupon = result.code;
-        saveAppliedCoupon(result.code);
-        showFeedback('Coupon "' + result.code + '" applied successfully!', 'success');
-        couponInput.classList.remove('is-invalid');
-        couponInput.classList.add('is-valid');
-        window.dispatchEvent(new CustomEvent('couponApplied', { detail: result }));
+        // Exclusivity validation (#6296): a promo code can never be stacked on
+        // top of an auto-applied site-wide sale that gives an equal or better
+        // discount. Reject it up front with a clear message.
+        if (typeof window.PromoExclusivityEngine === 'function') {
+          resolveCartPageExclusivity(result.coupon, subtotal)
+            .then((conflictMessage) => {
+              if (conflictMessage) {
+                showFeedback(conflictMessage, 'error');
+                couponInput.classList.remove('is-valid');
+                couponInput.classList.add('is-invalid');
+                return;
+              }
+              applyValidCoupon(result.code, result);
+            })
+            .catch(() => applyValidCoupon(result.code, result));
+        } else {
+          // No engine (legacy/test environments) — apply synchronously.
+          applyValidCoupon(result.code, result);
+        }
       } else {
         showFeedback(result.message || 'Invalid coupon code.', 'error');
         couponInput.classList.remove('is-valid');
@@ -104,6 +117,52 @@
         couponInput.classList.add('is-invalid');
       }
     }
+  }
+
+  function applyValidCoupon(code, result) {
+    window.appliedCoupon = code;
+    saveAppliedCoupon(code);
+    showFeedback('Coupon "' + code + '" applied successfully!', 'success');
+    couponInput.classList.remove('is-invalid');
+    couponInput.classList.add('is-valid');
+    window.dispatchEvent(new CustomEvent('couponApplied', { detail: result }));
+  }
+
+  function readCart() {
+    try {
+      const raw = JSON.parse(
+        localStorage.getItem('productsInCart') ||
+          localStorage.getItem('cara_cart') ||
+          '[]',
+      );
+      return Array.isArray(raw) ? raw : [];
+    } catch (err) {
+      return [];
+    }
+  }
+
+  // Returns the exclusivity message when the promo code must be rejected, or
+  // null when it may be applied (no conflict / promo is the better offer).
+  function resolveCartPageExclusivity(coupon, subtotal) {
+    if (typeof window.PromoExclusivityEngine !== 'function') {
+      return Promise.resolve(null);
+    }
+    return PromoExclusivityEngine.loadProductCatalog()
+      .then((catalog) => {
+        const engine = new PromoExclusivityEngine({ catalog });
+        const couponValue =
+          coupon.type === 'percent'
+            ? (subtotal * coupon.value) / 100
+            : coupon.type === 'flat'
+              ? Math.min(subtotal, coupon.value)
+              : 0;
+        const result = engine.evaluateByValue(readCart(), couponValue);
+        if (result.conflict && result.rejectedSource === 'promo') {
+          return result.message;
+        }
+        return null;
+      })
+      .catch(() => null);
   }
 
   // ── Remove coupon ────────────────────────────────────────────────────────

--- a/js/config.js
+++ b/js/config.js
@@ -20,6 +20,12 @@
       POINTS_PER_RUPEE: 10,
       DEFAULT_BALANCE: 150,
     },
+    // Site-wide sales auto-applied to matching product categories at checkout.
+    // Promo codes are exclusive and can NEVER stack on top of these
+    // ("Best Offer Only", #6296).
+    SITE_WIDE_SALES: {
+      formal: 20,
+    },
   };
 
   window.CARA_COUPONS = window.CARA_COUPONS || {

--- a/js/coupon-validator.js
+++ b/js/coupon-validator.js
@@ -59,30 +59,81 @@
       return;
     }
 
-    if (Object.prototype.hasOwnProperty.call(COUPONS, code)) {
-      const discountPct = COUPONS[code];
-      window.appliedCoupon = code;
-      saveAppliedCoupon(code);
-
-      showFeedback(
-        `Coupon "${code}" applied! You saved ${discountPct}%.`,
-        'success',
-      );
-      couponInput.classList.remove('is-invalid');
-      couponInput.classList.add('is-valid');
-
-      // Dispatch event to trigger summary re-render
-      window.dispatchEvent(
-        new CustomEvent('couponApplied', { detail: { code, discountPct } }),
-      );
-      if (typeof window.updateCheckoutSummary === 'function') {
-        window.updateCheckoutSummary();
-      }
-    } else {
+    if (!Object.prototype.hasOwnProperty.call(COUPONS, code)) {
       showFeedback('Invalid coupon code. Try CARA20 or WELCOME10.', 'error');
       couponInput.classList.remove('is-valid');
       couponInput.classList.add('is-invalid');
+      return;
     }
+
+    const discountPct = COUPONS[code];
+
+    // Exclusivity validation (#6296): reject the promo code when a site-wide
+    // sale already delivers a better (or equal) discount on the cart. Promo
+    // codes can never be stacked on top of auto-applied site-wide sales.
+    if (typeof window.PromoExclusivityEngine === 'function') {
+      resolveSiteWideSaleConflict(discountPct)
+        .then((conflictMessage) => {
+          if (conflictMessage) {
+            showFeedback(conflictMessage, 'error');
+            couponInput.classList.remove('is-valid');
+            couponInput.classList.add('is-invalid');
+            return;
+          }
+          finalizeCouponApplication(code, discountPct);
+        })
+        .catch(() => finalizeCouponApplication(code, discountPct));
+    } else {
+      // No engine (legacy/test environments) — apply synchronously.
+      finalizeCouponApplication(code, discountPct);
+    }
+  }
+
+  function finalizeCouponApplication(code, discountPct) {
+    window.appliedCoupon = code;
+    saveAppliedCoupon(code);
+
+    showFeedback(
+      `Coupon "${code}" applied! You saved ${discountPct}%.`,
+      'success',
+    );
+    couponInput.classList.remove('is-invalid');
+    couponInput.classList.add('is-valid');
+
+    // Dispatch event to trigger summary re-render
+    window.dispatchEvent(
+      new CustomEvent('couponApplied', { detail: { code, discountPct } }),
+    );
+    if (typeof window.updateCheckoutSummary === 'function') {
+      window.updateCheckoutSummary();
+    }
+  }
+
+  function readCart() {
+    try {
+      const cart = JSON.parse(localStorage.getItem('productsInCart') || '[]');
+      return Array.isArray(cart) ? cart : [];
+    } catch (e) {
+      return [];
+    }
+  }
+
+  // Returns the exclusivity message when the promo code must be rejected,
+  // or null when it may be applied (no conflict / promo is the better offer).
+  function resolveSiteWideSaleConflict(discountPct) {
+    if (typeof window.PromoExclusivityEngine !== 'function') {
+      return Promise.resolve(null);
+    }
+    return PromoExclusivityEngine.loadProductCatalog()
+      .then((catalog) => {
+        const engine = new PromoExclusivityEngine({ catalog });
+        const result = engine.evaluate(readCart(), discountPct);
+        if (result.conflict && result.rejectedSource === 'promo') {
+          return result.message;
+        }
+        return null;
+      })
+      .catch(() => null);
   }
 
   // ── Remove coupon logic ────────────────────────────────────────────────────

--- a/js/promo-exclusivity-engine.js
+++ b/js/promo-exclusivity-engine.js
@@ -1,0 +1,225 @@
+/**
+ * Promo Exclusivity Engine (#6296)
+ *
+ * Enforces a strict "Best Offer Only" pricing rule: a promo code can NEVER be
+ * stacked on top of an automatically-applied site-wide sale. When a conflict
+ * is detected the engine keeps only the discount that delivers the better
+ * value to the customer and rejects the other — patching the discount
+ * stacking exploit that mathematically destroyed line-item profit margins.
+ *
+ * Site-wide sales are declared per product category in
+ * `CARA_CONFIG.SITE_WIDE_SALES` (e.g. `{ formal: 20 }` => 20% off all formal
+ * items). Cart items are persisted without a category field, so the engine
+ * resolves each item's category from the product catalog fetched via
+ * `loadProductCatalog()`.
+ */
+
+class PromoExclusivityEngine {
+  /**
+   * Fetch (and cache) the product catalog so cart items can be resolved to
+   * their category for site-wide sale matching.
+   * @param {Function} [fetchImpl] - injectable fetch for tests
+   * @returns {Promise<{byId: Map, byName: Map}>}
+   */
+  static loadProductCatalog(fetchImpl) {
+    if (PromoExclusivityEngine.cachedCatalog) {
+      return Promise.resolve(PromoExclusivityEngine.cachedCatalog);
+    }
+    if (PromoExclusivityEngine.catalogPromise) {
+      return PromoExclusivityEngine.catalogPromise;
+    }
+
+    const doFetch = fetchImpl || ((url, opts) => window.fetch(url, opts));
+    const baseUrl =
+      (typeof window !== 'undefined' && window.CARA_API_BASE_URL) || '';
+
+    PromoExclusivityEngine.catalogPromise = doFetch(
+      `${baseUrl}/api/products/`,
+      {
+        credentials: 'include',
+      },
+    )
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error(`Failed to load product catalog: ${res.status}`);
+        }
+        return res.json();
+      })
+      .then((products) => {
+        const byId = new Map();
+        const byName = new Map();
+        for (const product of Array.isArray(products) ? products : []) {
+          if (product.id != null)
+            byId.set(Number(product.id), product.category || '');
+          if (product.name) byName.set(product.name, product.category || '');
+        }
+        PromoExclusivityEngine.cachedCatalog = { byId, byName };
+        return PromoExclusivityEngine.cachedCatalog;
+      })
+      .catch((err) => {
+        PromoExclusivityEngine.catalogPromise = null;
+        throw err;
+      });
+
+    return PromoExclusivityEngine.catalogPromise;
+  }
+
+  constructor(options = {}) {
+    this.siteWideSales =
+      options.siteWideSales ||
+      (typeof window !== 'undefined' &&
+        window.CARA_CONFIG &&
+        window.CARA_CONFIG.SITE_WIDE_SALES) ||
+      {};
+    this.catalog =
+      options.catalog || PromoExclusivityEngine.cachedCatalog || null;
+    this.siteWideSaleMessage =
+      options.siteWideSaleMessage ||
+      'This promo code cannot be combined with existing site-wide sales.';
+  }
+
+  isSiteWideSaleActive() {
+    return Object.keys(this.siteWideSales).some(
+      (category) => Number(this.siteWideSales[category]) > 0,
+    );
+  }
+
+  /**
+   * Resolve a cart item's category from an explicit value, the product id, or
+   * the product name (in that order of confidence).
+   * @returns {string}
+   */
+  resolveCategory(item = {}) {
+    if (item.category) return String(item.category).toLowerCase();
+    if (!this.catalog) return '';
+    const byId = this.catalog.byId;
+    const byName = this.catalog.byName;
+    if (item.id != null && byId && byId.has(Number(item.id))) {
+      return String(byId.get(Number(item.id))).toLowerCase();
+    }
+    if (item.name && byName && byName.has(item.name)) {
+      return String(byName.get(item.name)).toLowerCase();
+    }
+    return '';
+  }
+
+  /**
+   * Compute the auto-applied site-wide sale discount for a cart.
+   * @param {Array<{name?, id?, category?, price, quantity?}>} cart
+   * @returns {{discount: number, categories: string[], affectedSubtotal: number}}
+   */
+  getSiteWideSaleDiscount(cart = []) {
+    if (!this.isSiteWideSaleActive()) {
+      return { discount: 0, categories: [], affectedSubtotal: 0 };
+    }
+
+    let discount = 0;
+    let affectedSubtotal = 0;
+    const categories = [];
+
+    for (const item of cart) {
+      const category = this.resolveCategory(item);
+      const pct = Number(this.siteWideSales[category]);
+      if (!pct || pct <= 0) continue;
+
+      const price = parseFloat(item && item.price) || 0;
+      const qty = parseInt(item && item.quantity, 10) || 1;
+      const subtotal = price * qty;
+      affectedSubtotal += subtotal;
+      discount += (subtotal * pct) / 100;
+
+      if (!categories.includes(category)) categories.push(category);
+    }
+
+    return {
+      discount: Number(discount.toFixed(2)),
+      categories,
+      affectedSubtotal: Number(affectedSubtotal.toFixed(2)),
+    };
+  }
+
+  /**
+   * Best-Offer-Only evaluation.
+   *
+   * @param {Array} cart       - cart items (category resolved internally)
+   * @param {number} couponPct - promo code discount percent (0 = no coupon)
+   * @returns {{
+   *   siteWideDiscount: number,
+   *   promoDiscount: number,
+   *   appliedDiscount: number,
+   *   appliedSource: 'sale'|'promo'|'none',
+   *   rejectedSource: 'sale'|'promo'|null,
+   *   conflict: boolean,
+   *   categories: string[],
+   *   message: string|null
+   * }}
+   */
+  evaluate(cart = [], couponPct = 0) {
+    const subtotal = this._cartSubtotal(cart);
+    const promoDiscount = Number(
+      ((subtotal * (Number(couponPct) || 0)) / 100).toFixed(2),
+    );
+    return this._decide(cart, subtotal, promoDiscount);
+  }
+
+  /**
+   * Same best-offer-only decision, but the promo discount is supplied as a
+   * monetary value (useful for flat-amount or free-shipping coupon types).
+   */
+  evaluateByValue(cart = [], promoDiscountValue = 0) {
+    const subtotal = this._cartSubtotal(cart);
+    return this._decide(cart, subtotal, Number(promoDiscountValue) || 0);
+  }
+
+  _cartSubtotal(cart) {
+    return cart.reduce((sum, item) => {
+      const price = parseFloat(item && item.price) || 0;
+      const qty = parseInt(item && item.quantity, 10) || 1;
+      return sum + price * qty;
+    }, 0);
+  }
+
+  _decide(cart, subtotal, promoDiscount) {
+    const { discount: siteWideDiscount, categories } =
+      this.getSiteWideSaleDiscount(cart);
+
+    const hasSale = siteWideDiscount > 0;
+    const hasPromo = promoDiscount > 0 && subtotal > 0;
+
+    // No conflict: apply whichever single discount is present.
+    if (!hasSale || !hasPromo) {
+      return {
+        siteWideDiscount,
+        promoDiscount,
+        appliedDiscount: hasSale ? siteWideDiscount : promoDiscount,
+        appliedSource: hasSale ? 'sale' : hasPromo ? 'promo' : 'none',
+        rejectedSource: null,
+        conflict: false,
+        categories,
+        message: null,
+      };
+    }
+
+    // Conflict — stacking is forbidden. Keep only the better offer.
+    const saleWins = siteWideDiscount >= promoDiscount;
+    return {
+      siteWideDiscount,
+      promoDiscount,
+      appliedDiscount: saleWins ? siteWideDiscount : promoDiscount,
+      appliedSource: saleWins ? 'sale' : 'promo',
+      rejectedSource: saleWins ? 'promo' : 'sale',
+      conflict: true,
+      categories,
+      message: saleWins ? this.siteWideSaleMessage : null,
+    };
+  }
+}
+
+PromoExclusivityEngine.cachedCatalog = null;
+PromoExclusivityEngine.catalogPromise = null;
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = PromoExclusivityEngine;
+} else {
+  window.PromoExclusivityEngine = PromoExclusivityEngine;
+}

--- a/tests/unit/promo-exclusivity-engine.test.js
+++ b/tests/unit/promo-exclusivity-engine.test.js
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import PromoExclusivityEngine from '../../js/promo-exclusivity-engine.js';
+
+const SITE_WIDE_SALES = { formal: 20 };
+const CATALOG = {
+  byId: new Map([
+    [1, 'formal'],
+    [2, 'minimal'],
+  ]),
+  byName: new Map([
+    ['Formal Tee', 'formal'],
+    ['Minimal Tee', 'minimal'],
+  ]),
+};
+
+function buildEngine() {
+  return new PromoExclusivityEngine({
+    siteWideSales: SITE_WIDE_SALES,
+    catalog: CATALOG,
+  });
+}
+
+const formalCart = [{ id: 1, name: 'Formal Tee', price: 500, quantity: 2 }]; // subtotal 1000
+const minimalCart = [{ id: 2, name: 'Minimal Tee', price: 500, quantity: 2 }]; // subtotal 1000
+const emptyCart = [];
+
+beforeEach(() => {
+  PromoExclusivityEngine.cachedCatalog = null;
+  PromoExclusivityEngine.catalogPromise = null;
+});
+
+describe('PromoExclusivityEngine', () => {
+  it('detects an active site-wide sale', () => {
+    expect(buildEngine().isSiteWideSaleActive()).toBe(true);
+  });
+
+  it('is inactive when all sales are zero', () => {
+    const engine = new PromoExclusivityEngine({
+      siteWideSales: { formal: 0 },
+      catalog: CATALOG,
+    });
+    expect(engine.isSiteWideSaleActive()).toBe(false);
+  });
+
+  it('computes the site-wide sale discount for matching categories only', () => {
+    const result = buildEngine().getSiteWideSaleDiscount(formalCart);
+    expect(result.discount).toBe(200);
+    expect(result.categories).toEqual(['formal']);
+    expect(result.affectedSubtotal).toBe(1000);
+  });
+
+  it('does not discount non-sale categories', () => {
+    const result = buildEngine().getSiteWideSaleDiscount(minimalCart);
+    expect(result.discount).toBe(0);
+    expect(result.categories).toEqual([]);
+  });
+
+  it('rejects the promo when the sale equals the promo (never stacks)', () => {
+    const result = buildEngine().evaluate(formalCart, 20);
+    expect(result.conflict).toBe(true);
+    expect(result.rejectedSource).toBe('promo');
+    expect(result.appliedSource).toBe('sale');
+    expect(result.appliedDiscount).toBe(200);
+    expect(result.message).toContain('cannot be combined');
+  });
+
+  it('applies the promo when it beats the site-wide sale', () => {
+    const result = buildEngine().evaluate(formalCart, 30);
+    expect(result.conflict).toBe(true);
+    expect(result.rejectedSource).toBe('sale');
+    expect(result.appliedSource).toBe('promo');
+    expect(result.appliedDiscount).toBe(300);
+  });
+
+  it('applies the sale when no promo is present', () => {
+    const result = buildEngine().evaluate(formalCart, 0);
+    expect(result.conflict).toBe(false);
+    expect(result.appliedSource).toBe('sale');
+    expect(result.appliedDiscount).toBe(200);
+  });
+
+  it('applies the promo normally outside a sale category', () => {
+    const result = buildEngine().evaluate(minimalCart, 20);
+    expect(result.conflict).toBe(false);
+    expect(result.appliedSource).toBe('promo');
+    expect(result.appliedDiscount).toBe(200);
+  });
+
+  it('supports monetary promo values via evaluateByValue', () => {
+    const result = buildEngine().evaluateByValue(formalCart, 150);
+    expect(result.conflict).toBe(true);
+    expect(result.rejectedSource).toBe('promo');
+    expect(result.appliedSource).toBe('sale');
+    expect(result.appliedDiscount).toBe(200);
+  });
+
+  it('handles an empty cart gracefully', () => {
+    const result = buildEngine().evaluate(emptyCart, 20);
+    expect(result.appliedDiscount).toBe(0);
+    expect(result.conflict).toBe(false);
+  });
+
+  it('loads and caches the product catalog from the API', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        { id: 1, name: 'Formal Tee', category: 'formal' },
+        { id: 2, name: 'Minimal Tee', category: 'minimal' },
+      ],
+    });
+
+    const catalog = await PromoExclusivityEngine.loadProductCatalog(fetchImpl);
+    expect(catalog.byId.get(1)).toBe('formal');
+    expect(catalog.byName.get('Minimal Tee')).toBe('minimal');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    const again = await PromoExclusivityEngine.loadProductCatalog(fetchImpl);
+    expect(again).toBe(catalog);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #6296 — promo codes could previously be stacked on top of an automatically-applied **site-wide sale**, giving the customer BOTH discounts and destroying the line-item margin (e.g. a 20% site-wide sale on formal items plus `CARA20` produced a 40% effective discount).

This PR enforces a strict **Best Offer Only** rule: when a promo code conflicts with an active site-wide sale, only the single better discount is applied — never both.

## Changes

### Frontend
- **`js/promo-exclusivity-engine.js`** (new): `PromoExclusivityEngine` loads the product catalog once, resolves each cart item's category, computes the site-wide sale discount, and decides the best single offer (`evaluate` / `evaluateByValue`).
- **`checkout.js`**: summary now shows an auto-applied **site-wide sale row**, hides a rejected promo row, surfaces an **exclusivity notice**, and computes the grand total from the single applied discount.
- **`js/coupon-validator.js` / `js/cart-coupon.js`**: coupon application rejects the promo code up front when a site-wide sale already gives an equal or better discount.
- **`js/config.js` / `app.js`**: declare `SITE_WIDE_SALES = { formal: 20 }` (20% off formal).

### Backend
- **`backend/app/api/orders.py`**: `create_order` mirrors the rule — sale discount accumulated per product category, promo code never stacked, only the better offer applied. Response now returns `discount`, `discount_source`, `subtotal`, `shipping`, `tax`, `grand_total`.

### Tests
- **`tests/unit/promo-exclusivity-engine.test.js`**: engine unit tests (sale-only, promo-only, promo-wins, sale-wins-tie, empty cart, catalog loading/caching).
- **`backend/tests/test_order_discount_exclusivity.py`**: end-to-end order tests verifying discount is never stacked and totals are correct.

## Verification
- `npx vitest run` — all new + related suites pass.
- `python -m pytest backend/tests/test_order_discount_exclusivity.py` — 5/5 pass.
- Pre-existing backend failures in `test_newsletter`, `test_profile`, `test_password_reset`, `test_order_email_match`, `test_admin` and `tests/unit/shared-cart.test.js` reproduce identically on clean `main` (verified by stashing changes) and are unrelated to this PR.
