### PR TITLE
fix: made color clash filtering symmetric in outfit rules engine

### DIFF
--- a/backend/app/rules/engine.py
+++ b/backend/app/rules/engine.py
@@ -32,11 +32,18 @@ def filter_by_rules(base_product, candidates):
             if base_product.category == "formal" or c.category == "formal":
                 continue # Strictly block formal mixed with non-formal
                 
-        # Rule 4: Color Harmony
+        # Rule 4: Color Harmony (symmetric clash check)
         if base_product.color and c.color:
             base_color = base_product.color.lower()
             cand_color = c.color.lower()
-            if base_color in clashing_colors and cand_color in clashing_colors[base_color]:
+            colors_clash = (
+                base_color in clashing_colors
+                and cand_color in clashing_colors[base_color]
+            ) or (
+                cand_color in clashing_colors
+                and base_color in clashing_colors[cand_color]
+            )
+            if colors_clash:
                 continue
                 
         # Rule 5: Pattern Clashing (Don't mix two different patterns)

--- a/backend/tests/test_rules_pytest.py
+++ b/backend/tests/test_rules_pytest.py
@@ -52,6 +52,18 @@ def test_blocks_clashing_colors():
     assert [r.id for r in results] == [3]
 
 
+def test_blocks_clashing_colors_reverse_direction():
+    # Red lists green as clashing; a green base must reject a red candidate
+    # just like a red base rejects a green candidate.
+    base = MockProduct(1, "formal", "top", "green", "classic")
+    candidates = [
+        MockProduct(2, "formal", "bottom", "red", "classic"),
+        MockProduct(3, "formal", "bottom", "beige", "classic"),
+    ]
+    results = filter_by_rules(base, candidates)
+    assert [r.id for r in results] == [3]
+
+
 def test_blocks_mixed_heavy_patterns():
     base = MockProduct(10, "street", "top", "red", "floral")
     candidates = [


### PR DESCRIPTION
## 📄 Description
The clashing-colors rule in the backend outfit rules engine only inspected the base product's color key, so a green base product was never rejected against a red candidate even though red explicitly lists green as clashing. The check now evaluates both directions, making color harmony deterministic and symmetric.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6551

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.