### PR TITLE
feat: add pause and resume methods to ToastQueueManager in toast-queue.js

### DIFF
--- a/js/toast-queue.js
+++ b/js/toast-queue.js
@@ -21,6 +21,7 @@ export class ToastQueueManager {
     this.maxToasts = maxToasts;
     this.queue = [];
     this.container = null;
+    this._paused = false;
   }
 
   getOrCreateContainer() {
@@ -38,6 +39,12 @@ export class ToastQueueManager {
   }
 
   show(message, type = 'info', duration = 3000) {
+    // When paused, queue the item but do not render it yet.
+    if (this._paused) {
+      const toastItem = { id: `toast-${Date.now()}-${Math.random().toString(36).substr(2, 5)}`, message, type, duration, _pending: true };
+      this.queue.push(toastItem);
+      return toastItem.id;
+    }
     const container = this.getOrCreateContainer();
     const toastId = `toast-${Date.now()}-${Math.random().toString(36).substr(2, 5)}`;
 
@@ -49,7 +56,7 @@ export class ToastQueueManager {
     };
 
     this.queue.push(toastItem);
-    if (this.queue.length > this.maxToasts) {
+    if (!this._paused && this.queue.length > this.maxToasts) {
       this.dismiss(this.queue[0].id);
     }
 
@@ -95,6 +102,32 @@ export class ToastQueueManager {
   clearAll() {
     this.queue.forEach((t) => this.dismiss(t.id));
     this.queue = [];
+  }
+
+  pause() {
+    this._paused = true;
+  }
+
+  resume() {
+    if (!this._paused) return;
+    const pending = this.queue.splice(0, this.queue.length, ...this.queue.filter((t) => !t._pending));
+    this._paused = false;
+    // Render pending items by calling show for each (show() will handle them normally now).
+    pending.forEach((t) => {
+      this._paused = false;
+      const container = this.getOrCreateContainer();
+      const el = document.createElement('div');
+      el.id = t.id;
+      el.className = 'toast-card toast-' + t.type;
+      el.setAttribute('role', 'alert');
+      el.innerHTML =
+        '<div class="toast-content">' +
+        '<span class="toast-icon">' + (t.type === 'success' ? '&#10003;' : t.type === 'error' ? '&#10005;' : '&#8505;') + '</span>' +
+        '<span class="toast-message">' + escapeHtml(t.message) + '</span></div>' +
+        '<button class="toast-close" aria-label="Close notification">&times;</button>';
+      if (container) container.appendChild(el);
+      if (t.duration > 0) setTimeout(() => this.dismiss(t.id), t.duration);
+    });
   }
 }
 


### PR DESCRIPTION
## 📄 Description
Adds `pause()` and `resume()` methods to `ToastQueueManager` for toast lifecycle control.

## 🔗 Related Issues
Closes #7585

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) -- please assign this PR to the `tmdeveloper007` account when picking it up.