### PR TITLE
fix: initialized stock-simulator on immediate DOM ready state

### DIFF
--- a/js/stock-simulator.js
+++ b/js/stock-simulator.js
@@ -87,5 +87,8 @@ export function initStockSimulator() {
 }
 
 if (typeof document !== 'undefined') {
+  // Initialize immediately when the script loads after DOMContentLoaded, and
+  // also on the event for scripts that run during initial parsing.
   document.addEventListener('DOMContentLoaded', initStockSimulator);
+  initStockSimulator();
 }

--- a/tests/unit/stock-simulator.test.js
+++ b/tests/unit/stock-simulator.test.js
@@ -2,6 +2,30 @@ import { describe, it, expect, vi } from 'vitest';
 import { getStockInfo, startStockReservationTimer, mockStockData } from '../../js/stock-simulator.js';
 
 describe('Stock Simulator Unit Tests', () => {
+  it('initializes immediately when the DOM is already ready', async () => {
+    vi.resetModules();
+    Object.defineProperty(document, 'readyState', {
+      configurable: true,
+      value: 'complete',
+    });
+    document.body.innerHTML = `
+      <select id="sizeSelect">
+        <option value="XL">XL</option>
+      </select>
+      <div id="stock-alert-container"></div>
+    `;
+    await import('../../js/stock-simulator.js');
+
+    // Simulate a size change; the listener should already be attached because
+    // initStockSimulator ran immediately at import time.
+    const select = document.getElementById('sizeSelect');
+    select.value = 'XL';
+    select.dispatchEvent(new Event('change'));
+
+    const container = document.getElementById('stock-alert-container');
+    expect(container.innerHTML).toContain('Out of Stock');
+  });
+
   it('should return stock details for a valid size', () => {
     const info = getStockInfo('Small');
     expect(info).toEqual({ count: 15, status: 'normal' });


### PR DESCRIPTION
## 📄 Description
js/stock-simulator.js only initialized on DOMContentLoaded, so a deferred script loaded after the event never attached the size-change listener and stock alerts never updated. The module now initializes immediately (idempotently) and keeps the event listener for scripts that run during initial parsing.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6574

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.