### PR TITLE
test: added missing key fallback coverage to i18n

### DIFF
--- a/tests/unit/i18n.test.js
+++ b/tests/unit/i18n.test.js
@@ -150,4 +150,19 @@ describe('formatI18nPlaceholder', () => {
   it('is exported as a callable function', () => {
     expect(typeof formatI18nPlaceholder).toBe('function');
   });
+
+  it('substitutes known parameters into the template', () => {
+    expect(formatI18nPlaceholder('Hello {{name}}', { name: 'Cara' })).toBe(
+      'Hello Cara',
+    );
+  });
+
+  it('renders missing parameters as empty strings', () => {
+    expect(formatI18nPlaceholder('Hello {{name}}', {})).toBe('Hello ');
+  });
+
+  it('returns an empty string for a falsy template', () => {
+    expect(formatI18nPlaceholder('')).toBe('');
+    expect(formatI18nPlaceholder(null)).toBe('');
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/i18n.test.js for formatI18nPlaceholder parameter substitution, missing parameters rendering empty, and falsy templates returning an empty string.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6605

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.