### PR TITLE
test: added cross tab broadcast coverage to cart-sync-manager

### DIFF
--- a/tests/unit/cart-sync-manager.test.js
+++ b/tests/unit/cart-sync-manager.test.js
@@ -56,6 +56,46 @@ describe('CartSyncManager Unit Tests', () => {
     expect(cart[0].quantity).toBe(1);
     expect(cart[1].quantity).toBe(1);
   });
+
+  it('syncs the cart when a storage event fires for the same key', () => {
+    cartManager.addItem({ id: 'item-1', name: 'Local Item' });
+
+    // The remote tab writes to localStorage, then fires the storage event.
+    const externalCart = JSON.stringify({
+      items: [{ id: 'item-2', name: 'Remote Item', quantity: 1 }],
+      timestamp: Date.now(),
+    });
+    localStorage.setItem('test_cart', externalCart);
+
+    const syncCallback = vi.fn();
+    cartManager.onSync(syncCallback);
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: 'test_cart',
+        newValue: externalCart,
+      }),
+    );
+
+    expect(syncCallback).toHaveBeenCalledTimes(1);
+    const syncedCart = syncCallback.mock.calls[0][0];
+    expect(syncedCart).toHaveLength(1);
+    expect(syncedCart[0].name).toBe('Remote Item');
+  });
+
+  it('ignores storage events for unrelated keys', () => {
+    cartManager.addItem({ id: 'item-1', name: 'Local Item' });
+    const syncCallback = vi.fn();
+    cartManager.onSync(syncCallback);
+
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: 'unrelated_key',
+        newValue: JSON.stringify([{ id: 'x' }]),
+      }),
+    );
+
+    expect(syncCallback).not.toHaveBeenCalled();
+  });
 });
 
 describe('shouldCompressPayload', () => {


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/cart-sync-manager.test.js for storage events on the cart key invoking the sync callback and unrelated keys being ignored.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6634

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.