### PR TITLE
fix: add error handling to bare catch block in ar-product-viewer.js

### DIFF
--- a/js/ar-product-viewer.js
+++ b/js/ar-product-viewer.js
@@ -31,9 +31,7 @@
         try {
           const a = document.createElement('a');
           return a.relList && a.relList.supports && a.relList.supports('ar');
-        } catch {
-          return false;
-        }
+        } catch (err) { console.warn('[ARProductViewer] AR capability check failed:', err); }
       })();
 
     return Boolean(isWebXR || isiOSAR || window.customElements?.get('model-viewer'));


### PR DESCRIPTION
## 📄 Description
Replaces the bare `catch {}` block in `isARSupported()` with a catch that logs the error via `console.warn`.

## 🔗 Related Issues
Closes #7564

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) -- please assign this PR to the `tmdeveloper007` account when picking it up.