### PR TITLE
fix: installed simple-captcha on immediate DOM ready state

### DIFF
--- a/js/simple-captcha.js
+++ b/js/simple-captcha.js
@@ -1,5 +1,6 @@
 // Simple Login Mathematics Verification Captcha
-document.addEventListener('DOMContentLoaded', () => {
+function installCaptcha() {
+  if (typeof document === 'undefined') return;
   const loginForm = document.querySelector('form');
   if (!loginForm) return;
 
@@ -62,4 +63,10 @@ document.addEventListener('DOMContentLoaded', () => {
         'Incorrect captcha. Please solve math query correctly.';
     }
   });
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', installCaptcha);
+} else {
+  installCaptcha();
+}

--- a/tests/unit/simple-captcha.test.js
+++ b/tests/unit/simple-captcha.test.js
@@ -58,4 +58,16 @@ describe('simple-captcha', () => {
     expect(num1).toBeLessThanOrEqual(10);
     expect(num2).toBeLessThanOrEqual(10);
   });
+
+  it('installs the captcha immediately when the DOM is already ready', async () => {
+    Object.defineProperty(document, 'readyState', {
+      configurable: true,
+      value: 'complete',
+    });
+    await import('../../js/simple-captcha.js');
+
+    expect(document.getElementById('captcha-input')).toBeTruthy();
+    expect(document.getElementById('captcha-math-label')).toBeTruthy();
+    expect(document.getElementById('captcha-reset-btn')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## 📄 Description
js/simple-captcha.js only registered a DOMContentLoaded listener to inject the math captcha. When the script loads with defer after the event, the captcha never appears. The module now checks document.readyState and installs immediately when the DOM is ready.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6572

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.