### PR TITLE
fix : use textContent instead of innerHTML for shipping calc feedback

### DIFF
--- a/js/shipping-calc.js
+++ b/js/shipping-calc.js
@@ -39,10 +39,8 @@ document.addEventListener('DOMContentLoaded', () => {
       days = speed === 'exp' ? '4-5 days' : '9-12 days';
     }
 
-    document.getElementById('calc-feedback').innerHTML = `
-            Estimated Cost: ₹${total} <br>
-            Estimated Time: ${days}
-        `;
+    const feedbackEl = document.getElementById('calc-feedback');
+    feedbackEl.textContent = 'Estimated Cost: Rs.' + total + ' | Estimated Time: ' + days;
 
     // Dynamically update Cart Totals summary if elements exist
     const shippingEl = document.getElementById('summary-shipping');


### PR DESCRIPTION
## 📄 Description
Replaced `innerHTML` with `textContent` when displaying the calculated shipping cost and estimated delivery time in `js/shipping-calc.js`. Using `textContent` prevents potential XSS if dynamic values ever contain malicious content, and is the appropriate API for plain text output.

## 🔗 Related Issues
Closes #7382

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.