### PR TITLE
fix: bound register-interests handlers on immediate DOM ready state

### DIFF
--- a/js/register-interests.js
+++ b/js/register-interests.js
@@ -1,7 +1,11 @@
 // Interactive Newsletter Interest Selector
-document.addEventListener('DOMContentLoaded', () => {
+function initInterests() {
+  if (typeof document === 'undefined') return;
   const form = document.querySelector('form');
   if (!form) return;
+
+  // Skip re-initialization if the widget is already present.
+  if (document.querySelector('.newsletter-interests-wrapper')) return;
 
   const interestContainer = document.createElement('div');
   interestContainer.className = 'newsletter-interests-wrapper';
@@ -40,4 +44,9 @@ document.addEventListener('DOMContentLoaded', () => {
         selectedList.join(',');
     });
   });
-});
+}
+
+// Initialize when the DOM is ready. The immediate idempotent call covers
+// deferred scripts that load after DOMContentLoaded has already fired.
+document.addEventListener('DOMContentLoaded', initInterests);
+initInterests();

--- a/tests/unit/register-interests.test.js
+++ b/tests/unit/register-interests.test.js
@@ -6,6 +6,47 @@ describe('register-interests.js unit tests', function () {
     vi.restoreAllMocks();
   });
 
+  it('initializes the interest widget immediately when the DOM is ready', async function () {
+    vi.resetModules();
+    Object.defineProperty(document, 'readyState', {
+      configurable: true,
+      value: 'complete',
+    });
+    document.body.innerHTML = `
+      <form id="reg-form">
+        <button type="submit">Register</button>
+      </form>
+    `;
+    await import('../../js/register-interests.js');
+
+    const container = document.querySelector('.newsletter-interests-wrapper');
+    expect(container).not.toBeNull();
+    expect(document.querySelectorAll('.interest-chip').length).toBe(3);
+  });
+
+  it('toggles the hidden interests input when chips are clicked', async function () {
+    vi.resetModules();
+    Object.defineProperty(document, 'readyState', {
+      configurable: true,
+      value: 'complete',
+    });
+    document.body.innerHTML = `
+      <form id="reg-form">
+        <button type="submit">Register</button>
+      </form>
+    `;
+    await import('../../js/register-interests.js');
+
+    const hidden = document.getElementById('selected-interests');
+    const chips = document.querySelectorAll('.interest-chip');
+    chips[0].click();
+    expect(hidden.value).toBe('mens');
+    chips[1].click();
+    expect(hidden.value).toBe('mens,womens');
+    chips[0].click();
+    expect(hidden.value).toBe('womens');
+  });
+
   it('chip click toggles selected state', function () {
     var selectedList = [];
     var chip = document.createElement('span');


### PR DESCRIPTION
## 📄 Description
js/register-interests.js only registered a DOMContentLoaded listener, so a deferred script loaded after the event never injected the interest selector. The module now initializes immediately (idempotently) and keeps the event listener for early scripts.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6583

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.