### PR TITLE
fix : added coupon discount percentage cap at 100

### DIFF
--- a/js/coupon-validator.js
+++ b/js/coupon-validator.js
@@ -60,7 +60,7 @@
     }
 
     if (Object.prototype.hasOwnProperty.call(COUPONS, code)) {
-      const discountPct = COUPONS[code];
+      const discountPct = Math.min(Number(COUPONS[code]) || 0, 100);
       window.appliedCoupon = code;
       saveAppliedCoupon(code);
 


### PR DESCRIPTION
## Description
Capped the discount percentage at 100 using Math.min to prevent invalid discount values from being applied via the couponApplied event.

## Related Issues
Closes #6973

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test
- [ ] Chore / dependency update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC -- please assign this PR to the tmdeveloper007 account when picking it up.