### PR TITLE
test: added unobserve coverage to lazyload-observer

### DIFF
--- a/tests/unit/lazyload-observer.test.js
+++ b/tests/unit/lazyload-observer.test.js
@@ -67,4 +67,20 @@ describe('unobserveLazyElement', () => {
   it('is exported as a callable function', () => {
     expect(typeof unobserveLazyElement).toBe('function');
   });
+
+  it('unobserves a tracked element without throwing', () => {
+    const img = document.createElement('img');
+    img.className = 'lazyload';
+    img.dataset.src = 'img/products/f1.jpg';
+    document.body.appendChild(img);
+
+    const result = initLazyLoadObserver('img.lazyload');
+    expect(() => unobserveLazyElement(img)).not.toThrow();
+    expect(typeof result.unobserve).toBe('function');
+  });
+
+  it('unobserving an unknown element is a safe no-op', () => {
+    const img = document.createElement('img');
+    expect(() => unobserveLazyElement(img)).not.toThrow();
+  });
 });


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/lazyload-observer.test.js for unobserving a tracked element and unknown elements as safe no-ops.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6636

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.