### PR TITLE
test: added resubscribe coverage to newsletter tests

### DIFF
--- a/backend/tests/test_newsletter.py
+++ b/backend/tests/test_newsletter.py
@@ -50,17 +50,54 @@ def test_unsubscribe_not_found(client):
 
 
 def test_reactivate_after_unsubscribe(client):
+    from app.models import NewsletterSubscriber
+    from tests.conftest import TestingSessionLocal
+
     client.post(
         "/api/newsletter/subscribe",
-        json={"email": "reactivate@example.com"},
+        json={"email": "resub@example.com"},
     )
+
+    def _token_for(email):
+        db = TestingSessionLocal()
+        sub = (
+            db.query(NewsletterSubscriber)
+            .filter(NewsletterSubscriber.email == email)
+            .first()
+        )
+        token = sub.unsubscribe_token
+        db.close()
+        return token
+
+    first_token = _token_for("resub@example.com")
+    assert first_token
+
+    # Unsubscribe, then resubscribe.
     client.post(
         "/api/newsletter/unsubscribe",
-        json={"email": "reactivate@example.com"},
+        json={"token": first_token},
     )
-    response = client.post(
+    resub = client.post(
         "/api/newsletter/subscribe",
-        json={"email": "reactivate@example.com"},
+        json={"email": "resub@example.com"},
     )
-    assert response.status_code == 201
-    assert response.json()["message"] == "Subscription reactivated"
+    assert resub.status_code == 201
+
+    # The subscriber is active again and still has a valid token.
+    second_token = _token_for("resub@example.com")
+    assert second_token
+    db = TestingSessionLocal()
+    sub = (
+        db.query(NewsletterSubscriber)
+        .filter(NewsletterSubscriber.email == "resub@example.com")
+        .first()
+    )
+    assert sub.is_active is True
+    db.close()
+
+    # The (reused) token can unsubscribe again.
+    unsub = client.post(
+        "/api/newsletter/unsubscribe",
+        json={"token": second_token},
+    )
+    assert unsub.status_code == 200


### PR DESCRIPTION
## 📄 Description
Adds backend test coverage to tests/test_newsletter.py for the full resubscribe flow: subscribe, unsubscribe with the token, resubscribe to 201, confirm the subscriber is active again, and that the token still unsubscribes.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6590

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.