### PR TITLE
test: added keyboard edge coverage to accessibility-focus-manager

### DIFF
--- a/tests/unit/accessibility-focus-manager.test.js
+++ b/tests/unit/accessibility-focus-manager.test.js
@@ -77,4 +77,38 @@ describe('AccessibilityFocusManager', () => {
     const event = new KeyboardEvent('keydown', { key: 'Tab' });
     expect(() => manager.handleKeyDown(event)).not.toThrow();
   });
+
+  it('should ignore non-Tab keys while a modal is active', () => {
+    document.body.innerHTML = `
+      <button id="trigger-btn">Open Modal</button>
+      <div id="test-modal">
+        <input id="input-1" type="text" />
+        <button id="btn-close">Close</button>
+      </div>
+    `;
+    const manager = new AccessibilityFocusManager();
+    const modal = document.getElementById('test-modal');
+    manager.trapFocus(modal);
+
+    const event = new KeyboardEvent('keydown', { key: 'Enter' });
+    expect(() => manager.handleKeyDown(event)).not.toThrow();
+    expect(document.activeElement.id).toBe('input-1');
+  });
+
+  it('should wrap forward from the last focusable element to the first', () => {
+    document.body.innerHTML = `
+      <div id="test-modal">
+        <input id="input-1" type="text" />
+        <button id="btn-close">Close</button>
+      </div>
+    `;
+    const manager = new AccessibilityFocusManager();
+    const modal = document.getElementById('test-modal');
+    manager.trapFocus(modal);
+
+    document.getElementById('btn-close').focus();
+    const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: false });
+    manager.handleKeyDown(event);
+    expect(document.activeElement.id).toBe('input-1');
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/accessibility-focus-manager.test.js for non-Tab keys being ignored while a modal is active and forward focus wrapping from the last focusable element to the first.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6623

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.