### PR TITLE
fix: guarded scroll-top-fab onScroll against missing window scrollY

### DIFF
--- a/js/scroll-top-fab.js
+++ b/js/scroll-top-fab.js
@@ -23,7 +23,8 @@ export class ScrollTopFab {
 
   onScroll() {
     if (!this.button) return;
-    if (window.scrollY > this.threshold) {
+    const scrollY = typeof window !== 'undefined' ? window.scrollY || 0 : 0;
+    if (scrollY > this.threshold) {
       this.button.style.display = 'block';
     } else {
       this.button.style.display = 'none';

--- a/tests/unit/scroll-top-fab.test.js
+++ b/tests/unit/scroll-top-fab.test.js
@@ -45,4 +45,12 @@ describe('ScrollTopFab', () => {
     fab.onScroll();
     expect(btn.style.display).toBe('block');
   });
+
+  it('keeps the button hidden when scrollY is unavailable', () => {
+    const fab = new ScrollTopFab({ threshold: 300 });
+    const btn = document.getElementById('scroll-top-fab');
+    delete window.scrollY;
+    fab.onScroll();
+    expect(btn.style.display).toBe('none');
+  });
 });


### PR DESCRIPTION
## 📄 Description
js/scroll-top-fab.js onScroll dereferenced window.scrollY without a guard, so non-browser hosts where scrollY is undefined silently misbehaved. The handler now defaults to 0 when scrollY is unavailable.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6560

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.