### PR TITLE
fix: consolidate duplicate var declaration in error-logger.js

### DIFF
--- a/js/error-logger.js
+++ b/js/error-logger.js
@@ -8,10 +8,11 @@ var _logHook = function (msg, error) {
 
 window.addEventListener('error', (event) => {
   _logHook('[error-logger] Runtime exception caught: ', event.error);
+  var errors;
   try {
-    var errors = JSON.parse(localStorage.getItem('cara_runtime_errors')) || [];
+    errors = JSON.parse(localStorage.getItem('cara_runtime_errors')) || [];
   } catch (e) {
-    var errors = [];
+    errors = [];
   }
   errors.push({
     message: String(event.message || '').slice(0, 2000),


### PR DESCRIPTION
## 📄 Description
Consolidates the duplicate `var errors` declaration into a single declaration.

## 🔗 Related Issues
Closes #7573

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) -- please assign this PR to the `tmdeveloper007` account when picking it up.