### PR TITLE
test: added validation edge coverage to profile endpoint

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -70,13 +70,18 @@ def auth_headers(client, db_session):
     from app.models import User
     from passlib.context import CryptContext
     pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
-    user = User(
-        username="testuser",
-        email="test@example.com",
-        hashed_password=pwd.hash("Test@1234"),
-    )
-    db_session.add(user)
-    db_session.commit()
+
+    # Reuse an existing testuser so the fixture is idempotent across tests
+    # that share the session-scoped database.
+    user = db_session.query(User).filter(User.email == "test@example.com").first()
+    if user is None:
+        user = User(
+            username="testuser",
+            email="test@example.com",
+            hashed_password=pwd.hash("Test@1234"),
+        )
+        db_session.add(user)
+        db_session.commit()
 
     response = client.post(
         "/api/auth/login",
@@ -91,14 +96,19 @@ def admin_auth_headers(client, db_session):
     from app.models import User
     from passlib.context import CryptContext
     pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
-    user = User(
-        username="adminuser",
-        email="admin@example.com",
-        hashed_password=pwd.hash("Admin@1234"),
-        role="ADMIN",
-    )
-    db_session.add(user)
-    db_session.commit()
+
+    # Reuse an existing adminuser so the fixture is idempotent across tests
+    # that share the session-scoped database.
+    user = db_session.query(User).filter(User.email == "admin@example.com").first()
+    if user is None:
+        user = User(
+            username="adminuser",
+            email="admin@example.com",
+            hashed_password=pwd.hash("Admin@1234"),
+            role="ADMIN",
+        )
+        db_session.add(user)
+        db_session.commit()
 
     response = client.post(
         "/api/auth/login",

--- a/backend/tests/test_profile.py
+++ b/backend/tests/test_profile.py
@@ -54,3 +54,42 @@ def test_get_profile_after_update(client, auth_headers):
     assert response.status_code == 200
     assert response.json()["full_name"] == "Jane Doe"
     assert response.json()["phone"] == "+1-555-0200"
+
+
+def test_get_profile_requires_auth(client):
+    response = client.get("/api/profile/")
+    assert response.status_code == 401
+
+
+def test_update_profile_requires_auth(client):
+    response = client.put("/api/profile/", json={"full_name": "No Auth"})
+    assert response.status_code == 401
+
+
+def test_update_profile_rejects_empty_body(client, auth_headers):
+    response = client.put("/api/profile/", json={}, headers=auth_headers)
+    assert response.status_code == 200
+    # Empty body must leave the profile unchanged.
+    data = response.json()
+    assert data["email"] == "test@example.com"
+
+
+def test_update_profile_persists_multiple_fields(client, auth_headers):
+    response = client.put(
+        "/api/profile/",
+        json={
+            "full_name": "Alex Doe",
+            "phone": "+1-555-0300",
+            "address_line1": "456 Oak Ave",
+            "city": "Chicago",
+            "state": "IL",
+            "zip_code": "60601",
+        },
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["full_name"] == "Alex Doe"
+    assert data["phone"] == "+1-555-0300"
+    assert data["address_line1"] == "456 Oak Ave"
+    assert data["zip_code"] == "60601"


### PR DESCRIPTION
## 📄 Description
Adds backend test coverage to tests/test_profile.py for unauthenticated access, empty-body updates, and multi-field persistence. Also makes the auth_headers and admin_auth_headers fixtures in conftest.py idempotent so tests sharing the session-scoped database no longer collide on the unique username constraint.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6586

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.