### PR TITLE
feat: algorithmic predictive search engine (#6295)

### DIFF
--- a/backend/app/api/products.py
+++ b/backend/app/api/products.py
@@ -175,6 +175,85 @@ def get_category_summary(db: Session = Depends(get_db)) -> dict:
     }
 
 
+def _predictive_score(name: str, brand: str, rating: int, q: str) -> int:
+    """Score a product against a partial query for predictive ranking.
+
+    Heuristic used by the algorithmic predictive search engine (#6295):
+      * exact name match          +200
+      * name starts with query    +150
+      * name contains query       +100
+      * brand starts with query   +60
+      * brand contains query      +30
+      * rating boosts to prefer highly-rated matches.
+    """
+    q = q.strip().lower()
+    name_l = (name or "").lower()
+    brand_l = (brand or "").lower()
+
+    score = 0
+    if name_l == q:
+        score += 200
+    elif name_l.startswith(q):
+        score += 150
+    elif q in name_l:
+        score += 100
+
+    if brand_l == q:
+        score += 80
+    elif brand_l.startswith(q):
+        score += 60
+    elif q in brand_l:
+        score += 30
+
+    score += int(rating or 0) * 10
+    return score
+
+
+@router.get("/search/predictive", response_model=schemas.PredictiveSearchResponse)
+def predictive_search(
+    q: Optional[str] = Query(
+        default=None,
+        min_length=1,
+        max_length=60,
+        description="Partial query to predictively match against product name and brand.",
+    ),
+    limit: int = Query(default=3, ge=1, le=10),
+    db: Session = Depends(get_db),
+) -> dict:
+    """
+    Algorithmic predictive search: return the top-N best matches for a
+    partial query as the user types.
+
+    Candidates are any product whose name or brand contains the query; they
+    are ranked by `_predictive_score` (exact/prefix/substring match on the
+    name being worth more than a brand match, with a rating tiebreak) and the
+    top ``limit`` are returned for a rich search-as-you-type dropdown.
+    """
+    query = (q or "").strip()
+    if not query:
+        return {"query": query, "suggestions": []}
+
+    search_term = f"%{query}%"
+    candidates = (
+        db.query(models.Product)
+        .filter(
+            or_(
+                func.lower(models.Product.name).like(func.lower(search_term)),
+                func.lower(models.Product.brand).like(func.lower(search_term)),
+            )
+        )
+        .all()
+    )
+
+    ranked = sorted(
+        candidates,
+        key=lambda p: _predictive_score(p.name, p.brand, p.rating, query),
+        reverse=True,
+    )[:limit]
+
+    return {"query": query, "suggestions": ranked}
+
+
 # ---------------------------------------------------------------------------
 # Product by ID (must stay after literal /search/* paths)
 # ---------------------------------------------------------------------------

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -192,6 +192,30 @@ class PriceRange(BaseModel):
     max: float
 
 
+class PredictiveSearchResult(BaseModel):
+    """A single suggestion returned by GET /api/products/search/predictive.
+
+    Intentionally lightweight: the navbar dropdown only needs enough to render
+    a rich card (thumbnail, price, rating) and wire a one-click add-to-cart.
+    """
+    id: int
+    name: str
+    brand: str
+    price: float
+    img: str
+    rating: int
+    category: str
+
+    class Config:
+        from_attributes = True
+
+
+class PredictiveSearchResponse(BaseModel):
+    """Top-N best-matching products for a partial query, ranked algorithmically."""
+    query: str
+    suggestions: list[PredictiveSearchResult]
+
+
 class ForgotPasswordRequest(BaseModel):
     email: EmailStr
 

