### PR TITLE
fix : use crypto.randomUUID for receipt signatures

### DIFF
--- a/js/receipt-exporter.js
+++ b/js/receipt-exporter.js
@@ -35,7 +35,7 @@
 
   function generateLocalReceiptData(orderId, orderData = {}) {
     const timestamp = new Date().toISOString();
-    const signature = 'sig_' + Math.random().toString(36).substring(2) + '_' + Date.now().toString(36);
+    const signature = 'sig_' + (typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).substring(2) + '_' + Date.now().toString(36));
 
     return {
       order_id: orderId,


### PR DESCRIPTION
## 📄 Description
Replaced Math.random() with crypto.randomUUID() for signature generation in receipt-exporter.js with fallback for older browsers.

## 🔗 Related Issues
Closes #7375

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.