### PR TITLE
fix: remove unused errors variable in error-logger.js

### DIFF
--- a/js/error-logger.js
+++ b/js/error-logger.js
@@ -8,11 +8,10 @@ var _logHook = function (msg, error) {
 
 window.addEventListener('error', (event) => {
   _logHook('[error-logger] Runtime exception caught: ', event.error);
-  let errors = [];
   try {
-    errors = JSON.parse(localStorage.getItem('cara_runtime_errors')) || [];
+    var errors = JSON.parse(localStorage.getItem('cara_runtime_errors')) || [];
   } catch (e) {
-    errors = [];
+    var errors = [];
   }
   errors.push({
     message: String(event.message || '').slice(0, 2000),


### PR DESCRIPTION
## 📄 Description
Removed the unused let errors = [] declaration that was immediately overwritten in the next statement, eliminating dead code in error-logger.js.

## 🔗 Related Issues
Closes #7516

## 🧩 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) — please assign this PR to the `tmdeveloper007` account when picking it up.