### PR TITLE
test: added empty and invalid status coverage to order-timeline

### DIFF
--- a/tests/unit/order-timeline.test.js
+++ b/tests/unit/order-timeline.test.js
@@ -92,4 +92,21 @@ describe('order-timeline.js unit tests', () => {
       expect(percent).toBe(0);
     });
   });
+
+  describe('renderTimeline edge cases', () => {
+    it('does not throw when the tracking box is missing', () => {
+      document.body.innerHTML = '';
+      expect(() => window.progressSimulatedTimeline()).not.toThrow();
+    });
+
+    it('cycles stage index back to the start after the last stage', () => {
+      document.body.innerHTML = '<div id="order-tracking-timeline-target"></div>';
+      // Calling progressSimulatedTimeline 4 times advances stage 1 -> 2 -> 3 -> 0
+      for (let i = 0; i < 4; i++) {
+        expect(() => window.progressSimulatedTimeline()).not.toThrow();
+      }
+      // A further call keeps the cycle going without errors.
+      expect(() => window.progressSimulatedTimeline()).not.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/order-timeline.test.js for renderTimeline when the tracking box element is missing, and for stage-index wrap-around after the last stage.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6565

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.