### PR TITLE
test: added tick boundary and size fallback coverage to stock-simulator

### DIFF
--- a/tests/unit/stock-simulator.test.js
+++ b/tests/unit/stock-simulator.test.js
@@ -60,4 +60,24 @@ describe('Stock Simulator Unit Tests', () => {
     expect(onExpire).toHaveBeenCalledTimes(2);
     expect(intervalNegative).toBeNull();
   });
+
+  it('should tick to zero and expire for a one-second duration', () => {
+    vi.useFakeTimers();
+    const onTick = vi.fn();
+    const onExpire = vi.fn();
+
+    const interval = startStockReservationTimer(1, onTick, onExpire);
+    expect(interval).not.toBeNull();
+
+    vi.advanceTimersByTime(1000);
+    expect(onTick).toHaveBeenCalledWith(0);
+    expect(onExpire).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it('should return the default stock info for unknown and undefined sizes', () => {
+    expect(getStockInfo('UnknownSize')).toEqual({ count: 5, status: 'normal' });
+    expect(getStockInfo('Select Size')).toEqual(mockStockData['Select Size']);
+    expect(getStockInfo(undefined)).toEqual({ count: 0, status: 'unknown' });
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds edge-case unit tests to tests/unit/stock-simulator.test.js covering the one-second duration tick-to-zero and expire path, the default stock info fallback for unknown sizes, and the undefined-size unknown status.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6561

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.