### PR TITLE
test: added no-scroll coverage to reading-progress

### DIFF
--- a/tests/unit/reading-progress.test.js
+++ b/tests/unit/reading-progress.test.js
@@ -47,6 +47,26 @@ describe('reading-progress', () => {
     window.dispatchEvent(new Event('scroll'));
     expect(bar.style.width).toBe('50%');
   });
+
+  it('stays at 0% when the page has no scrollable content', async () => {
+    await load();
+    const bar = document.getElementById('reading-progress-bar');
+    // No scroll; scrollHeight equals clientHeight.
+    Object.defineProperty(document.body, 'scrollTop', {
+      value: 0,
+      configurable: true,
+    });
+    Object.defineProperty(document.documentElement, 'scrollHeight', {
+      value: 600,
+      configurable: true,
+    });
+    Object.defineProperty(document.documentElement, 'clientHeight', {
+      value: 600,
+      configurable: true,
+    });
+    window.dispatchEvent(new Event('scroll'));
+    expect(bar.style.width).toBe('0%');
+  });
 });
 
 import { roundScrollProgressPercent } from '../../js/reading-progress.js';


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/reading-progress.test.js for the progress bar staying at 0% when the page has no scrollable content.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6615

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.