### PR TITLE
fix: returned base url for id-less wishlist exports

### DIFF
--- a/js/wishlist-share-exporter.js
+++ b/js/wishlist-share-exporter.js
@@ -6,6 +6,7 @@ export class WishlistShareExporter {
   static exportToShareableLink(items = [], baseUrl = 'https://cara.store/wishlist.html') {
     if (!Array.isArray(items) || items.length === 0) return baseUrl;
     const ids = items.map(item => typeof item === 'object' ? item.id : item).filter(Boolean);
+    if (ids.length === 0) return baseUrl;
     // encodeURIComponent keeps btoa from throwing on non-Latin1 characters.
     const encoded = btoa(encodeURIComponent(JSON.stringify(ids)));
     return `${baseUrl}?share=${encodeURIComponent(encoded)}`;

--- a/tests/unit/wishlist-share-exporter.test.js
+++ b/tests/unit/wishlist-share-exporter.test.js
@@ -35,4 +35,39 @@ describe('WishlistShareExporter', () => {
     expect(WishlistShareExporter.parseShareableLink('?other=1')).toEqual([]);
     expect(WishlistShareExporter.parseShareableLink('?share=%%%bad')).toEqual([]);
   });
+
+  it('returns the base url when every item lacks an id', () => {
+    const items = [{ name: 'Tee' }, { name: 'Shirt' }];
+    expect(
+      WishlistShareExporter.exportToShareableLink(
+        items,
+        'http://localhost/wishlist.html',
+      ),
+    ).toBe('http://localhost/wishlist.html');
+  });
+
+  it('filters out id-less items from a mixed list', () => {
+    const items = [{ id: 'p1' }, { name: 'No Id' }, { id: 'p2' }];
+    const url = WishlistShareExporter.exportToShareableLink(
+      items,
+      'http://localhost/wishlist.html',
+    );
+    const query = url.substring(url.indexOf('?'));
+    expect(WishlistShareExporter.parseShareableLink(query)).toEqual([
+      'p1',
+      'p2',
+    ]);
+  });
+
+  it('handles string items by treating them as ids', () => {
+    const url = WishlistShareExporter.exportToShareableLink(
+      ['p1', 'p2'],
+      'http://localhost/wishlist.html',
+    );
+    const query = url.substring(url.indexOf('?'));
+    expect(WishlistShareExporter.parseShareableLink(query)).toEqual([
+      'p1',
+      'p2',
+    ]);
+  });
 });


### PR DESCRIPTION
## 📄 Description
js/wishlist-share-exporter.js exportToShareableLink built a share link with an empty id array when every item lacked an id. It now returns the base url when no ids survive filtering, with tests for id-less, mixed, and string-item lists.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6614

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.