### PR TITLE
fix: ran terms-print button injection on immediate DOM ready state

### DIFF
--- a/js/terms-print.js
+++ b/js/terms-print.js
@@ -1,5 +1,6 @@
 // Print-Friendly Terms Optimization
-document.addEventListener('DOMContentLoaded', () => {
+function initTermsPrint() {
+  if (typeof document === 'undefined') return;
   const parentContainer = document.querySelector('section') || document.body;
 
   // Inject Print Button
@@ -31,4 +32,10 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     `;
   document.head.appendChild(style);
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initTermsPrint);
+} else {
+  initTermsPrint();
+}

--- a/tests/unit/terms-print.test.js
+++ b/tests/unit/terms-print.test.js
@@ -40,4 +40,18 @@ describe('terms-print', () => {
     document.body.innerHTML = '<div id="terms">Terms of Service</div>';
     await expect(load()).resolves.not.toThrow();
   });
+
+  it('injects the button immediately when the DOM is already ready', async () => {
+    Object.defineProperty(document, 'readyState', {
+      configurable: true,
+      value: 'complete',
+    });
+    document.body.innerHTML = '<section id="terms"><p>Terms of Service</p></section>';
+    await import('../../js/terms-print.js');
+
+    const btn = document.getElementById('terms').previousElementSibling;
+    expect(btn).toBeTruthy();
+    expect(btn.tagName).toBe('BUTTON');
+    expect(btn.textContent).toContain('Print');
+  });
 });


### PR DESCRIPTION
## 📄 Description
js/terms-print.js only registered a DOMContentLoaded listener to inject the print button and print styles. When the script loads with defer after the event, the button never appears. The setup now runs immediately when document.readyState is interactive or complete.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6553

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.