### PR TITLE
test: added cancellation window edge coverage to order cancel

### DIFF
--- a/backend/tests/test_order_cancel.py
+++ b/backend/tests/test_order_cancel.py
@@ -231,3 +231,48 @@ def test_order_uses_product_id_when_duplicate_names_exist(client):
     assert item.product_id == expensive_id
     assert item.price == 999.0
     db.close()
+
+
+def test_cancel_rejected_outside_24h_window(client):
+    from datetime import datetime, timedelta, timezone
+    from app.models import OrderItem
+
+    headers = _auth_headers(client, username="olduser", email="old@example.com")
+    db = TestingSessionLocal()
+    product = _seed_product(db, name="Old Window Shirt", stock=10)
+    product_id = product.id
+    db.close()
+
+    create = client.post(
+        ORDERS_URL,
+        headers=headers,
+        json={
+            "fullName": "Old User",
+            "email": "old@example.com",
+            "address": "1 Test St",
+            "city": "Testville",
+            "zip": "12345",
+            "items": [{"product_id": product_id, "quantity": 1}],
+        },
+    )
+    assert create.status_code == 201, create.text
+    order_id = create.json()["order_id"]
+
+    # Age the order beyond the 24h cancellable window while keeping the
+    # status cancellable (CONFIRMED).
+    db = TestingSessionLocal()
+    order = db.query(Order).filter(Order.id == order_id).one()
+    order.created_at = datetime.now(timezone.utc) - timedelta(hours=25)
+    db.commit()
+    db.close()
+
+    response = client.post(f"{ORDERS_URL}{order_id}/cancel", headers=headers)
+    assert response.status_code == 400, response.text
+    assert "within 24 hours" in response.json()["detail"]
+
+    # Stock must NOT be restored since the cancellation was rejected.
+    db = TestingSessionLocal()
+    assert db.query(Product).filter(Product.id == product_id).one().stock == 9
+    assert db.query(Order).filter(Order.id == order_id).one().status == "CONFIRMED"
+    assert db.query(OrderItem).filter(OrderItem.order_id == order_id).count() == 1
+    db.close()


### PR DESCRIPTION
## 📄 Description
Adds backend test coverage to tests/test_order_cancel.py for cancelling a CONFIRMED order aged beyond the 24h cancellable window, verifying a 400 response and that stock is not restored.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6587

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.