### PR TITLE
docs: documented focus trap utility in README accessibility section

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ The frontend keeps small, focused helpers in `js/` that are reusable across page
 - `input-shield.js` — client-side XSS script-injection filtering on form submit.
 - `i18n.js`, `loyalty-rewards-engine.js`, `error-logger.js` — translation, loyalty points, and error logging helpers.
 - `utils/debounce.js` — reusable trailing-edge debounce utility for throttling rapid event handlers.
+- `a11y-focus-trap.js` — keyboard focus trap for modal and dialog flows so tab navigation stays contained.
+- `a11y-announcer.js` — ARIA live-region announcement manager for screen reader feedback.
 
 Many of these expose their logic on `window` (or as ES module exports) so they can be exercised by unit tests in `tests/unit/`.
 


### PR DESCRIPTION
## 📄 Description
Adds the js/a11y-focus-trap.js and js/a11y-announcer.js modules to the Frontend Utility Modules list in README.md so contributors can discover the accessibility helpers.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6602

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.