### PR TITLE
test: added legacy shape coverage to cart-recovery-engine

### DIFF
--- a/tests/unit/cart-recovery-engine.test.js
+++ b/tests/unit/cart-recovery-engine.test.js
@@ -37,6 +37,37 @@ describe('CartRecoveryEngine', () => {
     expect(engine.getAbandonedCartSession()).toBeNull();
   });
 
+  it('should treat a session without a timestamp as expired', () => {
+    const items = [{ id: 'p1', name: 'Shirt', price: 29.99, quantity: 1 }];
+    engine.saveCartSession(items);
+
+    const raw = localStorage.getItem('cara_abandoned_cart');
+    const data = JSON.parse(raw);
+    delete data.timestamp;
+    localStorage.setItem('cara_abandoned_cart', JSON.stringify(data));
+
+    expect(engine.getAbandonedCartSession()).toBeNull();
+  });
+
+  it('should reject sessions with corrupt or non-array items', () => {
+    localStorage.setItem(
+      'cara_abandoned_cart',
+      JSON.stringify({ items: 'not-an-array', timestamp: Date.now() }),
+    );
+    expect(engine.getAbandonedCartSession()).toBeNull();
+
+    localStorage.setItem(
+      'cara_abandoned_cart',
+      JSON.stringify({ items: [{ id: 'p1' }], recovered: true, timestamp: Date.now() }),
+    );
+    expect(engine.getAbandonedCartSession()).toBeNull();
+  });
+
+  it('should return null when the stored JSON is corrupt', () => {
+    localStorage.setItem('cara_abandoned_cart', '{not valid json');
+    expect(engine.getAbandonedCartSession()).toBeNull();
+  });
+
   it('should mark abandoned session as recovered', () => {
     const items = [{ id: 'p1', name: 'Shirt', price: 29.99, quantity: 1 }];
     engine.saveCartSession(items);


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/cart-recovery-engine.test.js for sessions without a timestamp, non-array items, already-recovered sessions, and corrupt stored JSON being rejected by getAbandonedCartSession.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6569

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.