### PR TITLE
fix : validate email before API call in passkey-auth.js

### DIFF
--- a/js/passkey-auth.js
+++ b/js/passkey-auth.js
@@ -16,6 +16,12 @@
 })(typeof self !== 'undefined' ? self : this, function () {
   'use strict';
 
+function isValidEmail(email) {
+  if (!email || typeof email !== 'string') return false;
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim());
+}
+
+
   function bufferToBase64URL(buffer) {
     const bytes = new Uint8Array(buffer);
     let binary = '';
@@ -50,6 +56,9 @@
   }
 
   async function registerPasskey(email, options = {}) {
+    if (!isValidEmail(email)) {
+      throw new Error('Invalid email format.');
+    }
     if (!isWebAuthnSupported()) {
       throw new Error('WebAuthn biometrics is not supported in this browser.');
     }
@@ -119,6 +128,9 @@
   }
 
   async function loginWithPasskey(email = '', options = {}) {
+    if (email && !isValidEmail(email)) {
+      throw new Error('Invalid email format.');
+    }
     if (!isWebAuthnSupported()) {
       throw new Error('WebAuthn biometrics is not supported in this browser.');
     }


### PR DESCRIPTION
## 📄 Description
Added email format validation to both registerPasskey and loginWithPasskey before making API calls. Throws an informative error for invalid email formats.

## 🔗 Related Issues
Closes #7318

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.