### PR TITLE
test: added whitespace normalization coverage to address-validation-service

### DIFF
--- a/tests/unit/address-validation-service.test.js
+++ b/tests/unit/address-validation-service.test.js
@@ -82,4 +82,36 @@ describe('AddressValidationService Unit Tests', () => {
     expect(result.sanitized.state).toBe('ENGLAND');
     expect(result.sanitized.country).toBe('UK');
   });
+
+  it('should accept addresses with leading and trailing whitespace', () => {
+    const result = service.validateAddress({
+      street: '  123 Main Street  ',
+      city: '  Denver  ',
+      state: ' CO ',
+      postalCode: ' 80202 ',
+      country: 'US'
+    });
+    expect(result.isValid).toBe(true);
+    expect(result.sanitized.street).toBe('123 Main Street');
+    expect(result.sanitized.city).toBe('Denver');
+    expect(result.sanitized.state).toBe('CO');
+    expect(result.sanitized.postalCode).toBe('80202');
+  });
+
+  it('should trim the postal code before validating', () => {
+    expect(service.validatePostalCode('  90210  ', 'US').valid).toBe(true);
+    expect(service.validatePostalCode(' 400001 ', 'IN').valid).toBe(true);
+  });
+
+  it('should still reject a short street after trimming whitespace', () => {
+    const result = service.validateAddress({
+      street: '  123  ',
+      city: 'Austin',
+      state: 'TX',
+      postalCode: '73301',
+      country: 'US'
+    });
+    expect(result.isValid).toBe(false);
+    expect(result.errors.street).toBeDefined();
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/address-validation-service.test.js proving address fields with leading and trailing whitespace are trimmed before validation, postal codes are trimmed, and short streets are still rejected after trimming.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6594

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.