### PR TITLE
fix : removed unused generateCsrfFallbackToken from csrf-protection.js

### DIFF
--- a/js/csrf-protection.js
+++ b/js/csrf-protection.js
@@ -61,6 +61,3 @@ export function attachCSRFHeader(headers = {}) {
 if (typeof document !== 'undefined') {
   document.addEventListener('DOMContentLoaded', () => injectCSRFInputs());
 }
-
-
-function generateCsrfFallbackToken() { return 'csrf-' + Math.random().toString(36).substring(2, 15); }


### PR DESCRIPTION
## 📄 Description
Removed the unused generateCsrfFallbackToken function from js/csrf-protection.js to eliminate dead code.

## 🔗 Related Issues
Closes #7317

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the tmdeveloper007 account when picking it up.