### PR TITLE
fix: rejected fractional step indices in checkout-wizard

### DIFF
--- a/js/checkout-wizard.js
+++ b/js/checkout-wizard.js
@@ -5,4 +5,4 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 
-export function isValidStepBounds(index, maxSteps = 4) { return typeof index === 'number' && index >= 1 && index <= maxSteps; }
+export function isValidStepBounds(index, maxSteps = 4) { return typeof index === 'number' && Number.isInteger(index) && index >= 1 && index <= maxSteps; }

--- a/tests/unit/checkout-wizard.test.js
+++ b/tests/unit/checkout-wizard.test.js
@@ -35,4 +35,18 @@ describe('isValidStepBounds', () => {
     expect(isValidStepBounds(3, 3)).toBe(true);
     expect(isValidStepBounds(4, 3)).toBe(false);
   });
+
+  it('rejects fractional step indices', () => {
+    expect(isValidStepBounds(1.5)).toBe(false);
+    expect(isValidStepBounds(2.9)).toBe(false);
+  });
+
+  it('rejects NaN step indices', () => {
+    expect(isValidStepBounds(NaN)).toBe(false);
+  });
+
+  it('accepts a step at a custom maximum of one', () => {
+    expect(isValidStepBounds(1, 1)).toBe(true);
+    expect(isValidStepBounds(2, 1)).toBe(false);
+  });
 });


### PR DESCRIPTION
## 📄 Description
js/checkout-wizard.js isValidStepBounds accepted fractional indices like 1.5 because it only checked the numeric range. It now requires whole numbers, with boundary tests for fractional, NaN, and single-step max cases.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6610

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.