### PR TITLE
fix: made checkout-timer resilient to missing DOM elements

### DIFF
--- a/js/checkout-timer.js
+++ b/js/checkout-timer.js
@@ -1,7 +1,11 @@
 // Checkout Promo Count Down Timer
-document.addEventListener('DOMContentLoaded', () => {
+function initCheckoutTimer() {
+  if (typeof document === 'undefined') return;
   const totalEl = document.getElementById('summary-total');
   if (!totalEl) return;
+
+  // Skip re-initialization if the timer bar is already present.
+  if (document.getElementById('checkout-promo-alert-bar')) return;
 
   // Inject Urgency Bar at the top of checkout content
   const checkoutHeader =
@@ -59,4 +63,9 @@ document.addEventListener('DOMContentLoaded', () => {
       window.updateCheckoutSummary();
     }
   }
-});
+}
+
+// Initialize when the DOM is ready. The immediate idempotent call covers
+// deferred scripts that load after DOMContentLoaded has already fired.
+document.addEventListener('DOMContentLoaded', initCheckoutTimer);
+initCheckoutTimer();

--- a/tests/unit/checkout-timer.test.js
+++ b/tests/unit/checkout-timer.test.js
@@ -131,4 +131,44 @@ describe('Checkout Timer Unit Tests', () => {
     expect(timerExpired).toBe(true);
   });
 
+  it('does nothing when the summary total element is missing', async () => {
+    vi.resetModules();
+    document.body.innerHTML = '<div class="checkout-container"></div>';
+    await import('../../js/checkout-timer.js');
+    expect(document.getElementById('checkout-promo-alert-bar')).toBeNull();
+  });
+
+  it('initializes the timer bar immediately when the DOM is ready', async () => {
+    vi.resetModules();
+    Object.defineProperty(document, 'readyState', {
+      configurable: true,
+      value: 'complete',
+    });
+    document.body.innerHTML = `
+      <div id="summary-total"></div>
+      <div class="checkout-container"></div>
+    `;
+    await import('../../js/checkout-timer.js');
+
+    const bar = document.getElementById('checkout-promo-alert-bar');
+    expect(bar).not.toBeNull();
+    expect(document.getElementById('checkout-timer').textContent).toBe('15:00');
+  });
+
+  it('updates the displayed time as the timer ticks down', async () => {
+    vi.resetModules();
+    Object.defineProperty(document, 'readyState', {
+      configurable: true,
+      value: 'complete',
+    });
+    document.body.innerHTML = `
+      <div id="summary-total"></div>
+      <div class="checkout-container"></div>
+    `;
+    await import('../../js/checkout-timer.js');
+
+    vi.advanceTimersByTime(1000);
+    expect(document.getElementById('checkout-timer').textContent).toBe('14:59');
+  });
+
 });


### PR DESCRIPTION
## 📄 Description
js/checkout-timer.js only ran on DOMContentLoaded and could crash or duplicate its urgency bar. The setup is now an idempotent function that initializes immediately when the DOM is ready, no-ops without the summary-total element, and skips re-initialization when the bar already exists.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6584

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.