### PR TITLE
test: added escaping and threshold coverage to inventory-alert-banner

### DIFF
--- a/tests/unit/inventory-alert-banner.test.js
+++ b/tests/unit/inventory-alert-banner.test.js
@@ -86,11 +86,37 @@ describe('renderInventoryBanner', () => {
     expect(banner.tagName).toBe('DIV');
   });
 
-  it('should evaluate low stock threshold trigger', () => { expect(true).toBe(true); });
+  it('escapes HTML in the message text', () => {
+    const banner = renderInventoryBanner(
+      'test-container',
+      '<img src=x onerror=alert(1)>',
+      'warning',
+    );
+    const textEl = banner.querySelector('.inventory-banner-text');
+    // No real img element may be injected by the message.
+    expect(textEl.querySelector('img')).toBeNull();
+    expect(textEl.innerHTML).toContain('&lt;img');
+  });
 });
 
 describe('isLowStockQuantity', () => {
   it('is exported as a callable function', () => {
     expect(typeof isLowStockQuantity).toBe('function');
+  });
+
+  it('returns true for counts at or below the threshold', () => {
+    expect(isLowStockQuantity(1)).toBe(true);
+    expect(isLowStockQuantity(5)).toBe(true);
+  });
+
+  it('returns false above the threshold and for zero', () => {
+    expect(isLowStockQuantity(6)).toBe(false);
+    expect(isLowStockQuantity(0)).toBe(false);
+  });
+
+  it('returns false for non-number input', () => {
+    expect(isLowStockQuantity('5')).toBe(false);
+    expect(isLowStockQuantity(null)).toBe(false);
+    expect(isLowStockQuantity(NaN)).toBe(false);
   });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/inventory-alert-banner.test.js for message HTML escaping in renderInventoryBanner and boundary behavior of isLowStockQuantity, including non-number input.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6563

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.