### PR TITLE
test: added missing-container coverage to admin-analytics renders

### DIFF
--- a/tests/unit/admin-analytics.test.js
+++ b/tests/unit/admin-analytics.test.js
@@ -134,4 +134,26 @@ describe('admin-analytics.js unit tests', () => {
       expect(opts.credentials).toBe('include');
     });
   });
+
+  it('no-ops safely when dashboard DOM nodes are absent', async () => {
+    vi.resetModules();
+    // Clear the DOM so the module captures null element references.
+    document.body.innerHTML = '';
+    await import('../../js/admin-analytics.js');
+
+    fetchSpy.mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve({}) });
+    await expect(window.AdminDashboard.refresh()).resolves.not.toThrow();
+  });
+
+  it('renders an error alert when refresh fails', async () => {
+    vi.resetModules();
+    await import('../../js/admin-analytics.js');
+    const errorAlert = document.getElementById('analyticsError');
+
+    fetchSpy.mockResolvedValue({ ok: false, status: 500 });
+    await window.AdminDashboard.refresh();
+
+    expect(errorAlert.textContent).toContain('Failed to retrieve dashboard analytics.');
+    expect(errorAlert.style.display).toBe('block');
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/admin-analytics.test.js verifying AdminDashboard.refresh no-ops safely when dashboard DOM nodes are absent, and that a failed refresh renders the error alert with the right message.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6564

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.