### PR TITLE
fix : apply discount max cap in promo-discount-calculator.js calculateTotal

### DIFF
--- a/js/promo-discount-calculator.js
+++ b/js/promo-discount-calculator.js
@@ -4,7 +4,7 @@
  */
 
 class PromoDiscountCalculator {
-  constructor() {
+  constructor(options = {}) {
     this.coupons = {
       'WELCOME10': { type: 'percent', value: 10, minSpend: 20 },
       'CARA20': { type: 'percent', value: 20, minSpend: 50 },
@@ -12,6 +12,7 @@ class PromoDiscountCalculator {
       'FREESHIP': { type: 'freeship', value: 0, minSpend: 30 }
     };
     this.freeShippingThreshold = 75;
+    this.maxDiscountCap = options.maxDiscountCap !== undefined ? options.maxDiscountCap : Infinity;
   }
 
   validateCoupon(code, subtotal = 0) {
@@ -47,6 +48,7 @@ class PromoDiscountCalculator {
         appliedCoupon = validation.coupon;
         if (appliedCoupon.type === 'percent') {
           discount = (subtotal * appliedCoupon.value) / 100;
+          discount = this.applyPromoDiscountMaxCap(discount, this.maxDiscountCap);
         } else if (appliedCoupon.type === 'flat') {
           discount = Math.min(subtotal, appliedCoupon.value);
         } else if (appliedCoupon.type === 'freeship') {


### PR DESCRIPTION
## 📄 Description
Integrated the existing applyPromoDiscountMaxCap method into calculateTotal so percentage discounts are capped by the configurable maxDiscountCap (defaults to Infinity). Added maxDiscountCap as a constructor option.

## 🔗 Related Issues
Closes #7316

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.