### PR TITLE
test : added tests for getErrorFallbackHTML in error-boundary.test.js

### DIFF
--- a/tests/unit/error-boundary.test.js
+++ b/tests/unit/error-boundary.test.js
@@ -94,3 +94,28 @@ describe('error-boundary.js unit tests', () => {
     expect(container.querySelector('.cara-error-fallback')).toBeNull();
   });
 });
+
+describe('getErrorFallbackHTML', () => {
+  beforeEach(() => {
+    errorSpy.mockClear();
+  });
+
+  it('returns fallback HTML with the provided message', () => {
+    const html = window.getErrorFallbackHTML('Something broke');
+    expect(html).toContain('error-fallback-box');
+    expect(html).toContain('Something broke');
+  });
+
+  it('returns fallback HTML with default message when argument is undefined', () => {
+    const html = window.getErrorFallbackHTML(undefined);
+    expect(html).toContain('error-fallback-box');
+    expect(html).toContain('An unexpected error occurred.');
+  });
+
+  it('returns a valid HTML string for any input', () => {
+    const html = window.getErrorFallbackHTML(12345);
+    expect(typeof html).toBe('string');
+    expect(html.length).toBeGreaterThan(0);
+    expect(html).toContain('error-fallback-box');
+  });
+});


### PR DESCRIPTION
## 📄 Description
Add unit tests for the `getErrorFallbackHTML` utility function in `error-boundary.test.js`. The new tests cover: returning fallback HTML with a custom message, falling back to the default message when the argument is undefined, and returning a valid HTML string for non-string inputs.

## 🔗 Related Issues
Closes #6389

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) -- please assign this PR to the `tmdeveloper007` account when picking it up.