### PR TITLE
test: added lazy init and reuse coverage to a11y-announcer

### DIFF
--- a/tests/unit/a11y-announcer.test.js
+++ b/tests/unit/a11y-announcer.test.js
@@ -95,4 +95,40 @@ describe('a11y-announcer Unit Tests', () => {
     expect(() => announce('')).not.toThrow();
     expect(() => announce(null)).not.toThrow();
   });
+
+  it('should lazily create live regions when announce is called first', () => {
+    // No explicit initAnnouncer() call; announce should create the regions.
+    announce('Lazy init works');
+    vi.advanceTimersByTime(100);
+
+    const polite = document.getElementById('a11y-announcer-polite');
+    expect(polite).not.toBeNull();
+    expect(polite.textContent).toBe('Lazy init works');
+  });
+
+  it('should reuse existing live regions instead of duplicating them', () => {
+    const existing = document.createElement('div');
+    existing.id = 'a11y-announcer-polite';
+    existing.className = 'sr-only';
+    existing.setAttribute('aria-live', 'polite');
+    document.body.appendChild(existing);
+
+    initAnnouncer();
+    expect(document.querySelectorAll('#a11y-announcer-polite').length).toBe(1);
+
+    announce('Reused region');
+    vi.advanceTimersByTime(100);
+    expect(existing.textContent).toBe('Reused region');
+  });
+
+  it('should replace prior text before announcing new content', () => {
+    initAnnouncer();
+    announce('First message');
+    vi.advanceTimersByTime(100);
+    announce('Second message');
+    vi.advanceTimersByTime(100);
+
+    const polite = document.getElementById('a11y-announcer-polite');
+    expect(polite.textContent).toBe('Second message');
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/a11y-announcer.test.js for lazy live-region creation from announce, reusing existing regions without duplication, and replacing prior announcement text.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6581

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.