### PR TITLE
fix: add NaN guard to addEarnedPoints in loyalty-rewards-engine.js

### DIFF
--- a/js/loyalty-rewards-engine.js
+++ b/js/loyalty-rewards-engine.js
@@ -47,6 +47,7 @@ class LoyaltyRewardsEngine {
   }
 
   addEarnedPoints(purchaseAmount) {
+    if (typeof purchaseAmount !== 'number' || !isFinite(purchaseAmount)) return 0;
     if (purchaseAmount <= 0) return 0;
     const currentTier = this.getTier();
     const basePoints = Math.floor(purchaseAmount);


### PR DESCRIPTION
## 📄 Description
Added an early return of 0 if purchaseAmount is not a finite number, preventing NaN from corrupting the loyalty points balance.

## 🔗 Related Issues
Closes #7532

## 🧩 Type of Change
- [[x]] Bug fix
- [] New feature
- [] Documentation update
- [] Style / UI improvement
- [] Refactor
- [] Test
- [] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.