### PR TITLE
fix : do not save empty query to search history in smart-search-engine.js

### DIFF
--- a/js/smart-search-engine.js
+++ b/js/smart-search-engine.js
@@ -82,7 +82,7 @@ class SmartSearchEngine {
   }
 
   saveHistory(query) {
-    if (!query) return;
+    if (!query || !query.trim()) return;
     try {
       let history = this.getHistory();
       history = history.filter((q) => q.toLowerCase() !== query.toLowerCase());


### PR DESCRIPTION
## 📄 Description
Added guard in saveHistory to prevent whitespace-only or blank strings from being saved to search history.

## 🔗 Related Issues
Closes #7319

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.