### PR TITLE
fix: add NaN guard in promo-discount-calculator.js

### DIFF
--- a/js/promo-discount-calculator.js
+++ b/js/promo-discount-calculator.js
@@ -43,7 +43,10 @@ class PromoDiscountCalculator {
   }
 
   calculateTotal(subtotal, couponCode = '', baseShipping = 10) {
-    if (typeof subtotal !== 'number' || subtotal < 0) {
+    if (typeof subtotal !== 'number' || !isFinite(subtotal)) {
+      return { error: 'Invalid subtotal: must be a finite number.' };
+    }
+    if (subtotal < 0) {
       return { error: 'Invalid subtotal: must be a non-negative number.' };
     }
     let discount = 0;


### PR DESCRIPTION
## 📄 Description
Added an early return with error object when subtotal is not a finite number, preventing silent NaN propagation in the grand total field.

## 🔗 Related Issues
Closes #7519

## 🧩 Type of Change
- [[x]] Bug fix
- [] New feature
- [] Documentation update
- [] Style / UI improvement
- [] Refactor
- [] Test
- [] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.