### PR TITLE
test: added pagination boundary coverage to products endpoint

### DIFF
--- a/backend/tests/test_products.py
+++ b/backend/tests/test_products.py
@@ -70,3 +70,36 @@ def test_products_checkout_endpoint_removed(client):
     assert remaining is not None
     assert remaining.stock == starting_stock
     db.close()
+
+
+def test_get_products_negative_skip_clamps(client):
+    db = TestingSessionLocal()
+    for i in range(3):
+        _seed_product(db, name=f"Clamp Product {i}")
+    db.close()
+
+    r = client.get(PRODUCTS_URL, params={"skip": -5, "limit": 2})
+    assert r.status_code == 200
+    assert len(r.json()) <= 2
+
+
+def test_get_products_limit_above_max_rejected(client):
+    r = client.get(PRODUCTS_URL, params={"limit": 500})
+    assert r.status_code == 422
+
+
+def test_get_products_skip_paginates(client):
+    db = TestingSessionLocal()
+    for i in range(5):
+        _seed_product(db, name=f"Page Product {i}")
+    db.close()
+
+    page1 = client.get(PRODUCTS_URL, params={"skip": 0, "limit": 2}).json()
+    page2 = client.get(PRODUCTS_URL, params={"skip": 2, "limit": 2}).json()
+
+    assert len(page1) == 2
+    assert len(page2) == 2
+    # The two pages must not overlap on product ids.
+    ids1 = {p["id"] for p in page1}
+    ids2 = {p["id"] for p in page2}
+    assert ids1.isdisjoint(ids2)


### PR DESCRIPTION
## 📄 Description
Adds backend test coverage to tests/test_products.py for pagination boundaries on the products list endpoint: negative skip clamping, limits above the 100 max returning 422, and non-overlapping page boundaries.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6577

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.