### PR TITLE
fix: loyalty points awarded 100x lower than configured POINTS_PER_RUPEE (#5983)

### DIFF
--- a/checkout.js
+++ b/checkout.js
@@ -457,7 +457,7 @@ function submitCheckoutForm() {
           sum + parsePriceString(item.price) * (parseInt(item.quantity, 10) || 1),
         0,
       );
-      const earnedPoints = Math.floor(subtotal * (window.CARA_CONFIG ? window.CARA_CONFIG.LOYALTY.POINTS_PER_RUPEE / 100 : 0.1));
+      const earnedPoints = Math.floor(subtotal * (window.CARA_CONFIG ? window.CARA_CONFIG.LOYALTY.POINTS_PER_RUPEE : 10));
       const newBalance = Math.max(
         0,
         currentBalance - appliedPoints + earnedPoints,


### PR DESCRIPTION
# 📋 Summary
Fixes loyalty points calculation so customers are awarded the correct
number of points per rupee spent, instead of 100x fewer than configured.

---
## 🔗 Related Issue
Closes #5983

---
## 🔄 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

---
## 🛠️ What Was Changed
- Corrected the loyalty points calculation in checkout.js so it matches the configured `POINTS_PER_RUPEE` value
- Points awarded per order now reflect the intended rate instead of being scaled down by 100x

---
## why this needed
- Customers were being under-rewarded, receiving 100x fewer loyalty points than the configured rate intended
- This directly affects redemption value and customer trust in the loyalty program

---
## 🧪 How Has This Been Tested?
- [x] Ran frontend locally with `npm run dev`
- [x] Ran `npm run lint` — no errors
- [ ] Ran `npm run build` — no errors
- [ ] Uploaded a test document and verified output
- [ ] Tested on mobile view



---
## ✅ Self-Review Checklist
- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #IssueNumber`)
- [x] I have tested my changes locally
- [ ] I have added screenshots for UI changes
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue

---
## 📋 Additional Notes
None.