### PR TITLE
fix: rendered useful toast text for non-string messages

### DIFF
--- a/js/toast-queue.js
+++ b/js/toast-queue.js
@@ -1,7 +1,19 @@
 // Reusable Toast Notification Queue Manager
 
 function escapeHtml(value) {
-  return String(value).replace(
+  let text;
+  if (typeof value === 'string') {
+    text = value;
+  } else if (value === null || value === undefined) {
+    text = '';
+  } else {
+    try {
+      text = JSON.stringify(value);
+    } catch (e) {
+      text = String(value);
+    }
+  }
+  return text.replace(
     /[&<>"']/g,
     (char) =>
       ({

--- a/tests/unit/toast-queue.test.js
+++ b/tests/unit/toast-queue.test.js
@@ -70,4 +70,21 @@ describe('Toast Queue Manager Unit Tests', () => {
     expect(toastCard.querySelector('.toast-message').innerHTML).toContain('&lt;img');
     expect(toastCard.querySelector('.toast-message').innerHTML).not.toContain('<img');
   });
+
+  it('should render a useful text for object messages', () => {
+    const id = manager.show({ code: 'E500', detail: 'Something failed' }, 'error', 0);
+    const toastCard = document.getElementById(id);
+    expect(toastCard.querySelector('.toast-message').textContent).toContain(
+      '"code":"E500"',
+    );
+    expect(toastCard.querySelector('.toast-message').textContent).toContain(
+      '"detail":"Something failed"',
+    );
+  });
+
+  it('should render an empty message for null or undefined input', () => {
+    const id = manager.show(null, 'info', 0);
+    const toastCard = document.getElementById(id);
+    expect(toastCard.querySelector('.toast-message').textContent).toBe('');
+  });
 });


### PR DESCRIPTION
## 📄 Description
js/toast-queue.js escapeHtml used String(value), so object or error messages rendered as useless [object Object]. Non-string values are now stringified as JSON (with a string fallback), and null or undefined renders as empty text.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6559

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.