### PR TITLE
test: added tie breaking coverage to smart-search-engine

### DIFF
--- a/tests/unit/smart-search-engine.test.js
+++ b/tests/unit/smart-search-engine.test.js
@@ -67,4 +67,33 @@ describe('SmartSearchEngine Unit Tests', () => {
     expect(results.length).toBe(1);
     expect(results[0].name).toBe('Casual Leather Shoes');
   });
+
+  it('should preserve input order for equally-relevant matches', () => {
+    const engine2 = new SmartSearchEngine([
+      { id: 1, name: 'Blue Tee', category: 'tshirts', price: 20 },
+      { id: 2, name: 'Blue Tee Deluxe', category: 'tshirts', price: 20 },
+      { id: 3, name: 'Blue Tee Pro', category: 'tshirts', price: 20 },
+    ]);
+    const results = engine2.filter({ query: 'blue' });
+    expect(results.map((p) => p.id)).toEqual([1, 2, 3]);
+  });
+
+  it('should sort ties stably by price when price-asc is requested', () => {
+    const engine2 = new SmartSearchEngine([
+      { id: 1, name: 'Tee A', category: 'tshirts', price: 20 },
+      { id: 2, name: 'Tee B', category: 'tshirts', price: 10 },
+      { id: 3, name: 'Tee C', category: 'tshirts', price: 20 },
+    ]);
+    const results = engine2.filter({ query: 'tee', sortBy: 'price-asc' });
+    expect(results.map((p) => p.id)).toEqual([2, 1, 3]);
+  });
+
+  it('should cap the search history at 10 entries', () => {
+    for (let i = 1; i <= 12; i++) {
+      engine.filter({ query: `query-${i}` });
+    }
+    const history = engine.getHistory();
+    expect(history.length).toBe(10);
+    expect(history[0]).toBe('query-12');
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/smart-search-engine.test.js for input-order preservation on equally relevant matches, stable price sorting, and the 10-entry search history cap.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6621

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.