### PR TITLE
fix : added missing authenticity key in French i18n translations

### DIFF
--- a/js/i18n.js
+++ b/js/i18n.js
@@ -50,6 +50,7 @@ const translations = {
     community: "Communaute",
     orders: "Mes Commandes",
     outfit: "Verificateur de Tenue",
+    authenticity: "Authenticite",
     addToCart: "Ajouter au Panier",
     buyNow: "Acheter Maintenant",
     search: "Rechercher des produits..."


### PR DESCRIPTION
## 📄 Description
Added the missing `authenticity: "Authenticite"` key to the French translations object in js/i18n.js. This ensures that the authenticity label displays correctly when users switch to French language.

## 🔗 Related Issues
Closes #7367

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.