### PR TITLE
test: added tier boundary coverage to loyalty-rewards-engine

### DIFF
--- a/tests/unit/loyalty-rewards-engine.test.js
+++ b/tests/unit/loyalty-rewards-engine.test.js
@@ -40,6 +40,36 @@ describe('LoyaltyRewardsEngine Unit Tests', () => {
     expect(getRewardsMultiplierForTier('gold')).toBe(1.5);
     expect(getRewardsMultiplierForTier('platinum')).toBe(2.0);
   });
+
+  it('should assign tiers exactly at the point boundaries', () => {
+    engine.data.points = 499;
+    expect(engine.getTier().name).toBe('Bronze');
+    engine.data.points = 500;
+    expect(engine.getTier().name).toBe('Silver');
+    engine.data.points = 1500;
+    expect(engine.getTier().name).toBe('Gold');
+    engine.data.points = 3000;
+    expect(engine.getTier().name).toBe('Platinum');
+  });
+
+  it('should return the multiplier for a tier name via getMultiplier', () => {
+    expect(engine.getMultiplier('Bronze')).toBe(1.0);
+    expect(engine.getMultiplier('Silver')).toBe(1.25);
+    expect(engine.getMultiplier('Gold')).toBe(1.5);
+    expect(engine.getMultiplier('Platinum')).toBe(2.0);
+  });
+
+  it('should return 1.0 for an unknown tier name in getMultiplier', () => {
+    expect(engine.getMultiplier('Diamond')).toBe(1.0);
+    expect(engine.getMultiplier('')).toBe(1.0);
+  });
+
+  it('should reject redemption of more points than the balance', () => {
+    engine.addEarnedPoints(100);
+    const res = engine.redeemPoints(150);
+    expect(res.success).toBe(false);
+    expect(engine.getPoints()).toBe(100);
+  });
 });
 
 describe('getRewardsMultiplierForTier', () => {


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/loyalty-rewards-engine.test.js for exact tier point boundaries, getMultiplier for known and unknown tiers, and over-balance redemption rejection.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6606

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.