### PR TITLE
test: added clipboard fallback coverage to wishlist-export-share

### DIFF
--- a/tests/unit/wishlist-export-share.test.js
+++ b/tests/unit/wishlist-export-share.test.js
@@ -43,4 +43,64 @@ describe('WishlistExportShare', () => {
     expect(nameField.startsWith('"')).toBe(true);
     expect(nameField.endsWith('"')).toBe(true);
   });
+
+  it('returns the link for manual copying when clipboard is unavailable', async () => {
+    // Ensure navigator.clipboard is undefined.
+    const originalClipboard = global.navigator.clipboard;
+    Object.defineProperty(global.navigator, 'clipboard', {
+      value: undefined,
+      configurable: true,
+    });
+    try {
+      const res = await exporter.copyShareLinkToClipboard(
+        [{ id: 'p1', name: 'Tee' }],
+        'http://localhost/wishlist.html',
+      );
+      expect(res.ok).toBe(false);
+      expect(res.link).toContain('?wishlist=');
+    } finally {
+      Object.defineProperty(global.navigator, 'clipboard', {
+        value: originalClipboard,
+        configurable: true,
+      });
+    }
+  });
+
+  it('returns the link for manual copying when clipboard.writeText fails', async () => {
+    Object.defineProperty(global.navigator, 'clipboard', {
+      value: {
+        writeText: () => Promise.reject(new Error('denied')),
+      },
+      configurable: true,
+    });
+    try {
+      const res = await exporter.copyShareLinkToClipboard(
+        [{ id: 'p1', name: 'Tee' }],
+        'http://localhost/wishlist.html',
+      );
+      expect(res.ok).toBe(false);
+      expect(res.link).toContain('?wishlist=');
+    } finally {
+      delete global.navigator.clipboard;
+    }
+  });
+
+  it('returns ok when the clipboard write succeeds', async () => {
+    Object.defineProperty(global.navigator, 'clipboard', {
+      value: {
+        writeText: () => Promise.resolve(),
+      },
+      configurable: true,
+    });
+    try {
+      const res = await exporter.copyShareLinkToClipboard(
+        [{ id: 'p1', name: 'Tee' }],
+        'http://localhost/wishlist.html',
+      );
+      expect(res.ok).toBe(true);
+      expect(res.link).toContain('?wishlist=');
+    } finally {
+      delete global.navigator.clipboard;
+    }
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/wishlist-export-share.test.js for returning the link for manual copying when the clipboard API is unavailable or fails, and ok on a successful write.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6645

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.