### PR TITLE
test: added note and tag limit coverage to wishlist-notes-tag-manager

### DIFF
--- a/tests/unit/wishlist-notes-tag-manager.test.js
+++ b/tests/unit/wishlist-notes-tag-manager.test.js
@@ -63,4 +63,24 @@ describe('WishlistNotesTagManager Unit Tests', () => {
     const res = manager.setPriority('product-304', -5);
     expect(res.priority).toBe(0);
   });
+
+  it('should cap the tag list at 10 entries', () => {
+    const manyTags = Array.from({ length: 15 }, (_, i) => `tag-${i}`);
+    manager.addTags('product-305', manyTags);
+    const meta = manager.getProductMeta('product-305');
+    expect(meta.tags.length).toBe(10);
+  });
+
+  it('should truncate individual tags to 20 characters', () => {
+    manager.addTags('product-306', ['x'.repeat(50)]);
+    const meta = manager.getProductMeta('product-306');
+    expect(meta.tags[0].length).toBe(20);
+  });
+
+  it('should merge new tags with existing ones without duplicates', () => {
+    manager.addTags('product-307', ['summer', 'gift']);
+    manager.addTags('product-307', ['gift', 'winter']);
+    const meta = manager.getProductMeta('product-307');
+    expect(meta.tags).toEqual(['summer', 'gift', 'winter']);
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/wishlist-notes-tag-manager.test.js for the 10-tag cap, 20-character per-tag truncation, and duplicate-free tag merging.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6612

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.