### PR TITLE
test: added sort order coverage to product-reviews

### DIFF
--- a/tests/unit/product-reviews.test.js
+++ b/tests/unit/product-reviews.test.js
@@ -91,4 +91,23 @@ describe('ProductReviewManager Unit Tests', () => {
     expect(summary.distribution[3]).toBe(1);
     expect(Number.isNaN(summary.averageRating)).toBe(false);
   });
+
+  it('stores the newest review first', () => {
+    manager.addReview('prod-order', {
+      authorName: 'Alice',
+      authorEmail: 'alice@example.com',
+      rating: 5,
+      comment: 'First review, absolutely wonderful!',
+    });
+    manager.addReview('prod-order', {
+      authorName: 'Bob',
+      authorEmail: 'bob@example.com',
+      rating: 4,
+      comment: 'Second review, still pretty great!',
+    });
+
+    // Reviews are unshifted so the newest appears first.
+    expect(manager.reviews['prod-order'][0].authorName).toBe('Bob');
+    expect(manager.reviews['prod-order'][1].authorName).toBe('Alice');
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/product-reviews.test.js for the newest review being stored first in the review list.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6646

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.