### PR TITLE
fix: use consistent [session-lock] prefix for console warnings

### DIFF
--- a/js/session-lock.js
+++ b/js/session-lock.js
@@ -25,7 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
       method: 'POST',
       credentials: 'include',
     })
-      .catch((err) => console.warn('Failed to end session on server:', err))
+      .catch((err) => console.warn('[session-lock] Failed to end session on server:', err))
       .finally(() => {
         window.location.href = 'login.html';
       });


### PR DESCRIPTION
## 📄 Description

Adds [session-lock] prefix to console.warn calls.

## 🔗 Related Issues

Closes #7427

## 🧩 Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added or updated