### PR TITLE
test: added system default theme coverage to theme-engine

### DIFF
--- a/tests/unit/theme-engine.test.js
+++ b/tests/unit/theme-engine.test.js
@@ -64,4 +64,24 @@ describe('Centralized Theme Engine Unit Tests', () => {
     const stored = document.documentElement.getAttribute('data-theme');
     expect([THEMES.LIGHT, THEMES.DARK]).toContain(stored);
   });
+
+  it('should resolve light when matchMedia reports light preference', () => {
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+    try {
+      expect(getSystemTheme()).toBe(THEMES.LIGHT);
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
+  });
+
+  it('should resolve dark when matchMedia reports dark preference', () => {
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true });
+    try {
+      expect(getSystemTheme()).toBe(THEMES.DARK);
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/theme-engine.test.js for getSystemTheme resolving light and dark from the matchMedia preference.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6630

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.