### PR TITLE
test: added quantity boundary coverage to save-for-later-manager

### DIFF
--- a/tests/unit/save-for-later-manager.test.js
+++ b/tests/unit/save-for-later-manager.test.js
@@ -45,4 +45,26 @@ describe('SaveForLaterManager', () => {
     expect(manager.getSavedItems()).toEqual([]);
     expect(manager.saveItem({ id: 'p2' })).toBe(true);
   });
+
+  it('preserves the item quantity when moving it back to the cart', () => {
+    manager.saveItem({ id: 'p1', name: 'Hoodie', quantity: 3 });
+    const cart = [];
+    manager.moveToCart('p1', cart);
+    expect(cart[0].quantity).toBe(3);
+  });
+
+  it('saves items with zero or negative quantity as-is', () => {
+    // The module has no quantity validation; it must not reject these items.
+    expect(manager.saveItem({ id: 'q0', quantity: 0 })).toBe(true);
+    expect(manager.saveItem({ id: 'qneg', quantity: -2 })).toBe(true);
+    expect(manager.getSavedItems().length).toBe(2);
+  });
+
+  it('does not mutate the saved list when moving an unknown id', () => {
+    manager.saveItem({ id: 'p1', name: 'Hoodie' });
+    const cart = [];
+    expect(manager.moveToCart('unknown', cart)).toBeNull();
+    expect(cart.length).toBe(0);
+    expect(manager.getSavedItems().length).toBe(1);
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/save-for-later-manager.test.js for quantity preservation when moving items back to the cart, zero and negative quantity items being saved, and no mutation on unknown-id moves.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6608

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.