### PR TITLE
fix: merge duplicate input event listeners in gift-options.js

### DIFF
--- a/js/gift-options.js
+++ b/js/gift-options.js
@@ -43,15 +43,11 @@ document.addEventListener('DOMContentLoaded', () => {
     counter.style.cssText = 'font-size:11px; color:#888; display:block; text-align:right;';
     counter.textContent = `0/${MAX_GIFT_MSG_LENGTH}`;
     giftMsgInput.parentNode.appendChild(counter);
-    giftMsgInput.addEventListener('input', function() {
-      counter.textContent = `${giftMsgInput.value.length}/${MAX_GIFT_MSG_LENGTH}`;
-    });
-  }
-  if (giftMsgInput) {
     giftMsgInput.addEventListener('input', () => {
+      counter.textContent = giftMsgInput.value.length + '/' + MAX_GIFT_MSG_LENGTH;
       const valid = validateGiftMessageLength(giftMsgInput.value, MAX_GIFT_MSG_LENGTH);
       if (!valid) {
-        giftMsgInput.setCustomValidity(`Gift message exceeds the ${MAX_GIFT_MSG_LENGTH}-character limit.`);
+        giftMsgInput.setCustomValidity('Gift message exceeds the ' + MAX_GIFT_MSG_LENGTH + '-character limit.');
         giftMsgInput.reportValidity();
       } else {
         giftMsgInput.setCustomValidity('');
@@ -64,4 +60,4 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 
-function validateGiftMessageLength(message, maxChars = 200) { if (!message || typeof message !== 'string') return true; return message.trim().length <= maxChars; }
+export function validateGiftMessageLength(message, maxChars = 200) { if (!message || typeof message !== 'string') return true; return message.trim().length <= maxChars; }


### PR DESCRIPTION
## 📄 Description
Merges two separate `input` event listeners on `giftMsgInput` into a single handler.

## 🔗 Related Issues
Closes #7568

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) -- please assign this PR to the `tmdeveloper007` account when picking it up.