### PR TITLE
test: added debounce coverage to address-autocomplete

### DIFF
--- a/tests/unit/address-autocomplete.test.js
+++ b/tests/unit/address-autocomplete.test.js
@@ -95,4 +95,38 @@ describe('Address Autocomplete DOM Integration', () => {
     expect(escapeHTML(null)).toBe('null');
   });
 
+  it('debounces the autocomplete request while typing', async () => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
+
+    document.body.innerHTML = `
+      <input type="text" id="address" />
+      <input type="text" id="city" />
+      <input type="text" id="zip" />
+    `;
+    await import('../../js/address-autocomplete.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const input = document.getElementById('address');
+    // Rapid keystrokes should not fire a request per keystroke.
+    input.value = 'M';
+    input.dispatchEvent(new Event('input'));
+    input.value = 'MG';
+    input.dispatchEvent(new Event('input'));
+    input.value = 'MG R';
+    input.dispatchEvent(new Event('input'));
+
+    expect(global.fetch).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(300);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(String(global.fetch.mock.calls[0][0])).toContain('q=MG%20R');
+
+    vi.useRealTimers();
+  });
+
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/address-autocomplete.test.js verifying rapid keystrokes fire a single autocomplete request after the debounce delay.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6626

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.