### PR TITLE
fix: guarded shop-sort-filter element reads

### DIFF
--- a/js/shop-sort-filter.js
+++ b/js/shop-sort-filter.js
@@ -1,9 +1,13 @@
 // Dynamic Catalog Sorter and Filter
-document.addEventListener('DOMContentLoaded', () => {
+function initShopSortFilter() {
+  if (typeof document === 'undefined') return;
   const productsContainer =
     document.getElementById('shop-products-container') ||
     document.querySelector('.pro-container');
   if (!productsContainer) return;
+
+  // Skip re-initialization if the control panel is already present.
+  if (document.getElementById('catalog-sorter')) return;
 
   // Inject Sort Control Panel
   const controlPanel = document.createElement('div');
@@ -76,4 +80,9 @@ document.addEventListener('DOMContentLoaded', () => {
   document
     .getElementById('catalog-sorter')
     .addEventListener('change', filterAndSort);
-});
+}
+
+// Initialize when the DOM is ready. The immediate idempotent call covers
+// deferred scripts that load after DOMContentLoaded has already fired.
+document.addEventListener('DOMContentLoaded', initShopSortFilter);
+initShopSortFilter();

--- a/tests/unit/shop-sort-filter.test.js
+++ b/tests/unit/shop-sort-filter.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 describe('js/shop-sort-filter.js — price parsing logic', () => {
   it('extracts price from text containing Rs. symbol', () => {
@@ -60,5 +60,40 @@ describe('js/shop-sort-filter.js — price parsing logic', () => {
     });
     expect(sorted[0].textContent).toBe('Rs. 250');
     expect(sorted[2].textContent).toBe('Rs. 50');
+  });
+
+  it('injects the sort controls immediately when the DOM is ready', async () => {
+    vi.resetModules();
+    Object.defineProperty(document, 'readyState', {
+      configurable: true,
+      value: 'complete',
+    });
+    document.body.innerHTML = `
+      <div id="shop-products-container">
+        <div class="pro"><h4>Rs. 100</h4></div>
+      </div>
+    `;
+    await import('../../js/shop-sort-filter.js');
+
+    expect(document.getElementById('price-filter')).not.toBeNull();
+    expect(document.getElementById('catalog-sorter')).not.toBeNull();
+  });
+
+  it('does not duplicate the sort controls on re-initialization', async () => {
+    vi.resetModules();
+    Object.defineProperty(document, 'readyState', {
+      configurable: true,
+      value: 'complete',
+    });
+    document.body.innerHTML = `
+      <div id="shop-products-container">
+        <div class="pro"><h4>Rs. 100</h4></div>
+      </div>
+    `;
+    await import('../../js/shop-sort-filter.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(document.querySelectorAll('#catalog-sorter').length).toBe(1);
+    expect(document.querySelectorAll('#price-filter').length).toBe(1);
   });
 });


### PR DESCRIPTION
## 📄 Description
js/shop-sort-filter.js only ran on DOMContentLoaded, so a deferred script loaded after the event never injected the sort controls. The panel now initializes immediately when the DOM is ready, with an idempotency guard against duplicates.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6592

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.