### PR TITLE
feat: add validateConfigSchema function to config.js for startup validation

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -26,4 +26,44 @@
     CARA20: 20,
     WELCOME10: 10,
   };
+
+  /**
+   * Validates the shape of window.CARA_CONFIG at startup.
+   * Logs a console.warn for any missing or unexpectedly-typed keys.
+   */
+  function validateConfigSchema() {
+    const cfg = window.CARA_CONFIG;
+    const schema = {
+      TAX_RATE: 'number',
+      SHIPPING: 'object',
+      URGENCY_DISCOUNT_PCT: 'number',
+      GIFT_WRAP_CHARGE: 'number',
+      LOYALTY: 'object',
+    };
+    const nestedSchema = {
+      SHIPPING: { FEE: 'number', FREE_THRESHOLD: 'number' },
+      LOYALTY: { POINTS_PER_RUPEE: 'number', DEFAULT_BALANCE: 'number' },
+    };
+
+    for (const [key, expectedType] of Object.entries(schema)) {
+      if (!(key in cfg)) {
+        console.warn('[CARA_CONFIG] Missing required key: ' + key + '. Using default.');
+      } else if (typeof cfg[key] !== expectedType) {
+        console.warn('[CARA_CONFIG] Key ' + key + ' has unexpected type ' + typeof cfg[key] + ' (expected ' + expectedType + ').');
+      }
+    }
+
+    for (const [parent, children] of Object.entries(nestedSchema)) {
+      if (typeof cfg[parent] !== 'object' || cfg[parent] === null) continue;
+      for (const [child, expectedType] of Object.entries(children)) {
+        if (!(child in cfg[parent])) {
+          console.warn('[CARA_CONFIG] Missing required nested key: ' + parent + '.' + child + '.');
+        } else if (typeof cfg[parent][child] !== expectedType) {
+          console.warn('[CARA_CONFIG] Key ' + parent + '.' + child + ' has unexpected type ' + typeof cfg[parent][child] + ' (expected ' + expectedType + ').');
+        }
+      }
+    }
+  }
+
+  validateConfigSchema();
 })();


### PR DESCRIPTION
## 📄 Description
Adds `validateConfigSchema()` that checks required `window.CARA_CONFIG` keys at startup.

## 🔗 Related Issues
Closes #7588

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) -- please assign this PR to the `tmdeveloper007` account when picking it up.