### PR TITLE
fix: add null name guard in recommendations.js

### DIFF
--- a/js/recommendations.js
+++ b/js/recommendations.js
@@ -16,6 +16,9 @@ export class RecommendationEngine {
             // Corrupt or legacy storage falls back to defaults.
             history = [];
         }
+        history = history.filter(function(item) {
+          return item && typeof item.id !== 'undefined' && item.name;
+        });
         if (history.length === 0) return this.getDefaultRecommendations();
         return history.slice(0, 4);
     }


### PR DESCRIPTION
## 📄 Description
Added a filter to getRecommendations to exclude history items with null/undefined names or ids, preventing broken recommendation cards from rendering.

## 🔗 Related Issues
Closes #7518

## 🧩 Type of Change
- [[x]] Bug fix
- [] New feature
- [] Documentation update
- [] Style / UI improvement
- [] Refactor
- [] Test
- [] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.