### PR TITLE
fix : add try/catch to persist() in store.js for localStorage failures

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -41,7 +41,11 @@ class Store {
   }
 
   persist() {
-    localStorage.setItem(this.storageKey, JSON.stringify(this.state));
+    try {
+      localStorage.setItem(this.storageKey, JSON.stringify(this.state));
+    } catch (e) {
+      // Silently ignore localStorage failures (quota exceeded, private browsing, etc.)
+    }
   }
 }
 


### PR DESCRIPTION
## 📄 Description
Wrapped `localStorage.setItem` in `persist()` with a try/catch block in `js/store.js`. This prevents uncaught errors when localStorage is unavailable (private browsing, quota exceeded, or storage disabled).

## 🔗 Related Issues
Closes #7387

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.