### PR TITLE
fix : return DISPLAY_DURATION from getSalesToastDisplayDuration

### DIFF
--- a/js/live-sales-toast.js
+++ b/js/live-sales-toast.js
@@ -208,4 +208,4 @@
 })();
 
 
-export function getSalesToastDisplayDuration() { return 4000; }
+export function getSalesToastDisplayDuration() { return DISPLAY_DURATION; }


### PR DESCRIPTION
## 📄 Description
Fixed bug as described in issue.

## 🔗 Related Issues
Closes #7383

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Bug fix
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.