### PR TITLE
test: ran real a11y-validation audit in tests

### DIFF
--- a/tests/unit/a11y-validation.test.js
+++ b/tests/unit/a11y-validation.test.js
@@ -4,6 +4,9 @@
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
+// Load the real module so window.runA11yAudit is exposed.
+import '../../js/a11y-validation.js';
+
 // Extract the audit logic for unit testing.
 // Mirrors the checks in js/a11y-validation.js.
 function runA11yAudit(document) {
@@ -181,6 +184,31 @@ describe('A11y Validation Audit', () => {
     doc.innerHTML = '<img src="test.jpg">';
     const results = runA11yAudit(doc);
     expect(results.errors.length).toBe(1);
+  });
+
+  describe('Real module audit function', () => {
+    it('exposes runA11yAudit on the window', () => {
+      expect(typeof window.runA11yAudit).toBe('function');
+    });
+
+    it('runs the real audit on a compliant page without throwing', () => {
+      document.body.innerHTML = `
+        <img src="ok.jpg" alt="Ok image" />
+        <button>Submit</button>
+        <label for="name">Name</label>
+        <input type="text" id="name" name="name" />
+      `;
+      expect(() => window.runA11yAudit()).not.toThrow();
+    });
+
+    it('runs the real audit on a violating page without throwing', () => {
+      document.body.innerHTML = `
+        <img src="bad.jpg" />
+        <button></button>
+        <input type="text" name="unnamed" />
+      `;
+      expect(() => window.runA11yAudit()).not.toThrow();
+    });
   });
 
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/a11y-validation.test.js that exercises the real window.runA11yAudit function from the module on compliant and violating DOMs, instead of only testing the mirrored replica logic.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6582

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.