### PR TITLE
test: added persistence read-back coverage to recently-viewed

### DIFF
--- a/tests/unit/recently-viewed.test.js
+++ b/tests/unit/recently-viewed.test.js
@@ -112,6 +112,16 @@ describe('addRecentlyViewed', () => {
     expect(() => RecentlyViewed.addRecentlyViewed({})).not.toThrow();
     expect(RecentlyViewed.getRecentlyViewed()).toHaveLength(0);
   });
+
+  it('getRecentlyViewed reads back the persisted list', () => {
+    RecentlyViewed.addRecentlyViewed(product({ id: 7, name: 'Persisted Tee' }));
+    RecentlyViewed.addRecentlyViewed(product({ id: 8, name: 'Another Tee' }));
+
+    const list = RecentlyViewed.getRecentlyViewed();
+    expect(list).toHaveLength(2);
+    expect(list[0].name).toBe('Another Tee');
+    expect(list[1].name).toBe('Persisted Tee');
+  });
 });
 
 describe('renderRecentlyViewed', () => {


### PR DESCRIPTION
## 📄 Description
Adds unit test coverage to tests/unit/recently-viewed.test.js for getRecentlyViewed returning the persisted list in insertion order.

This change is part of GSSOC (GirlScript Summer of Code).

## 🔗 Related Issues
Closes #6632

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) - please assign this PR to the `tmdeveloper007` account when picking it up.