### PR TITLE
fix: used fetchWithTimeout for the session-lock logout request

### DIFF
--- a/js/session-lock.js
+++ b/js/session-lock.js
@@ -20,8 +20,10 @@ document.addEventListener('DOMContentLoaded', () => {
     localStorage.removeItem('cara_user_role');
 
     // The real session lives in httpOnly cookies, which JS can't clear
-    // directly, so ask the server to invalidate them.
-    fetch(`${apiBase}/api/auth/logout`, {
+    // directly, so ask the server to invalidate them. Use the same
+    // fetchWithTimeout wrapper as the /me check so a hung request cannot
+    // delay the redirect to login indefinitely.
+    fetchFunc(`${apiBase}/api/auth/logout`, {
       method: 'POST',
       credentials: 'include',
     })

--- a/tests/unit/session-lock.test.js
+++ b/tests/unit/session-lock.test.js
@@ -96,4 +96,40 @@ describe('session-lock', () => {
     expect(localStorage.getItem('cara_user_token')).toBeNull();
     expect(localStorage.getItem('access_token')).toBeNull();
   });
+
+  it('routes the logout request through fetchWithTimeout when available', async () => {
+    const fetchWithTimeoutMock = vi.fn(async (url, options = {}) => {
+      if (String(url).includes('/api/auth/me')) {
+        return { ok: true, status: 200, json: async () => ({ email: 'a@b.c' }) };
+      }
+      if (String(url).includes('/api/auth/logout')) {
+        return { ok: true, status: 200, json: async () => ({}) };
+      }
+      return { ok: false, status: 404 };
+    });
+    vi.stubGlobal('fetchWithTimeout', fetchWithTimeoutMock);
+    const fetchMock = vi.fn(async () => ({ ok: false, status: 404 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await import('../../js/session-lock.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await vi.waitFor(() =>
+      expect(
+        fetchWithTimeoutMock.mock.calls.some((call) =>
+          String(call[0]).includes('/api/auth/me'),
+        ),
+      ).toBe(true),
+    );
+    await Promise.resolve();
+
+    vi.advanceTimersByTime(15 * 60 * 1000);
+    await vi.waitFor(() =>
+      expect(
+        fetchWithTimeoutMock.mock.calls.some((call) =>
+          String(call[0]).includes('/api/auth/logout'),
+        ),
+      ).toBe(true),
+    );
+    await vi.waitFor(() => expect(window.location.href).toBe('login.html'));
+  });
 });


### PR DESCRIPTION
## 📄 Description
js/session-lock.js used a bare fetch() for the inactivity logout request while the /me check used fetchWithTimeout. A hung logout request could delay the redirect to login.html indefinitely. The logout now goes through the same timeout wrapper.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6554

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.