### PR TITLE
test: add unit tests for address-validation-service trim and null handling

### DIFF
--- a/tests/unit/address-validation-service.test.js
+++ b/tests/unit/address-validation-service.test.js
@@ -114,4 +114,17 @@ describe('AddressValidationService Unit Tests', () => {
     expect(result.isValid).toBe(false);
     expect(result.errors.street).toBeDefined();
   });
+
+  it('validatePostalCode trims whitespace before validation', () => {
+    const result = service.validatePostalCode(' 110001  ', 'IN');
+    expect(result.valid).toBe(true);
+    expect(result.postalCode).toBe('110001');
+  });
+
+  it('validatePostalCode handles non-string input safely', () => {
+    const result = service.validatePostalCode(null, 'IN');
+    expect(result.valid).toBe(false);
+  });
 });
+
+


### PR DESCRIPTION
## 📄 Description
Adds test cases for `validatePostalCode` whitespace trimming and null input handling.

## 🔗 Related Issues
Closes #7570

## 🧩 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Note: This task is being handled by tmdeveloper007 as part of GSSOC (GirlScript Summer of Code) -- please assign this PR to the `tmdeveloper007` account when picking it up.