### PR TITLE
fix : added stages.length usage instead of hardcoded 4 in order-timeline

### DIFF
--- a/js/order-timeline.js
+++ b/js/order-timeline.js
@@ -56,7 +56,7 @@ function renderTimeline() {
 // Expose for testing — set immediately so tests can access it
 // regardless of whether DOMContentLoaded has fired yet.
 window.progressSimulatedTimeline = function() {
-    stageIndex = (stageIndex + 1) % 4;
+    stageIndex = (stageIndex + 1) % stages.length;
     renderTimeline();
 };
 


### PR DESCRIPTION
## 📄 Description
Fixed the progressSimulatedTimeline function in js/order-timeline.js to use `stages.length` instead of a hardcoded `4`. This makes the code more maintainable and ensures the function properly cycles through all stages including the Delivered state.

## 🔗 Related Issues
Closes #7369

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.