### PR TITLE
fix: guarded stock-simulator timer against non-finite duration

### DIFF
--- a/js/stock-simulator.js
+++ b/js/stock-simulator.js
@@ -15,7 +15,9 @@ export function getStockInfo(size) {
 }
 
 export function startStockReservationTimer(durationSeconds, onTick, onExpire) {
-  if (durationSeconds <= 0) {
+  // Normalize non-finite input (NaN, Infinity) and non-positive durations:
+  // there is nothing to count down, so expire immediately.
+  if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) {
     if (onExpire) onExpire();
     return null;
   }

--- a/tests/unit/stock-simulator.test.js
+++ b/tests/unit/stock-simulator.test.js
@@ -60,4 +60,18 @@ describe('Stock Simulator Unit Tests', () => {
     expect(onExpire).toHaveBeenCalledTimes(2);
     expect(intervalNegative).toBeNull();
   });
+
+  it('should expire immediately for NaN and Infinity durations', () => {
+    const onTick = vi.fn();
+    const onExpire = vi.fn();
+
+    const intervalNaN = startStockReservationTimer(NaN, onTick, onExpire);
+    expect(onExpire).toHaveBeenCalledTimes(1);
+    expect(onTick).not.toHaveBeenCalled();
+    expect(intervalNaN).toBeNull();
+
+    const intervalInfinity = startStockReservationTimer(Infinity, onTick, onExpire);
+    expect(onExpire).toHaveBeenCalledTimes(2);
+    expect(intervalInfinity).toBeNull();
+  });
 });


### PR DESCRIPTION
## 📄 Description
js/stock-simulator.js startStockReservationTimer only rejected durations <= 0, so NaN and Infinity durations produced broken setInterval behavior. The timer now normalizes non-finite input with a finite check and expires immediately, returning null.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6558

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.