### PR TITLE
fix: guarded delivery-date-estimator against invalid dates

### DIFF
--- a/js/delivery-date-estimator.js
+++ b/js/delivery-date-estimator.js
@@ -13,6 +13,11 @@ export class DeliveryDateEstimator {
     let daysAdded = 0;
     const current = new Date(orderDate);
 
+    // Guard against invalid date inputs so toISOString never throws.
+    if (Number.isNaN(current.getTime())) {
+      return null;
+    }
+
     while (daysAdded < targetDays) {
       current.setDate(current.getDate() + 1);
       const dayOfWeek = current.getDay();

--- a/tests/unit/delivery-date-estimator.test.js
+++ b/tests/unit/delivery-date-estimator.test.js
@@ -33,4 +33,13 @@ describe('DeliveryDateEstimator', () => {
     const estimated = estimator.estimateDeliveryDate(start, false);
     expect(estimated).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
+
+  it('returns null for an invalid date input', () => {
+    expect(estimator.estimateDeliveryDate('not-a-date')).toBeNull();
+    expect(estimator.estimateDeliveryDate(NaN)).toBeNull();
+  });
+
+  it('returns null for a date object that cannot parse', () => {
+    expect(estimator.estimateDeliveryDate(new Date('bogus'))).toBeNull();
+  });
 });


### PR DESCRIPTION
## 📄 Description
js/delivery-date-estimator.js estimateDeliveryDate threw a RangeError from toISOString when given an invalid date. It now returns null for unparseable inputs, with tests covering string and Date-object invalid inputs.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6595

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.