--- a/backend/tests/test_predictive_search.py
+++ b/backend/tests/test_predictive_search.py
@@ -1,0 +1,100 @@
+"""
+Tests for GET /api/products/search/predictive (#6295).
+
+Covers:
+  - Literal /search/predictive is not shadowed by /{product_id}
+  - Returns ranked suggestions (exact name match beats substring match)
+  - Rating tiebreak prefers the higher-rated match
+  - limit caps the number of suggestions
+  - Empty/missing query returns no suggestions
+"""
+from app.models import Product
+from tests.conftest import TestingSessionLocal
+
+PREDICTIVE_URL = "/api/products/search/predictive"
+
+
+def _seed(name, brand="SeedBrand", rating=4, price=999.0):
+    db = TestingSessionLocal()
+    p = Product(
+        brand=brand,
+        name=name,
+        price=price,
+        img="img.jpg",
+        rating=rating,
+        category="minimal",
+        subcategory="top",
+        color="blue",
+        style="casual",
+        stock=10,
+    )
+    db.add(p)
+    db.commit()
+    db.refresh(p)
+    pid = p.id
+    db.close()
+    return pid
+
+
+def test_predictive_route_not_shadowed_by_product_id_route(client):
+    """Literal /search/predictive must resolve (not 422 int validation)."""
+    resp = client.get(PREDICTIVE_URL + "?q=shirt")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "query" in body
+    assert "suggestions" in body
+    assert "detail" not in body or not isinstance(body.get("detail"), list)
+
+
+def test_exact_name_match_ranks_highest(client):
+    _seed("Classic Tee", rating=3)
+    _seed("Classic Tee Pro", rating=5)
+    resp = client.get(PREDICTIVE_URL + "?q=classic tee")
+    assert resp.status_code == 200
+    names = [s["name"] for s in resp.json()["suggestions"]]
+    # Exact name match ("Classic Tee") must outrank the substring match.
+    assert names[0] == "Classic Tee"
+
+
+def test_rating_breaks_ties(client):
+    _seed("Denim Jacket A", rating=3)
+    _seed("Denim Jacket B", rating=5)
+    resp = client.get(PREDICTIVE_URL + "?q=denim")
+    assert resp.status_code == 200
+    names = [s["name"] for s in resp.json()["suggestions"]]
+    assert names[0] == "Denim Jacket B"
+    assert names[1] == "Denim Jacket A"
+
+
+def test_limit_caps_suggestions(client):
+    for i in range(6):
+        _seed(f"Cotton Shirt {i}")
+    resp = client.get(PREDICTIVE_URL + "?q=cotton&limit=2")
+    assert resp.status_code == 200
+    suggestions = resp.json()["suggestions"]
+    assert len(suggestions) == 2
+
+
+def test_empty_query_returns_no_suggestions(client):
+    resp = client.get(PREDICTIVE_URL)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["query"] == ""
+    assert body["suggestions"] == []
+
+
+def test_no_match_returns_empty_suggestions(client):
+    resp = client.get(PREDICTIVE_URL + "?q=zzzzznomatch")
+    assert resp.status_code == 200
+    assert resp.json()["suggestions"] == []
+
+
+def test_suggestion_shape(client):
+    pid = _seed("Predictive Shape Tee", rating=4, price=1299.0)
+    resp = client.get(PREDICTIVE_URL + "?q=predictive shape")
+    suggestions = resp.json()["suggestions"]
+    assert len(suggestions) >= 1
+    first = suggestions[0]
+    assert first["id"] == pid
+    for key in ("name", "brand", "price", "img", "rating", "category"):
+        assert key in first

