### PR TITLE
fix: treated zero maxPrice facet as a real boundary

### DIFF
--- a/js/product-facet-filter.js
+++ b/js/product-facet-filter.js
@@ -67,11 +67,14 @@ export class ProductFacetFilter {
   parseQueryParams(queryString) {
     const params = new URLSearchParams(queryString);
     const rawCategories = params.get('categories');
+    const rawMinPrice = params.get('minPrice');
+    const rawMaxPrice = params.get('maxPrice');
+    const rawMinRating = params.get('minRating');
     const filters = {
       category: rawCategories ? rawCategories.split(',').filter((c) => c.length > 0) : [],
-      minPrice: parseFloat(params.get('minPrice')) || 0,
-      maxPrice: parseFloat(params.get('maxPrice')) || Infinity,
-      minRating: parseFloat(params.get('minRating')) || 0,
+      minPrice: rawMinPrice !== null && Number.isFinite(Number(rawMinPrice)) ? Number(rawMinPrice) : 0,
+      maxPrice: rawMaxPrice !== null && Number.isFinite(Number(rawMaxPrice)) ? Number(rawMaxPrice) : Infinity,
+      minRating: rawMinRating !== null && Number.isFinite(Number(rawMinRating)) ? Number(rawMinRating) : 0,
       inStockOnly: params.get('inStock') === 'true'
     };
     this.setFilters(filters);

--- a/tests/unit/product-facet-filter.test.js
+++ b/tests/unit/product-facet-filter.test.js
@@ -74,4 +74,28 @@ describe('ProductFacetFilter', () => {
     const filters = newEngine.parseQueryParams('categories=tshirts,,shirts');
     expect(filters.category).toEqual(['tshirts', 'shirts']);
   });
+
+  it('should treat maxPrice=0 as a real boundary, not unbounded', () => {
+    const freeProducts = [
+      { id: '1', name: 'Free Tee', category: 'tshirts', price: 0, rating: 4, inStock: true },
+      { id: '2', name: 'Paid Tee', category: 'tshirts', price: 20, rating: 4, inStock: true },
+    ];
+    const engine = new ProductFacetFilter(freeProducts);
+    const filters = engine.parseQueryParams('maxPrice=0');
+    expect(filters.maxPrice).toBe(0);
+
+    const results = engine.applyFilters();
+    expect(results.map((p) => p.id)).toEqual(['1']);
+
+    // Round trip: buildQueryParams should still emit maxPrice=0.
+    expect(engine.buildQueryParams()).toContain('maxPrice=0');
+  });
+
+  it('should round-trip minPrice and maxPrice through the URL', () => {
+    const engine = new ProductFacetFilter(sampleProducts);
+    engine.parseQueryParams('minPrice=30&maxPrice=60');
+    expect(engine.activeFilters.minPrice).toBe(30);
+    expect(engine.activeFilters.maxPrice).toBe(60);
+    expect(engine.applyFilters().map((p) => p.id)).toEqual(['2', '4']);
+  });
 });


### PR DESCRIPTION
## 📄 Description
js/product-facet-filter.js parseQueryParams used parseFloat(...) || Infinity, so a maxPrice=0 query parameter was silently treated as unbounded and free items could never be filtered. Explicit null and finite checks now keep 0 as a real boundary, and the URL round trip preserves it.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6555

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.