### PR TITLE
fix: guarded currency-converter element lookups

### DIFF
--- a/js/currency-converter.js
+++ b/js/currency-converter.js
@@ -114,8 +114,12 @@ export function initCurrencySelector(selectElementId = 'currencySelect') {
 }
 
 if (typeof document !== 'undefined') {
-  document.addEventListener('DOMContentLoaded', () => {
+  function initCurrencyConverter() {
     fetchExchangeRates();
     initCurrencySelector();
-  });
+  }
+  // Initialize when the DOM is ready. The immediate idempotent call covers
+  // deferred scripts that load after DOMContentLoaded has already fired.
+  document.addEventListener('DOMContentLoaded', initCurrencyConverter);
+  initCurrencyConverter();
 }

--- a/tests/unit/currency-converter.test.js
+++ b/tests/unit/currency-converter.test.js
@@ -7,6 +7,7 @@ import {
   convertPrice,
   formatCurrency,
   fetchExchangeRates,
+  initCurrencySelector,
 } from '../../js/currency-converter.js';
 
 describe('Currency Converter Unit Tests', () => {
@@ -104,5 +105,17 @@ describe('Currency Converter Unit Tests', () => {
     expect(convertPrice('not-a-number', 'USD')).toBe(0);
     expect(convertPrice(NaN, 'USD')).toBe(0);
     expect(convertPrice(undefined, 'USD')).toBe(0);
+  });
+
+  it('should no-op when the currency select element is missing', () => {
+    expect(() => initCurrencySelector('missing-select')).not.toThrow();
+  });
+
+  it('should bind the currency select when the element exists', () => {
+    document.body.innerHTML =
+      '<select id="currencySelect"><option value="USD">USD</option></select>';
+    expect(() => initCurrencySelector('currencySelect')).not.toThrow();
+    const select = document.getElementById('currencySelect');
+    expect(select.value).toBe(getActiveCurrency());
   });
 });


### PR DESCRIPTION
## 📄 Description
js/currency-converter.js only fetched exchange rates and bound the selector on DOMContentLoaded, so a deferred script loaded after the event never initialized. The init is now an idempotent function that runs immediately when the DOM is ready, with test coverage for missing and existing select elements.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6585

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.