### PR TITLE
test: added removal edge coverage to compare list

### DIFF
--- a/tests/unit/compare-view-navigation.test.js
+++ b/tests/unit/compare-view-navigation.test.js
@@ -103,3 +103,49 @@ describe('compare.js view-product navigation', () => {
     expect(stored.name).toBe('Jeans');
   });
 });
+
+describe('compare.js CaraCompare list API', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    sessionStorage.clear();
+    document.body.innerHTML = `
+      <div id="compareTableWrapper"></div>
+      <div id="compareEmpty"></div>
+      <div class="compare-actions"></div>
+    `;
+  });
+
+  it('adds a product and removes it leaving an empty list', async () => {
+    await import('../../compare.js');
+    const added = window.CaraCompare.add({ id: 'p1', name: 'Tee' });
+    expect(added).toBe(true);
+    expect(window.CaraCompare.getList().length).toBe(1);
+
+    window.CaraCompare.remove('p1');
+    expect(window.CaraCompare.getList().length).toBe(0);
+  });
+
+  it('removing an unknown id is a safe no-op', async () => {
+    await import('../../compare.js');
+    window.CaraCompare.add({ id: 'p1', name: 'Tee' });
+
+    expect(() => window.CaraCompare.remove('missing')).not.toThrow();
+    expect(window.CaraCompare.getList().length).toBe(1);
+  });
+
+  it('removing from an empty list does not throw', async () => {
+    await import('../../compare.js');
+    expect(() => window.CaraCompare.remove('p1')).not.toThrow();
+    expect(window.CaraCompare.getList()).toEqual([]);
+  });
+
+  it('clear empties the stored list', async () => {
+    await import('../../compare.js');
+    window.CaraCompare.add({ id: 'p1', name: 'Tee' });
+    window.CaraCompare.add({ id: 'p2', name: 'Shirt' });
+
+    window.CaraCompare.clear();
+    expect(window.CaraCompare.getList()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/compare-view-navigation.test.js for the CaraCompare list API: add then remove leaving an empty list, unknown-id removal as a safe no-op, removal from an empty list, and clear emptying the stored list.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6609

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.