--- a/js/predictive-search.js
+++ b/js/predictive-search.js
@@ -1,0 +1,402 @@
+/**
+ * Algorithmic Predictive Search (#6295)
+ *
+ * Search-as-you-type for the navbar #searchBar. While the user types, the
+ * module queries GET /api/products/search/predictive (which ranks matches
+ * algorithmically by name/brand match quality then rating) and renders a
+ * rich dropdown of up to 3 product cards with thumbnail, price, star rating
+ * and a one-click Add to Cart.
+ *
+ * Self-contained: it wires whatever #searchBar exists when it loads and uses a
+ * MutationObserver to pick up navbars injected later by navbar.js/loadNavbar.
+ */
+
+(function () {
+  'use strict';
+
+  const API_BASE_URL = window.CARA_API_BASE_URL || '';
+  const SUGGESTION_LIMIT = 3;
+  const DEBOUNCE_MS = 220;
+  const MIN_QUERY_LENGTH = 2;
+
+  let panel = null;
+  let activeRequest = null;
+  let debouncedSearch = null;
+  let observer = null;
+
+  const CSS = `
+    .predictive-search-panel {
+      position: fixed;
+      z-index: 2147483000;
+      background: var(--card-bg, #ffffff);
+      border: 1px solid rgba(0, 0, 0, 0.12);
+      border-radius: 12px;
+      box-shadow: 0 8px 30px rgba(0, 0, 0, 0.18);
+      overflow: hidden;
+      display: none;
+      font-family: inherit;
+      max-height: 80vh;
+      overflow-y: auto;
+    }
+    .predictive-search-panel.visible { display: block; }
+    .predictive-search-card {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 10px 12px;
+      cursor: pointer;
+      border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+    }
+    .predictive-search-card:hover,
+    .predictive-search-card.active {
+      background: rgba(8, 129, 120, 0.08);
+    }
+    .predictive-search-thumb {
+      width: 52px;
+      height: 64px;
+      object-fit: cover;
+      border-radius: 8px;
+      background: #f3f3f3;
+      flex: 0 0 auto;
+    }
+    .predictive-search-info {
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+      flex: 1;
+    }
+    .predictive-search-name {
+      font-weight: 600;
+      font-size: 14px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .predictive-search-brand {
+      font-size: 12px;
+      opacity: 0.65;
+    }
+    .predictive-search-meta {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-top: 4px;
+    }
+    .predictive-search-stars { color: #f5a623; font-size: 12px; }
+    .predictive-search-price { font-weight: 700; font-size: 14px; }
+    .predictive-search-add {
+      border: none;
+      background: var(--brand, #088178);
+      color: #fff;
+      border-radius: 8px;
+      padding: 6px 10px;
+      font-size: 12px;
+      font-weight: 700;
+      cursor: pointer;
+      flex: 0 0 auto;
+    }
+    .predictive-search-add:hover { filter: brightness(1.1); }
+  `;
+
+  function injectStyles() {
+    if (document.getElementById('predictive-search-styles')) return;
+    const style = document.createElement('style');
+    style.id = 'predictive-search-styles';
+    style.textContent = CSS;
+    document.head.appendChild(style);
+  }
+
+  function escapeHtml(value) {
+    return String(value == null ? '' : value).replace(
+      /[&<>"']/g,
+      (c) =>
+        ({
+          '&': '&amp;',
+          '<': '&lt;',
+          '>': '&gt;',
+          '"': '&quot;',
+          "'": '&#39;',
+        })[c],
+    );
+  }
+
+  function stars(rating) {
+    const r = Math.max(0, Math.min(5, Math.round(Number(rating)) || 0));
+    return '★'.repeat(r) + '☆'.repeat(5 - r);
+  }
+
+  function debounce(fn, wait) {
+    let timer = null;
+    return function (...args) {
+      clearTimeout(timer);
+      timer = setTimeout(() => fn.apply(this, args), wait);
+    };
+  }
+
+  function createPanel() {
+    panel = document.createElement('div');
+    panel.className = 'predictive-search-panel';
+    panel.setAttribute('role', 'listbox');
+    panel.setAttribute('aria-label', 'Search suggestions');
+    panel.addEventListener('click', onPanelClick);
+    document.body.appendChild(panel);
+    return panel;
+  }
+
+  function positionPanel(input) {
+    if (!panel) return;
+    const rect = input.getBoundingClientRect();
+    panel.style.top = rect.bottom + 6 + 'px';
+    panel.style.left = rect.left + 'px';
+    panel.style.width = Math.max(rect.width, 280) + 'px';
+  }
+
+  function renderPanel(data, input) {
+    const suggestions =
+      data && Array.isArray(data.suggestions) ? data.suggestions : [];
+    if (!suggestions.length) {
+      closePanel();
+      return;
+    }
+    if (!panel) createPanel();
+
+    let html = '';
+    for (const p of suggestions) {
+      const price = Number(p.price) || 0;
+      const safeName = escapeHtml(p.name);
+      html +=
+        `<div class="predictive-search-card" role="option" data-id="${escapeHtml(p.id)}" data-name="${safeName}">` +
+        `<img class="predictive-search-thumb" src="${escapeHtml(p.img)}" alt="${safeName}" loading="lazy" onerror="this.style.visibility='hidden'">` +
+        `<div class="predictive-search-info">` +
+        `<span class="predictive-search-name">${safeName}</span>` +
+        `<span class="predictive-search-brand">${escapeHtml(p.brand || '')}</span>` +
+        `<span class="predictive-search-meta">` +
+        `<span class="predictive-search-stars" aria-label="${escapeHtml(p.rating)} out of 5 stars">${stars(p.rating)}</span>` +
+        `<span class="predictive-search-price">₹${price.toLocaleString('en-IN')}</span>` +
+        `</span></div>` +
+        `<button class="predictive-search-add" type="button" data-id="${escapeHtml(p.id)}" data-name="${safeName}" data-price="${price}" data-img="${escapeHtml(p.img)}" aria-label="Add ${safeName} to cart">Add</button>` +
+        `</div>`;
+    }
+    panel.innerHTML = html;
+    positionPanel(input);
+    panel.classList.add('visible');
+  }
+
+  function closePanel() {
+    if (panel) {
+      panel.classList.remove('visible');
+      panel.innerHTML = '';
+    }
+    if (activeRequest) {
+      activeRequest.abort();
+      activeRequest = null;
+    }
+  }
+
+  function addToCartFromSuggestion(item) {
+    const productId =
+      item.id != null && item.id !== '' ? Number(item.id) : undefined;
+    if (typeof window.addToCart === 'function') {
+      window.addToCart(
+        item.name,
+        Number(item.price),
+        item.img,
+        1,
+        'Standard',
+        productId,
+      );
+    } else {
+      try {
+        const cart = JSON.parse(localStorage.getItem('productsInCart')) || [];
+        cart.push({
+          id: productId,
+          name: item.name,
+          price: Number(item.price),
+          image: item.img,
+          img: item.img,
+          quantity: 1,
+          size: 'Standard',
+        });
+        localStorage.setItem('productsInCart', JSON.stringify(cart));
+      } catch {
+        // Storage unavailable — swallow; the global addToCart path is the norm.
+      }
+    }
+    closePanel();
+  }
+
+  function onPanelClick(event) {
+    const addBtn = event.target.closest('.predictive-search-add');
+    if (addBtn) {
+      event.preventDefault();
+      event.stopPropagation();
+      addToCartFromSuggestion({
+        id: addBtn.dataset.id,
+        name: addBtn.dataset.name,
+        price: addBtn.dataset.price,
+        img: addBtn.dataset.img,
+      });
+      return;
+    }
+    const card = event.target.closest('.predictive-search-card');
+    if (card) {
+      event.preventDefault();
+      openProduct(card.dataset.id, card.dataset.name);
+    }
+  }
+
+  function openProduct(id, name) {
+    try {
+      const selected = {
+        id: Number(id),
+        name,
+        price: '',
+        brand: '',
+        image: '',
+      };
+      const card =
+        panel &&
+        panel.querySelector('.predictive-search-card[data-id="' + id + '"]');
+      if (card) {
+        const priceText = card.querySelector('.predictive-search-price');
+        const brandText = card.querySelector('.predictive-search-brand');
+        const imgEl = card.querySelector('.predictive-search-thumb');
+        if (priceText) selected.price = priceText.textContent;
+        if (brandText) selected.brand = brandText.textContent;
+        if (imgEl) selected.image = imgEl.src;
+      }
+      localStorage.setItem('selectedProduct', JSON.stringify(selected));
+    } catch {
+      // Ignore storage failures.
+    }
+    window.location.href = 'singleProduct.html';
+  }
+
+  async function fetchSuggestions(query) {
+    if (activeRequest) activeRequest.abort();
+    activeRequest = new AbortController();
+    const url =
+      API_BASE_URL +
+      '/api/products/search/predictive?q=' +
+      encodeURIComponent(query) +
+      '&limit=' +
+      SUGGESTION_LIMIT;
+    const res = await fetch(url, {
+      credentials: 'include',
+      signal: activeRequest.signal,
+    });
+    if (!res.ok) throw new Error('Predictive search failed: ' + res.status);
+    return res.json();
+  }
+
+  async function onInput(event) {
+    const input = event.target;
+    const query = input.value.trim();
+    if (query.length < MIN_QUERY_LENGTH) {
+      closePanel();
+      return;
+    }
+    try {
+      const data = await fetchSuggestions(query);
+      if (input.value.trim() !== query) return; // stale response — input changed
+      renderPanel(data, input);
+    } catch (err) {
+      if (!(err && err.name === 'AbortError')) closePanel();
+    }
+  }
+
+  function highlightNext(input, delta) {
+    if (!panel || !panel.classList.contains('visible')) return;
+    const items = panel.querySelectorAll('.predictive-search-card');
+    if (!items.length) return;
+    const current = panel.querySelector('.predictive-search-card.active');
+    let index = current ? Array.prototype.indexOf.call(items, current) : -1;
+    index = (index + delta + items.length) % items.length;
+    items.forEach((el, i) => el.classList.toggle('active', i === index));
+    items[index].scrollIntoView({ block: 'nearest' });
+  }
+
+  function onKeyDown(event) {
+    if (event.key === 'Escape') {
+      closePanel();
+      return;
+    }
+    if (!panel || !panel.classList.contains('visible')) return;
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      highlightNext(event.target, 1);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      highlightNext(event.target, -1);
+    } else if (event.key === 'Enter') {
+      const active = panel.querySelector('.predictive-search-card.active');
+      const first = panel.querySelector('.predictive-search-card');
+      const target = active || first;
+      if (target) {
+        event.preventDefault();
+        target.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      }
+    }
+  }
+
+  function onDocumentClick(event) {
+    if (panel && panel.classList.contains('visible')) {
+      if (
+        event.target.closest &&
+        !event.target.closest('#searchBar') &&
+        !event.target.closest('.predictive-search-panel')
+      ) {
+        closePanel();
+      }
+    }
+  }
+
+  function onReposition() {
+    const input = document.getElementById('searchBar');
+    if (input && panel && panel.classList.contains('visible'))
+      positionPanel(input);
+  }
+
+  function wireSearchBar() {
+    const input = document.getElementById('searchBar');
+    if (!input || input.dataset.predictiveWired) return;
+    input.dataset.predictiveWired = '1';
+
+    debouncedSearch = debounce(onInput, DEBOUNCE_MS);
+    input.addEventListener('input', debouncedSearch);
+    input.addEventListener('keydown', onKeyDown);
+    input.addEventListener('blur', () => {
+      setTimeout(() => {
+        if (document.activeElement !== input) closePanel();
+      }, 150);
+    });
+    input.addEventListener('focus', () => {
+      if (input.value.trim().length >= MIN_QUERY_LENGTH)
+        debouncedSearch({ target: input });
+    });
+  }
+
+  function init() {
+    injectStyles();
+    wireSearchBar();
+
+    if (typeof MutationObserver !== 'undefined' && !observer) {
+      observer = new MutationObserver(() => {
+        if (!document.getElementById('searchBar')) return;
+        wireSearchBar();
+        observer.disconnect();
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+    }
+
+    document.addEventListener('click', onDocumentClick);
+    window.addEventListener('scroll', onReposition, { passive: true });
+    window.addEventListener('resize', onReposition);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/navbar.js
+++ b/navbar.js
@@ -1,3 +1,5 @@
+import('./js/predictive-search.js').catch(() => {});
+
 function loadNavbar(activePage) {
   const navbarHTML = `
     <div class="search-container" role="search">

--- a/tests/unit/predictive-search.test.js
+++ b/tests/unit/predictive-search.test.js
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const suggestions = [
+  {
+    id: 1,
+    name: 'Classic Tee',
+    brand: 'Cara',
+    price: 999,
+    img: 'img1.jpg',
+    rating: 4,
+    category: 'minimal',
+  },
+  {
+    id: 2,
+    name: 'Denim Jacket',
+    brand: 'Cara',
+    price: 1999,
+    img: 'img2.jpg',
+    rating: 5,
+    category: 'street',
+  },
+];
+
+function setupDom() {
+  document.body.innerHTML = `
+    <div class="search-container">
+      <input type="text" id="searchBar" placeholder="Search products...">
+    </div>
+  `;
+}
+
+function typeAndWait(query) {
+  const input = document.getElementById('searchBar');
+  input.value = query;
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+async function loadModule() {
+  await import('../../js/predictive-search.js');
+  if (!document.getElementById('searchBar').dataset.predictiveWired) {
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+  }
+}
+
+const searchBar = () => document.getElementById('searchBar');
+const panel = () => document.querySelector('.predictive-search-panel');
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.restoreAllMocks();
+  setupDom();
+  localStorage.clear();
+  delete window.CARA_API_BASE_URL;
+  delete window.addToCart;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ query: 'classic', suggestions }),
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('predictive-search', () => {
+  it('renders a suggestion panel when the user types a query', async () => {
+    await loadModule();
+    vi.useFakeTimers();
+    typeAndWait('classic');
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '/api/products/search/predictive?q=classic&limit=3',
+      ),
+      expect.objectContaining({ credentials: 'include' }),
+    );
+    const p = panel();
+    expect(p).not.toBeNull();
+    expect(p.classList.contains('visible')).toBe(true);
+    expect(p.querySelectorAll('.predictive-search-card').length).toBe(2);
+    expect(p.textContent).toContain('Classic Tee');
+    expect(p.textContent).toContain('₹999');
+  });
+
+  it('does not fetch for very short queries', async () => {
+    await loadModule();
+    vi.useFakeTimers();
+    typeAndWait('a');
+    await vi.advanceTimersByTimeAsync(300);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('hides the panel when there are no matches', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ query: 'zzz', suggestions: [] }),
+      }),
+    );
+    await loadModule();
+    vi.useFakeTimers();
+    typeAndWait('zzz');
+    await vi.advanceTimersByTimeAsync(300);
+
+    const p = panel();
+    expect(p === null || !p.classList.contains('visible')).toBe(true);
+  });
+
+  it('closes the panel on Escape', async () => {
+    await loadModule();
+    vi.useFakeTimers();
+    typeAndWait('classic');
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(panel().classList.contains('visible')).toBe(true);
+    searchBar().dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+    );
+    expect(panel().classList.contains('visible')).toBe(false);
+  });
+
+  it('adds a suggestion to the cart via window.addToCart', async () => {
+    window.addToCart = vi.fn();
+    await loadModule();
+    vi.useFakeTimers();
+    typeAndWait('classic');
+    await vi.advanceTimersByTimeAsync(300);
+
+    const addBtn = panel().querySelector('.predictive-search-add');
+    addBtn.click();
+    expect(window.addToCart).toHaveBeenCalledWith(
+      'Classic Tee',
+      999,
+      'img1.jpg',
+      1,
+      'Standard',
+      1,
+    );
+  });
+
+  it('navigates to the single product page when a card is clicked', async () => {
+    await loadModule();
+    vi.useFakeTimers();
+    typeAndWait('classic');
+    await vi.advanceTimersByTimeAsync(300);
+
+    panel().querySelector('.predictive-search-card').click();
+    const stored = JSON.parse(localStorage.getItem('selectedProduct'));
+    expect(stored.id).toBe(1);
+    expect(stored.name).toBe('Classic Tee');
+  });
+});


### PR DESCRIPTION
## Summary
Closes #6295 — adds an **algorithmic predictive search engine**: as the user types in the navbar search bar, the top-3 best matches are fetched and rendered in a rich dropdown (thumbnail, price, star rating, one-click Add to Cart, and product navigation).

## How it ranks
Candidates are products whose **name or brand** contains the partial query. They are scored algorithmically rather than by raw string order:

| Match quality | Points |
|---|---|
| Name == query | +200 |
| Name starts with query | +150 |
| Name contains query | +100 |
| Brand == query | +80 |
| Brand starts with query | +60 |
| Brand contains query | +30 |
| Rating | +10/star (tiebreak) |

The top-`limit` (default 3) results are returned.

## Changes

### Backend
- **`backend/app/api/products.py`**: new `GET /api/products/search/predictive?q=&limit=3` with the `_predictive_score` ranking function. Registered alongside the other literal `/search/*` routes so it is not shadowed by `/{product_id}`.
- **`backend/app/schemas.py`**: `PredictiveSearchResult` and `PredictiveSearchResponse` schemas.

### Frontend
- **`js/predictive-search.js`** (new): self-contained module wiring the navbar `#searchBar` — 220ms debounce, AbortController-cancelled fetches, stale-response guard, rich dropdown panel, outside-click / Escape / blur handling, arrow-key navigation, scroll/resize repositioning, and a MutationObserver so it works on navbars injected later by `loadNavbar` (and the hardcoded navbar on `index.html`).
- **`navbar.js`**: dynamically imports the module so the feature is active on every page that renders the shared navbar.

### Tests
- **`backend/tests/test_predictive_search.py`** (7): exact-name-match ranks first, rating tiebreak, limit capping, empty/missing query, no-match, response shape, and route-not-shadowed.
- **`tests/unit/predictive-search.test.js`** (6): panel rendering + fetch URL/credentials, short-query no-fetch, empty results hide panel, Escape closes, add-to-cart via `window.addToCart`, single-product navigation.

## Verification
- `npx vitest run tests/unit/predictive-search.test.js` — 6/6 pass; `eslint` clean on new files.
- `python -m pytest backend/tests/test_product_search.py backend/tests/test_predictive_search.py backend/tests/test_products.py` — 29/29 pass.
- The only failing tests in this repo (`tests/unit/shared-cart.test.js` and several backend suites like `test_newsletter`/`test_profile`/`test_password_reset`/`test_order_email_match`) reproduce identically on clean `main` and are unrelated to this PR.
