### PR TITLE
test: added boundary coverage to pincode-validation-engine

### DIFF
--- a/tests/unit/pincode-validation-engine.test.js
+++ b/tests/unit/pincode-validation-engine.test.js
@@ -57,4 +57,29 @@ describe('PincodeValidationEngine', () => {
     expect(engine.validatePostalCode('K1A 0B1', 'CA').valid).toBe(true);
     expect(engine.validatePostalCode('BAD', 'UK').valid).toBe(false);
   });
+
+  it('should validate US zip+4 extended format', () => {
+    expect(engine.validatePostalCode('90210-1234', 'US').valid).toBe(true);
+    expect(engine.validatePostalCode('90210-12', 'US').valid).toBe(false);
+  });
+
+  it('should apply the generic fallback for unknown country codes', () => {
+    expect(engine.validatePostalCode('ABC123', 'XX').valid).toBe(true);
+    expect(engine.validatePostalCode('NODIGITS', 'XX').valid).toBe(false);
+    expect(engine.validatePostalCode('AB', 'XX').valid).toBe(false);
+  });
+
+  it('should reject non-string postal codes', () => {
+    expect(engine.validatePostalCode(null, 'IN').valid).toBe(false);
+    expect(engine.validatePostalCode(undefined, 'IN').valid).toBe(false);
+    expect(engine.validatePostalCode(123456, 'IN').valid).toBe(false);
+  });
+
+  it('should treat the Indian metro boundary at 11 and 40', () => {
+    expect(engine.estimateDeliveryDays('110001', 'IN').tier).toBe('Express Zone');
+    expect(engine.estimateDeliveryDays('400001', 'IN').tier).toBe('Express Zone');
+    // 10 and 41 fall outside the metro range.
+    expect(engine.estimateDeliveryDays('100001', 'IN').tier).toBe('Standard Zone');
+    expect(engine.estimateDeliveryDays('410001', 'IN').tier).toBe('Standard Zone');
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/pincode-validation-engine.test.js for US zip+4, the generic fallback for unknown country codes, non-string postal codes, and the Indian metro-zone boundaries.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6568

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.