### PR TITLE
test: added facet parse round-trip coverage to product-facet-filter

### DIFF
--- a/tests/unit/product-facet-filter.test.js
+++ b/tests/unit/product-facet-filter.test.js
@@ -74,4 +74,37 @@ describe('ProductFacetFilter', () => {
     const filters = newEngine.parseQueryParams('categories=tshirts,,shirts');
     expect(filters.category).toEqual(['tshirts', 'shirts']);
   });
+
+  it('should round-trip filters through the URL query string', () => {
+    const engine = new ProductFacetFilter(sampleProducts);
+    engine.parseQueryParams('categories=tshirts&minPrice=20&maxPrice=40&minRating=4&inStock=true');
+
+    const query = engine.buildQueryParams();
+    expect(query).toContain('categories=tshirts');
+    expect(query).toContain('minPrice=20');
+    expect(query).toContain('maxPrice=40');
+    expect(query).toContain('minRating=4');
+    expect(query).toContain('inStock=true');
+  });
+
+  it('should produce an empty query string for default filters', () => {
+    const engine = new ProductFacetFilter(sampleProducts);
+    engine.resetFilters();
+    expect(engine.buildQueryParams()).toBe('');
+  });
+
+  it('should reset to defaults after parsing filters', () => {
+    const engine = new ProductFacetFilter(sampleProducts);
+    engine.parseQueryParams('categories=tshirts&minPrice=20&inStock=true');
+    engine.resetFilters();
+
+    expect(engine.activeFilters).toEqual({
+      category: [],
+      minPrice: 0,
+      maxPrice: Infinity,
+      minRating: 0,
+      inStockOnly: false,
+    });
+    expect(engine.applyFilters()).toHaveLength(4);
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/product-facet-filter.test.js for the parseQueryParams to buildQueryParams round trip, the empty query string produced by default filters, and resetFilters returning to the default state.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6562

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.