### PR TITLE
fix: debounce persist() calls in store.js to reduce localStorage I/O

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -19,6 +19,7 @@ class Store {
     
     const self = this;
     
+    this._persistTimer = null;
     this.state = new Proxy(state, {
       set(target, property, value) {
         target[property] = value;
@@ -41,7 +42,10 @@ class Store {
   }
 
   persist() {
-    localStorage.setItem(this.storageKey, JSON.stringify(this.state));
+    clearTimeout(this._persistTimer);
+    this._persistTimer = setTimeout(() => {
+      localStorage.setItem(this.storageKey, JSON.stringify(this.state));
+    }, 300);
   }
 }
 


### PR DESCRIPTION
## 📄 Description
Adds a 300ms debounce to the `persist()` method in the Store class.

## 🔗 Related Issues
Closes #7569

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) -- please assign this PR to the `tmdeveloper007` account when picking it up.