### PR TITLE
test: added gift message length boundary coverage

### DIFF
--- a/tests/unit/gift-options.test.js
+++ b/tests/unit/gift-options.test.js
@@ -82,4 +82,22 @@ describe('gift-options.js unit tests', () => {
     expect(window.validateGiftMessageLength('abc', 5)).toBe(true);
     expect(window.validateGiftMessageLength('abcdef', 5)).toBe(false);
   });
+
+  it('should trim the message before counting characters', async () => {
+    await import('../../js/gift-options.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    // 202 chars of raw content but only 200 after trimming.
+    const padded = '  ' + 'x'.repeat(200);
+    expect(window.validateGiftMessageLength(padded, 200)).toBe(true);
+    // 201 significant characters still fails.
+    expect(window.validateGiftMessageLength('x'.repeat(201), 200)).toBe(false);
+  });
+
+  it('should accept a whitespace-only message', async () => {
+    await import('../../js/gift-options.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(window.validateGiftMessageLength('     ', 200)).toBe(true);
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/gift-options.test.js for trimming before character counting, whitespace-only messages, and the 201-char rejection boundary.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6607

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.