### PR TITLE
test: added input edge coverage to address suggest endpoint

### DIFF
--- a/backend/tests/test_address.py
+++ b/backend/tests/test_address.py
@@ -22,3 +22,26 @@ def test_address_suggestions_empty_no_matches(client: TestClient):
     body = resp.json()
     assert isinstance(body, list)
     assert len(body) == 0
+
+
+def test_address_suggestions_case_insensitive(client: TestClient):
+    resp = client.get("/api/address/suggest?q=mG%20rOaD")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["street"] == "12/A MG Road"
+
+
+def test_address_suggestions_matches_city(client: TestClient):
+    resp = client.get("/api/address/suggest?q=pune")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert any(addr["city"] == "Pune" for addr in body)
+
+
+def test_address_suggestions_limits_to_five(client: TestClient):
+    # A query matching many records must return at most 5 suggestions.
+    resp = client.get("/api/address/suggest?q=road")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) <= 5


### PR DESCRIPTION
## 📄 Description
Adds backend test coverage to tests/test_address.py for the address suggest endpoint: case-insensitive matching, city-based matching, and the five-result limit.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6578

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.