### PR TITLE
test : added edge case tests for validateGiftMessageLength in gift-options.test.js

### DIFF
--- a/tests/unit/gift-options.test.js
+++ b/tests/unit/gift-options.test.js
@@ -82,4 +82,24 @@ describe('gift-options.js unit tests', () => {
     expect(window.validateGiftMessageLength('abc', 5)).toBe(true);
     expect(window.validateGiftMessageLength('abcdef', 5)).toBe(false);
   });
+
+  it('trims whitespace before length check and allows whitespace-only strings within limit', async () => {
+    await import('../../js/gift-options.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    // '   ' trimmed is '' which has length 0 <= 200
+    expect(window.validateGiftMessageLength('   ')).toBe(true);
+    // Trimmed length of 10 spaces is 0 <= 200
+    expect(window.validateGiftMessageLength('          ')).toBe(true);
+  });
+
+  it('rejects non-string truthy types gracefully', async () => {
+    await import('../../js/gift-options.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    // Numbers get coerced to string via trim; .toString() handles numbers
+    // null/undefined/empty string all return true per existing tests
+    // Non-string truthy values should return true (handled by typeof check)
+    expect(window.validateGiftMessageLength(0)).toBe(true);
+  });
 });


### PR DESCRIPTION
## 📄 Description
Add edge case unit tests for the `validateGiftMessageLength` function in `gift-options.test.js`. The new tests cover: whitespace-only strings and non-string truthy types like numbers.

## 🔗 Related Issues
Closes #6391

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) -- please assign this PR to the `tmdeveloper007` account when picking it up.