### PR TITLE
fix: installed input-shield on immediate DOM ready state

### DIFF
--- a/js/input-shield.js
+++ b/js/input-shield.js
@@ -1,5 +1,6 @@
 // Script tag injection shield
-document.addEventListener('DOMContentLoaded', () => {
+function installInputShield() {
+  if (typeof document === 'undefined') return;
   const form = document.querySelector('form');
   if (!form) return;
 
@@ -36,7 +37,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Expose utility function globally for external use
   window.containsSqlInjectionKeywords = containsSqlInjectionKeywords;
-});
+}
 
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', installInputShield);
+} else {
+  installInputShield();
+}
 
 function containsSqlInjectionKeywords(input) { if (!input || typeof input !== 'string') return false; return /\b(SELECT|INSERT|UPDATE|DELETE|DROP|UNION|ALTER)\b/i.test(input); }

--- a/tests/unit/input-shield.test.js
+++ b/tests/unit/input-shield.test.js
@@ -74,4 +74,17 @@ describe('input-shield', () => {
     expect(window.containsSqlInjectionKeywords('select name from users')).toBe(true);
     expect(window.containsSqlInjectionKeywords('Delete FROM sessions')).toBe(true);
   });
+
+  it('installs the shield immediately when the DOM is already ready', async () => {
+    Object.defineProperty(document, 'readyState', {
+      configurable: true,
+      value: 'complete',
+    });
+    setupForm('<script>alert(1)</script>');
+    await import('../../js/input-shield.js');
+
+    const event = await submitBuild();
+    expect(event.defaultPrevented).toBe(true);
+    expect(document.getElementById('field').value).toBe('');
+  });
 });


### PR DESCRIPTION
## 📄 Description
js/input-shield.js only registered a DOMContentLoaded listener to install the XSS submit shield. When the script loads with defer after the event, the shield never installs. The module now checks document.readyState and installs immediately when the DOM is ready.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6571

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.