### PR TITLE
fix: clamped ambassador follower_count upper bound

### DIFF
--- a/backend/app/api/ambassador.py
+++ b/backend/app/api/ambassador.py
@@ -7,6 +7,10 @@ from ..database import get_db
 
 router = APIRouter()
 
+# Sanity bound for social follower counts; anything above this is almost
+# certainly malformed or fraudulent input and would overflow the column.
+MAX_FOLLOWER_COUNT = 100_000_000
+
 
 class AmbassadorApplyRequest(BaseModel):
     full_name: str
@@ -20,6 +24,8 @@ class AmbassadorApplyRequest(BaseModel):
 def apply_ambassador(payload: AmbassadorApplyRequest, db: Session = Depends(get_db)):
     if payload.follower_count < 0:
         raise HTTPException(status_code=400, detail="Follower count cannot be negative")
+    if payload.follower_count > MAX_FOLLOWER_COUNT:
+        raise HTTPException(status_code=400, detail="Follower count is unreasonably large")
 
     application = models.AmbassadorApplication(
         full_name=payload.full_name,

--- a/backend/tests/test_ambassador.py
+++ b/backend/tests/test_ambassador.py
@@ -39,3 +39,17 @@ def test_ambassador_apply_invalid_email(client):
         },
     )
     assert response.status_code == 422
+
+
+def test_ambassador_apply_oversized_followers(client):
+    response = client.post(
+        "/api/ambassador/apply",
+        json={
+            "full_name": "Jane Doe",
+            "email": "jane@example.com",
+            "instagram_handle": "@janedoe",
+            "follower_count": 10**12,
+            "motivation": "Test"
+        },
+    )
+    assert response.status_code == 400


### PR DESCRIPTION
## 📄 Description
backend/app/api/ambassador.py only rejected negative follower counts, so absurdly large values (e.g. 10^12) passed through to the database. The endpoint now rejects counts above a sane bound of 100,000,000 with a 400 response, with test coverage added.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6557

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.