### PR TITLE
fix: add null guard for discountEl in shipping-calc.js

### DIFF
--- a/js/shipping-calc.js
+++ b/js/shipping-calc.js
@@ -57,7 +57,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const subtotalEl = document.getElementById('summary-subtotal');
     const taxEl = document.getElementById('summary-tax');
     const discountEl = document.getElementById('summary-discount');
-    if (shippingEl && totalEl && subtotalEl && taxEl) {
+    if (shippingEl && totalEl && subtotalEl && taxEl && discountEl) {
       shippingEl.textContent = total === 0 ? 'FREE' : '₹' + total;
       const subtotal = parseFloat(subtotalEl.textContent.replace(/[^\d\.]/g, '')) || 0;
       const tax = parseFloat(taxEl.textContent.replace(/[^\d\.]/g, '')) || 0;


### PR DESCRIPTION
## 📄 Description
Adds `discountEl` to the null-check guard before accessing `discountEl.innerText`.

## 🔗 Related Issues
Closes #7572

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) -- please assign this PR to the `tmdeveloper007` account when picking it up.