### PR TITLE
test: added queue ordering coverage to toast-notifications

### DIFF
--- a/tests/unit/toast-notifications.test.js
+++ b/tests/unit/toast-notifications.test.js
@@ -96,4 +96,23 @@ describe('toast-notifications.js — CaraNotifications', () => {
     advanceDismiss();
     expect(document.querySelector('[role="alert"]')).toBeNull();
   });
+
+  it('shows queued notifications in order', () => {
+    // Run animation frames synchronously so the queue keeps flushing.
+    window.requestAnimationFrame = (cb) => {
+      cb();
+      return 1;
+    };
+
+    window.CaraNotifications.info('First', 500);
+    window.CaraNotifications.info('Second', 500);
+    window.CaraNotifications.info('Third', 500);
+    vi.advanceTimersByTime(0);
+
+    const messages = Array.from(
+      document.querySelectorAll('[role="alert"]'),
+    ).map((el) => el.textContent);
+    // All three are queued and shown in the order they were added.
+    expect(messages).toEqual(['First', 'Second', 'Third']);
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/toast-notifications.test.js for multiple notifications being queued and shown in the order they were added.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6640

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.