### PR TITLE
test: added unsupported canvas coverage to virtual-tryon-engine

### DIFF
--- a/tests/unit/virtual-tryon-engine.test.js
+++ b/tests/unit/virtual-tryon-engine.test.js
@@ -47,4 +47,32 @@ describe('VirtualTryOnEngine Unit Tests', () => {
     const res = engine.updateTransform({ rotation: -90 });
     expect(res.rotation).toBe(270);
   });
+
+  it('should return false from render when no canvas is attached', () => {
+    const res = engine.render();
+    expect(res).toBe(false);
+  });
+
+  it('should return null from exportDataURL when no canvas is attached', () => {
+    expect(engine.exportDataURL()).toBeNull();
+  });
+
+  it('should return the current state from updateTransform without args', () => {
+    const res = engine.updateTransform({});
+    expect(res).toEqual({
+      modelImage: null,
+      garmentImage: null,
+      scale: 1.0,
+      rotation: 0,
+      position: { x: 0, y: 0 },
+    });
+  });
+
+  it('should keep bounds centered when no offsets are applied', () => {
+    const bounds = engine.calculateGarmentBounds(400, 600, 100, 150);
+    expect(bounds.centerX).toBe(200);
+    expect(bounds.centerY).toBe(300);
+    expect(bounds.width).toBe(100);
+    expect(bounds.height).toBe(150);
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/virtual-tryon-engine.test.js for render returning false without a canvas, exportDataURL returning null, the default state shape, and centered bounds without offsets.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6619

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.