### PR TITLE
fix: returned 201 for new newsletter subscriptions

### DIFF
--- a/backend/app/api/newsletter.py
+++ b/backend/app/api/newsletter.py
@@ -1,5 +1,6 @@
 import secrets
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 from pydantic import BaseModel, EmailStr
 from .. import models
@@ -29,9 +30,16 @@ def subscribe(payload: NewsletterSubscribeRequest, db: Session = Depends(get_db)
             if not existing.unsubscribe_token:
                 existing.unsubscribe_token = secrets.token_urlsafe(32)
             db.commit()
+            return JSONResponse(
+                status_code=201,
+                content={"message": "Subscription reactivated"},
+            )
         # Generic response regardless of prior state — avoids leaking
         # whether this email was already subscribed.
-        return {"message": "Subscription request processed"}
+        return JSONResponse(
+            status_code=200,
+            content={"message": "Subscription request processed"},
+        )
 
     subscriber = models.NewsletterSubscriber(
         email=payload.email,
@@ -39,7 +47,10 @@ def subscribe(payload: NewsletterSubscribeRequest, db: Session = Depends(get_db)
     )
     db.add(subscriber)
     db.commit()
-    return {"message": "Subscription request processed"}
+    return JSONResponse(
+        status_code=201,
+        content={"message": "Subscription request processed"},
+    )
 
 
 @router.post("/unsubscribe")

--- a/backend/tests/test_newsletter.py
+++ b/backend/tests/test_newsletter.py
@@ -4,10 +4,10 @@ def test_subscribe_success(client):
         json={"email": "newuser@example.com"},
     )
     assert response.status_code == 201
-    assert response.json()["message"] == "Successfully subscribed to newsletter"
+    assert response.json()["message"] == "Subscription request processed"
 
 
-def test_subscribe_duplicate(client):
+def test_subscribe_duplicate_returns_200(client):
     client.post(
         "/api/newsletter/subscribe",
         json={"email": "dup@example.com"},
@@ -16,8 +16,8 @@ def test_subscribe_duplicate(client):
         "/api/newsletter/subscribe",
         json={"email": "dup@example.com"},
     )
-    assert response.status_code == 409
-    assert "already subscribed" in response.json()["detail"]
+    assert response.status_code == 200
+    assert response.json()["message"] == "Subscription request processed"
 
 
 def test_subscribe_invalid_email(client):
@@ -33,30 +33,55 @@ def test_unsubscribe_success(client):
         "/api/newsletter/subscribe",
         json={"email": "unsub@example.com"},
     )
+    # Fetch the token the subscribe flow generated from the test DB.
+    from app.models import NewsletterSubscriber
+    from tests.conftest import TestingSessionLocal
+
+    db = TestingSessionLocal()
+    subscriber = (
+        db.query(NewsletterSubscriber)
+        .filter(NewsletterSubscriber.email == "unsub@example.com")
+        .first()
+    )
+    token = subscriber.unsubscribe_token
+    db.close()
+
     response = client.post(
         "/api/newsletter/unsubscribe",
-        json={"email": "unsub@example.com"},
+        json={"token": token},
     )
     assert response.status_code == 200
     assert response.json()["message"] == "Successfully unsubscribed"
 
 
-def test_unsubscribe_not_found(client):
+def test_unsubscribe_invalid_token(client):
     response = client.post(
         "/api/newsletter/unsubscribe",
-        json={"email": "never-subscribed@example.com"},
+        json={"token": "does-not-exist"},
     )
-    assert response.status_code == 404
+    assert response.status_code == 400
 
 
 def test_reactivate_after_unsubscribe(client):
+    from app.models import NewsletterSubscriber
+    from tests.conftest import TestingSessionLocal
+
     client.post(
         "/api/newsletter/subscribe",
         json={"email": "reactivate@example.com"},
     )
+    db = TestingSessionLocal()
+    subscriber = (
+        db.query(NewsletterSubscriber)
+        .filter(NewsletterSubscriber.email == "reactivate@example.com")
+        .first()
+    )
+    token = subscriber.unsubscribe_token
+    db.close()
+
     client.post(
         "/api/newsletter/unsubscribe",
-        json={"email": "reactivate@example.com"},
+        json={"token": token},
     )
     response = client.post(
         "/api/newsletter/subscribe",


### PR DESCRIPTION
## 📄 Description
The newsletter subscribe endpoint returned 200 for every request, hiding whether a new subscriber was created. New subscriptions and reactivations now return 201 while duplicates return 200. The stale tests were also updated to the token-based unsubscribe contract.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6576

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.