### PR TITLE
test: added max stack coverage to coupon-stacking-engine

### DIFF
--- a/tests/unit/coupon-stacking-engine.test.js
+++ b/tests/unit/coupon-stacking-engine.test.js
@@ -14,4 +14,41 @@ describe('CouponStackingEngine', () => {
     expect(res.discountTotal).toBe(150);
     expect(res.finalTotal).toBe(850);
   });
+
+  it('ignores coupons beyond the default max stack of two', () => {
+    const coupons = [
+      { code: 'A', type: 'percentage', value: 10 },
+      { code: 'B', type: 'flat', value: 50 },
+      { code: 'C', type: 'flat', value: 100 },
+    ];
+    const res = engine.calculateStackedDiscount(1000, coupons);
+    expect(res.appliedCoupons.length).toBe(2);
+    // A (100) + B (50); C is ignored.
+    expect(res.discountTotal).toBe(150);
+  });
+
+  it('honors a custom max stack count', () => {
+    const engine3 = new CouponStackingEngine({ maxStackedCoupons: 3 });
+    const coupons = [
+      { code: 'A', type: 'percentage', value: 10 },
+      { code: 'B', type: 'flat', value: 50 },
+      { code: 'C', type: 'flat', value: 100 },
+    ];
+    const res = engine3.calculateStackedDiscount(1000, coupons);
+    expect(res.appliedCoupons.length).toBe(3);
+  });
+
+  it('returns zero discount for an empty coupon list', () => {
+    const res = engine.calculateStackedDiscount(1000, []);
+    expect(res.discountTotal).toBe(0);
+    expect(res.finalTotal).toBe(1000);
+  });
+
+  it('clamps flat discount to the remaining cart total', () => {
+    const res = engine.calculateStackedDiscount(30, [
+      { code: 'FLAT99', type: 'flat', value: 99 },
+    ]);
+    expect(res.discountTotal).toBe(30);
+    expect(res.finalTotal).toBe(0);
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/coupon-stacking-engine.test.js for ignoring coupons beyond the default max stack of two, custom max stack counts, empty coupon lists, and flat discount clamping to the cart total.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6627

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.