### PR TITLE
feat : add getA11yAnnouncerStatusHelper117 to a11y-announcer.js

### DIFF
--- a/js/a11y-announcer.js
+++ b/js/a11y-announcer.js
@@ -45,3 +45,13 @@ export function clearAnnouncements() {
   if (liveRegionPolite) liveRegionPolite.textContent = '';
   if (liveRegionAssertive) liveRegionAssertive.textContent = '';
 }
+
+window.getA11yAnnouncerStatusHelper117 = function() {
+  return {
+    status: 'active',
+    module: 'A11yAnnouncer',
+    hasPoliteRegion: typeof document !== 'undefined' && !!document.getElementById('a11y-announcer-polite'),
+    hasAssertiveRegion: typeof document !== 'undefined' && !!document.getElementById('a11y-announcer-assertive'),
+    helper: 'getA11yAnnouncerStatusHelper117'
+  };
+};


### PR DESCRIPTION
## 📄 Description
Added getA11yAnnouncerStatusHelper117 function returning status metadata for the accessibility announcer module.

## 🔗 Related Issues
Closes #7364

## 🧩 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.