### PR TITLE
test: added empty profile fallback coverage to virtual-stylist-engine

### DIFF
--- a/tests/unit/virtual-stylist-engine.test.js
+++ b/tests/unit/virtual-stylist-engine.test.js
@@ -59,4 +59,16 @@ describe('VirtualStylistEngine', () => {
     expect(engine.recommendBottoms(top, 'not-an-array')).toEqual([]);
     expect(engine.recommendBottoms(null, [])).toEqual([]);
   });
+
+  it('should return an empty list for an empty catalog', () => {
+    const top = { category: 'shirts', color: 'blue' };
+    expect(engine.recommendBottoms(top, [])).toEqual([]);
+  });
+
+  it('should fall back to the default palette for unknown colors', () => {
+    // 'purple' is not a palette key; black, white, and grey are allowed.
+    expect(engine.isColorCompatible('purple', 'white')).toBe(true);
+    expect(engine.isColorCompatible('purple', 'black')).toBe(true);
+    expect(engine.isColorCompatible('purple', 'orange')).toBe(false);
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/virtual-stylist-engine.test.js for an empty catalog returning an empty recommendation list and the default palette fallback for unknown colors.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6618

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.