### PR TITLE
fix: carried coupon code in the couponRemoved event payload

### DIFF
--- a/js/coupon-validator.js
+++ b/js/coupon-validator.js
@@ -87,6 +87,7 @@
 
   // ── Remove coupon logic ────────────────────────────────────────────────────
   function removeCoupon() {
+    const removedCode = window.appliedCoupon || '';
     window.appliedCoupon = '';
     removeAppliedCoupon();
     if (couponInput) {
@@ -95,7 +96,9 @@
     }
     showFeedback('Coupon removed.', 'info');
 
-    window.dispatchEvent(new CustomEvent('couponRemoved'));
+    window.dispatchEvent(
+      new CustomEvent('couponRemoved', { detail: { code: removedCode } }),
+    );
     if (typeof window.updateCheckoutSummary === 'function') {
       window.updateCheckoutSummary();
     }

--- a/tests/unit/coupon-validator.test.js
+++ b/tests/unit/coupon-validator.test.js
@@ -57,6 +57,29 @@ describe('coupon-validator', () => {
     expect(listener).toHaveBeenCalledTimes(1);
   });
 
+  it('couponApplied event carries the code and discount payload', async () => {
+    document.getElementById('couponCodeInput').value = 'CARA20';
+    const listener = vi.fn();
+    window.addEventListener('couponApplied', listener);
+    await load();
+    apply();
+
+    const detail = listener.mock.calls[0][0].detail;
+    expect(detail.code).toBe('CARA20');
+    expect(detail.discountPct).toBe(20);
+  });
+
+  it('dispatches couponRemoved event when the coupon is removed', async () => {
+    window.appliedCoupon = 'CARA20';
+    const listener = vi.fn();
+    window.addEventListener('couponRemoved', listener);
+    await load();
+    window.removeCoupon();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0][0].detail).toEqual({ code: 'CARA20' });
+  });
+
   it('removes the coupon via the exposed helper', async () => {
     window.appliedCoupon = 'CARA20';
     await load();


### PR DESCRIPTION
## 📄 Description
The couponRemoved event carried no detail payload, so consumers could not tell which coupon was removed. The event now includes the removed code, and tests assert both the couponApplied and couponRemoved payloads.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6597

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.