### PR TITLE
test: added custom config coverage to skeleton-loader

### DIFF
--- a/tests/unit/skeleton-loader.test.js
+++ b/tests/unit/skeleton-loader.test.js
@@ -83,4 +83,26 @@ describe('skeleton-loader.js — CaraSkeleton', () => {
     const secondStyleCount = document.head.querySelectorAll('style').length;
     expect(secondStyleCount).toBe(firstStyleCount);
   });
+
+  it('show() honors a custom card class name', () => {
+    const container = document.getElementById('test-container');
+    window.CaraSkeleton.show(container, { count: 2, cardClass: 'custom-skeleton' });
+    expect(container.querySelectorAll('.custom-skeleton').length).toBe(2);
+    expect(container.querySelectorAll('.skeleton-card').length).toBe(0);
+  });
+
+  it('show() honors a custom count of one', () => {
+    const container = document.getElementById('test-container');
+    window.CaraSkeleton.show(container, { count: 1 });
+    expect(container.querySelectorAll('.skeleton-card').length).toBe(1);
+  });
+
+  it('show() renders custom card blocks with per-card sizing', () => {
+    const container = document.getElementById('test-container');
+    window.CaraSkeleton.show(container, { count: 1 });
+    const blocks = container.querySelectorAll('.skeleton-block');
+    // image (180px) + title + subtitle + meta = 4 blocks
+    expect(blocks.length).toBe(4);
+    expect(blocks[0].style.height).toBe('180px');
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/skeleton-loader.test.js for custom card class names, a custom count of one, and per-card block sizing in CaraSkeleton.show.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6616

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.