### PR TITLE
test: added captcha and reset token edge coverage to auth tests

### DIFF
--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -44,6 +44,30 @@ def test_register_invalid_email(client):
     assert r.status_code == 422
 
 
+def test_register_username_too_short(client):
+    r = client.post(REGISTER_URL, json={**VALID_USER, "username": "ab"})
+    assert r.status_code == 422
+
+
+def test_register_weak_password(client):
+    r = client.post(REGISTER_URL, json={**VALID_USER, "password": "weak"})
+    assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Captcha
+# ---------------------------------------------------------------------------
+
+def test_captcha_returns_image_and_token(client):
+    r = client.get("/api/auth/captcha")
+    assert r.status_code == 200
+    body = r.json()
+    assert "captcha_image" in body
+    assert body["captcha_image"].startswith("data:image/png;base64,")
+    assert "captcha_token" in body
+    assert body["captcha_token"]
+
+
 # ---------------------------------------------------------------------------
 # Login
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_password_reset.py
+++ b/backend/tests/test_password_reset.py
@@ -8,13 +8,41 @@ def test_forgot_password_nonexistent_email(client):
     assert "message" in data
 
 
+def test_forgot_password_dummy_token_without_smtp(client, monkeypatch):
+    # With SMTP unset, the endpoint returns a dummy reset token directly so the
+    # frontend fallback flow can continue.
+    from app.api import auth as auth_api
+    monkeypatch.setattr(auth_api, "SMTP_HOST", "")
+    response = client.post(
+        "/api/auth/forgot-password",
+        json={"email": "ghost@example.com"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "reset_token" in data
+    assert data["reset_token"].startswith("dummy_")
+
+
+def test_reset_password_accepts_dummy_token(client, monkeypatch):
+    from app.api import auth as auth_api
+    monkeypatch.setattr(auth_api, "SMTP_HOST", "")
+    # Generate a valid dummy token the same way the endpoint does.
+    token = auth_api.generate_dummy_token()
+    response = client.post(
+        "/api/auth/reset-password",
+        json={"token": token, "new_password": "NewPass@456"},
+    )
+    assert response.status_code == 200
+    assert response.json()["message"] == "Password has been reset successfully"
+
+
 def test_forgot_password_existing_email(client, db_session):
-    from backend.app.models import User
+    from app.models import User
     from passlib.context import CryptContext
     pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
     user = User(
-        username="testuser",
+        username="forgotuser",
         email="test@example.com",
         hashed_password=pwd.hash("Test@1234"),
     )
@@ -31,7 +59,7 @@ def test_forgot_password_existing_email(client, db_session):
 
 
 def test_reset_password_valid_token(client, db_session):
-    from backend.app.models import User, PasswordResetToken
+    from app.models import User, PasswordResetToken
     from passlib.context import CryptContext
     from datetime import datetime, timedelta, timezone
     import secrets


### PR DESCRIPTION
## 📄 Description
Adds backend test coverage to tests/test_auth.py and tests/test_password_reset.py: captcha image/token shape, register username and password validation boundaries, the dummy-token fallback path for forgot/reset password, plus fixes for two broken backend.app imports in the reset tests.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6580

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.