### PR TITLE
fix: guarded admin analytics status counts against non-numeric data

### DIFF
--- a/js/admin-analytics.js
+++ b/js/admin-analytics.js
@@ -91,9 +91,17 @@
         '<p class="text-muted text-center">No orders to categorize.</p>';
       return;
     }
-    const maxVal = Math.max(...list.map((r) => r.count), 1);
+    const validList = list.filter(
+      (r) => r && typeof r.count === 'number' && isFinite(r.count),
+    );
+    if (validList.length === 0) {
+      statusWrap.innerHTML =
+        '<p class="text-muted text-center">No valid order status data.</p>';
+      return;
+    }
+    const maxVal = Math.max(...validList.map((r) => r.count), 1);
 
-    statusWrap.innerHTML = list
+    statusWrap.innerHTML = validList
       .map((r) => {
         const pct = Math.round((r.count / maxVal) * 100);
         return `

--- a/tests/unit/admin-analytics.test.js
+++ b/tests/unit/admin-analytics.test.js
@@ -134,4 +134,36 @@ describe('admin-analytics.js unit tests', () => {
       expect(opts.credentials).toBe('include');
     });
   });
+
+  it('renders a graceful message when status counts are malformed', async () => {
+    vi.resetModules();
+    // Re-import after the DOM is populated so the module captures live refs.
+    await import('../../js/admin-analytics.js');
+    statusWrap = document.getElementById('analyticsStatusWrap');
+
+    fetchSpy
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ total_revenue: 100, total_orders: 2, total_customers: 1 }) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve([]) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve([{ status: 'PENDING', count: 'oops' }]) });
+
+    await window.AdminDashboard.refresh();
+
+    expect(statusWrap.innerHTML).toContain('No valid order status data.');
+    expect(statusWrap.querySelector('.status-dist-bar-wrap')).toBeNull();
+  });
+
+  it('renders a graceful message when category sales are malformed', async () => {
+    vi.resetModules();
+    await import('../../js/admin-analytics.js');
+    catTable = document.getElementById('analyticsCategoryTable');
+
+    fetchSpy
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ total_revenue: 100, total_orders: 2, total_customers: 1 }) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve([{ category: 'Tops', units_sold: 'many', revenue: 50 }]) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve([]) });
+
+    await window.AdminDashboard.refresh();
+
+    expect(catTable.innerHTML).toContain('No valid sales recorded.');
+  });
 });


### PR DESCRIPTION
## 📄 Description
js/admin-analytics.js renderStatusDistribution called r.count.toLocaleString() without guarding non-numeric count values, so a malformed analytics record crashed the entire dashboard render. The render now filters to finite numeric counts and shows a graceful empty-state message.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6556

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.