### PR TITLE
fix: trim postal code input before validation in address-validation-service.js

### DIFF
--- a/js/address-validation-service.js
+++ b/js/address-validation-service.js
@@ -19,7 +19,7 @@ class AddressValidationService {
       return { valid: false, message: 'Postal code is required.' };
     }
 
-    const clean = postalCode.trim().toUpperCase();
+    const clean = String(postalCode).trim().toUpperCase();
     const regex = this.postalRegex[country.toUpperCase()] || /^[A-Z0-9 -]{3,10}$/i;
 
     if (!regex.test(clean)) {


### PR DESCRIPTION
## 📄 Description
Wraps postal code input with `String(postalCode).trim()` before regex validation.

## 🔗 Related Issues
Closes #7570

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) -- please assign this PR to the `tmdeveloper007` account when picking it up.