### PR TITLE
test: added retry behavior coverage to error-boundary

### DIFF
--- a/tests/unit/error-boundary.test.js
+++ b/tests/unit/error-boundary.test.js
@@ -93,4 +93,34 @@ describe('error-boundary.js unit tests', () => {
     expect(container.querySelector('.ok')).not.toBeNull();
     expect(container.querySelector('.cara-error-fallback')).toBeNull();
   });
+
+  it('retry replaces the fallback with the rendered content on success', () => {
+    let callCount = 0;
+    const renderFn = vi.fn(() => {
+      callCount++;
+      if (callCount === 1) throw new Error('first fail');
+      container.innerHTML = '<p class="recovered">loaded</p>';
+    });
+    CaraErrorBoundary.wrap('#test-target', renderFn);
+    expect(container.querySelector('.cara-error-fallback')).not.toBeNull();
+
+    container.querySelector('.cara-error-retry').click();
+    expect(callCount).toBe(2);
+    expect(container.querySelector('.recovered')).not.toBeNull();
+    expect(container.querySelector('.cara-error-fallback')).toBeNull();
+  });
+
+  it('retry keeps showing the fallback when renderFn keeps failing', () => {
+    const renderFn = vi.fn(() => {
+      throw new Error('always fails');
+    });
+    CaraErrorBoundary.wrap('#test-target', renderFn);
+
+    const retryBtn = container.querySelector('.cara-error-retry');
+    retryBtn.click();
+    retryBtn.click();
+
+    expect(container.querySelector('.cara-error-fallback')).not.toBeNull();
+    expect(renderFn).toHaveBeenCalledTimes(3);
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/error-boundary.test.js for the retry button replacing the fallback with rendered content on success, and keeping the fallback while the render keeps failing.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6600

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.