### PR TITLE
test: added nested path coverage to breadcrumbs-generator

### DIFF
--- a/tests/unit/breadcrumbs-generator.test.js
+++ b/tests/unit/breadcrumbs-generator.test.js
@@ -36,4 +36,25 @@ describe('BreadcrumbsGenerator', () => {
     expect(gen.formatLabel('new-arrivals.html')).toBe('New arrivals');
     expect(gen.formatLabel('best_sellers')).toBe('Best sellers');
   });
+
+  it('handles a trailing slash on the path', () => {
+    const crumbs = gen.generateBreadcrumbs('/shop/tshirts/');
+    expect(crumbs.length).toBe(3);
+    expect(crumbs[2].label).toBe('Tshirts');
+  });
+
+  it('returns only the home crumb for a root slash', () => {
+    const crumbs = gen.generateBreadcrumbs('/');
+    expect(crumbs.length).toBe(1);
+    expect(crumbs[0].label).toBe('Home');
+  });
+
+  it('handles a deeply nested path with four segments', () => {
+    const crumbs = gen.generateBreadcrumbs('/men/formal/classic/shirts.html');
+    expect(crumbs.length).toBe(5);
+    expect(crumbs[1].url).toBe('/men');
+    expect(crumbs[2].url).toBe('/men/formal');
+    expect(crumbs[3].url).toBe('/men/formal/classic');
+    expect(crumbs[4].url).toBeNull();
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/breadcrumbs-generator.test.js for trailing slashes, root slash, and deeply nested four-segment paths.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6642

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.