### PR TITLE
test: added pagination boundary coverage to product-search

### DIFF
--- a/tests/unit/product-search.test.js
+++ b/tests/unit/product-search.test.js
@@ -62,10 +62,73 @@ describe('product-search', () => {
   });
 
   it('should enforce minimum search query character length threshold', () => { expect(true).toBe(true); });
+
+  it('renders pagination controls for multi-page results', async () => {
+    global.fetch.mockImplementation((url) => {
+      if (String(url).includes('/categories')) {
+        return Promise.resolve({ ok: true, json: async () => ({ categories: [] }) });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          total: 45,
+          page: 1,
+          page_size: 20,
+          products: [
+            { id: 1, name: 'Tee', price: 999, category: 'tshirts' },
+          ],
+        }),
+      });
+    });
+    await load();
+    const pagination = document.getElementById('searchPagination');
+    expect(pagination.querySelectorAll('.page-btn').length).toBeGreaterThan(1);
+  });
+
+  it('does not render pagination when results fit on one page', async () => {
+    global.fetch.mockImplementation((url) => {
+      if (String(url).includes('/categories')) {
+        return Promise.resolve({ ok: true, json: async () => ({ categories: [] }) });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          total: 5,
+          page: 1,
+          page_size: 20,
+          products: [],
+        }),
+      });
+    });
+    await load();
+    const pagination = document.getElementById('searchPagination');
+    expect(pagination.querySelectorAll('.page-btn').length).toBe(0);
+  });
 });
 
 describe('meetsSearchQueryThreshold', () => {
   it('is exported as a callable function', () => {
     expect(typeof meetsSearchQueryThreshold).toBe('function');
+  });
+
+  it('accepts queries at or above the minimum length', () => {
+    expect(meetsSearchQueryThreshold('ab')).toBe(true);
+    expect(meetsSearchQueryThreshold('tshirt')).toBe(true);
+  });
+
+  it('rejects queries below the minimum length', () => {
+    expect(meetsSearchQueryThreshold('a')).toBe(false);
+    expect(meetsSearchQueryThreshold('')).toBe(false);
+  });
+
+  it('trims whitespace before evaluating the threshold', () => {
+    expect(meetsSearchQueryThreshold('  ab  ')).toBe(true);
+    expect(meetsSearchQueryThreshold('   ')).toBe(false);
+  });
+
+  it('rejects non-string input', () => {
+    expect(meetsSearchQueryThreshold(null)).toBe(false);
+    expect(meetsSearchQueryThreshold(undefined)).toBe(false);
+    expect(meetsSearchQueryThreshold(12)).toBe(false);
   });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/product-search.test.js for pagination rendering with multi-page results, single-page suppression, and the meetsSearchQueryThreshold length, whitespace, and non-string boundaries.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6566

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.