### PR TITLE
test: added double-dismiss coverage to toast-queue

### DIFF
--- a/tests/unit/toast-queue.test.js
+++ b/tests/unit/toast-queue.test.js
@@ -70,4 +70,36 @@ describe('Toast Queue Manager Unit Tests', () => {
     expect(toastCard.querySelector('.toast-message').innerHTML).toContain('&lt;img');
     expect(toastCard.querySelector('.toast-message').innerHTML).not.toContain('<img');
   });
+
+  it('should be a safe no-op when dismissing an unknown toast id', () => {
+    vi.useFakeTimers();
+    const id = manager.show('Keep me', 'info', 0);
+    expect(manager.queue.length).toBe(1);
+
+    manager.dismiss('does-not-exist');
+    expect(manager.queue.length).toBe(1);
+    expect(document.getElementById(id)).not.toBeNull();
+
+    manager.dismiss(id);
+    expect(manager.queue.length).toBe(0);
+
+    // Dismissing again after removal must not throw or change state.
+    expect(() => manager.dismiss(id)).not.toThrow();
+    expect(manager.queue.length).toBe(0);
+    vi.useRealTimers();
+  });
+
+  it('should clear all queued toasts', () => {
+    vi.useFakeTimers();
+    manager.show('Msg 1', 'info', 0);
+    manager.show('Msg 2', 'info', 0);
+    manager.show('Msg 3', 'info', 0);
+    expect(manager.queue.length).toBe(3);
+
+    manager.clearAll();
+    expect(manager.queue.length).toBe(0);
+    vi.advanceTimersByTime(300);
+    expect(document.querySelectorAll('.toast-card').length).toBe(0);
+    vi.useRealTimers();
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/toast-queue.test.js for dismissing an unknown toast id as a safe no-op, dismissing an already-removed toast, and clearAll emptying the queue and DOM.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6567

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.