### PR TITLE
fix: trimmed whitespace-only product-search queries

### DIFF
--- a/js/product-search.js
+++ b/js/product-search.js
@@ -276,6 +276,22 @@
   // ── Attach event listeners ─────────────────────────────────────────────────
   const debouncedSearch = debounce(() => {
     filters.q = searchInput ? searchInput.value.trim() : '';
+    // Skip the API call for whitespace-only input with no other active filters.
+    if (!filters.q) {
+      const hasFilters =
+        filters.category ||
+        filters.subcategory ||
+        filters.color ||
+        filters.style ||
+        filters.min_price !== '' ||
+        filters.max_price !== '' ||
+        filters.min_rating !== '' ||
+        filters.in_stock;
+      if (!hasFilters) {
+        if (productGrid) productGrid.innerHTML = '';
+        return;
+      }
+    }
     filters.page = 1;
     fetchAndRender();
   }, DEBOUNCE_MS);

--- a/tests/unit/product-search.test.js
+++ b/tests/unit/product-search.test.js
@@ -62,6 +62,33 @@ describe('product-search', () => {
   });
 
   it('should enforce minimum search query character length threshold', () => { expect(true).toBe(true); });
+
+  it('skips the API call for whitespace-only input', async () => {
+    global.fetch.mockImplementation((url) => {
+      if (String(url).includes('/categories')) {
+        return Promise.resolve({ ok: true, json: async () => ({ categories: [] }) });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ total: 0, page: 1, page_size: 20, products: [] }),
+      });
+    });
+    await load();
+    const callsBefore = global.fetch.mock.calls.filter(([url]) =>
+      String(url).includes('/search/query'),
+    ).length;
+
+    const input = document.getElementById('productSearchInput');
+    input.value = '   ';
+    input.dispatchEvent(new Event('input'));
+    // Advance the debounce.
+    await new Promise((r) => setTimeout(r, 350));
+
+    const callsAfter = global.fetch.mock.calls.filter(([url]) =>
+      String(url).includes('/search/query'),
+    ).length;
+    expect(callsAfter).toBe(callsBefore);
+  });
 });
 
 describe('meetsSearchQueryThreshold', () => {


### PR DESCRIPTION
## 📄 Description
js/product-search.js fired a search request even for whitespace-only input, wasting API calls. The debounced search now trims the query and skips the call when the input is blank and no other filters are active.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6593

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.