### PR TITLE
test: added logout failure redirect coverage to session-lock

### DIFF
--- a/tests/unit/session-lock.test.js
+++ b/tests/unit/session-lock.test.js
@@ -96,4 +96,31 @@ describe('session-lock', () => {
     expect(localStorage.getItem('cara_user_token')).toBeNull();
     expect(localStorage.getItem('access_token')).toBeNull();
   });
+
+  it('still redirects to login when the logout request fails', async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).includes('/api/auth/me')) {
+        return { ok: true, status: 200, json: async () => ({ email: 'a@b.c' }) };
+      }
+      if (String(url).includes('/api/auth/logout')) {
+        throw new Error('network down');
+      }
+      return { ok: false, status: 404 };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await import('../../js/session-lock.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await vi.waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some((call) =>
+          String(call[0]).includes('/api/auth/me'),
+        ),
+      ).toBe(true),
+    );
+    await Promise.resolve();
+
+    vi.advanceTimersByTime(15 * 60 * 1000);
+    await vi.waitFor(() => expect(window.location.href).toBe('login.html'));
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/session-lock.test.js for the inactivity lock redirecting to login even when the logout request fails with a network error.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6637

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.