### PR TITLE
fix: surfaced barcode detect failures in scanner status

### DIFF
--- a/js/barcode-scanner.js
+++ b/js/barcode-scanner.js
@@ -230,7 +230,10 @@ document.addEventListener("DOMContentLoaded", () => {
         return;
       }
     } catch (err) {
-      // Ignore detection errors during frame processing
+      // Surface repeated detection failures instead of silently retrying.
+      status.textContent = 'Unable to read barcode. Try again.';
+      scanning = false;
+      return;
     }
 
     if (scanning) {

--- a/tests/unit/barcode-scanner.test.js
+++ b/tests/unit/barcode-scanner.test.js
@@ -44,4 +44,44 @@ describe('barcode-scanner', () => {
     expect(status.textContent).toBe('Camera access denied or unavailable.');
   });
 
+  it('writes a scan-failure status when detect rejects', async () => {
+    navigator.mediaDevices = {
+      getUserMedia: vi.fn().mockResolvedValue({
+        getTracks: () => [{ stop: vi.fn() }],
+      }),
+    };
+    // Make the mock detector's detect reject.
+    window.BarcodeDetector = class MockBarcodeDetector {
+      static getSupportedFormats() {
+        return Promise.resolve(['ean_13']);
+      }
+      detect() {
+        return Promise.reject(new Error('detect failed'));
+      }
+    };
+    // Run animation frames synchronously so scanFrame executes.
+    window.requestAnimationFrame = (cb) => {
+      cb();
+      return 1;
+    };
+
+    await load();
+    const video = document.getElementById('barcode-video');
+    // scanFrame only processes frames once the video stream is ready.
+    Object.defineProperty(video, 'videoWidth', { value: 640 });
+    Object.defineProperty(video, 'videoHeight', { value: 480 });
+
+    document.getElementById('scanBarcodeBtn').click();
+    // Let startScanner await getUserMedia and assign the stream.
+    await Promise.resolve();
+    await Promise.resolve();
+    // Fire onloadedmetadata to start the scan loop.
+    video.dispatchEvent(new Event('loadedmetadata'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const status = document.getElementById('scanner-status');
+    expect(status.textContent).toContain('Unable to read barcode');
+  });
+
 });


### PR DESCRIPTION
## 📄 Description
js/barcode-scanner.js silently swallowed detection errors, leaving the scanner stuck on Looking for barcode. It now writes an Unable to read barcode status and stops the scan loop, with a test covering the detect-rejection path.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6611

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.