### PR TITLE
feat: add locale-aware formatCurrencyLocale helper to currency-converter.js

### DIFF
--- a/js/currency-converter.js
+++ b/js/currency-converter.js
@@ -105,6 +105,29 @@ export function formatCurrency(amountInUSD, targetCurrency = getActiveCurrency()
   return `${symbol}${isFinite(converted) ? converted.toFixed(2) : '0.00'}`;
 }
 
+/**
+ * Formats an amount in a locale-aware manner using Intl.NumberFormat.
+ * @param {number} amountInUSD - The amount in USD to convert and format.
+ * @param {string} [targetCurrency=getActiveCurrency()] - ISO 4217 currency code.
+ * @param {string} [locale='en-IN'] - BCP 47 locale tag for number formatting.
+ * @returns {string} The formatted currency string.
+ */
+export function formatCurrencyLocale(amountInUSD, targetCurrency = getActiveCurrency(), locale = 'en-IN') {
+  const converted = convertPrice(amountInUSD, targetCurrency);
+  if (!isFinite(converted)) return '0.00';
+  try {
+    return new Intl.NumberFormat(locale, {
+      style: 'currency',
+      currency: targetCurrency,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(converted);
+  } catch (e) {
+    // Fall back to basic formatting for unsupported locales or currencies.
+    return formatCurrency(amountInUSD, targetCurrency);
+  }
+}
+
 export function initCurrencySelector(selectElementId = 'currencySelect') {
   if (typeof document === 'undefined') return;
   const select = document.getElementById(selectElementId);


### PR DESCRIPTION
## 📄 Description
Adds `formatCurrencyLocale()` using `Intl.NumberFormat` for locale-aware currency formatting.

## 🔗 Related Issues
Closes #7587

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) -- please assign this PR to the `tmdeveloper007` account when picking it up.