### PR TITLE
fix: ran toc build on immediate DOM ready state

### DIFF
--- a/js/toc.js
+++ b/js/toc.js
@@ -1,4 +1,5 @@
-document.addEventListener('DOMContentLoaded', () => {
+function buildPolicyToc() {
+  if (typeof document === 'undefined') return;
   const policyPage = document.querySelector('#policy-page');
   if (!policyPage) return;
 
@@ -51,4 +52,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
     toc.appendChild(link);
   });
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', buildPolicyToc);
+} else {
+  buildPolicyToc();
+}

--- a/tests/unit/toc.test.js
+++ b/tests/unit/toc.test.js
@@ -124,4 +124,30 @@ describe('Table of Contents Generation', () => {
     expect(links[1].getAttribute('href')).toBe('#policy-sec-1');
     expect(links[1].textContent).toBe('Terms of Service');
   });
+
+  it('builds the TOC immediately when the DOM is already ready', async () => {
+    vi.resetModules();
+    // Simulate a script loaded after DOMContentLoaded already fired.
+    Object.defineProperty(document, 'readyState', {
+      configurable: true,
+      value: 'complete',
+    });
+    document.body.innerHTML = `
+      <div id="policy-page">
+        <div class="policy-section">
+          <h2>Privacy Policy</h2>
+          <h2>Terms of Service</h2>
+        </div>
+      </div>
+    `;
+    await import('../../js/toc.js');
+
+    expect(document.getElementById('policy-layout')).not.toBeNull();
+    const toc = document.getElementById('privacy-toc-sidebar');
+    expect(toc).not.toBeNull();
+    const links = Array.from(toc.querySelectorAll('a'));
+    expect(links.length).toBe(2);
+    expect(links[0].getAttribute('href')).toBe('#policy-sec-0');
+    expect(links[0].textContent).toBe('Privacy Policy');
+  });
 });


### PR DESCRIPTION
## 📄 Description
js/toc.js only registered a DOMContentLoaded listener to build the policy table of contents. When the script loads with defer after the event, the handler never runs and the TOC is empty. The build now runs immediately when document.readyState is interactive or complete.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6552

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.