### PR TITLE
fix: Fix Memory Leak in Toast Notification Queue Manager (#6532)

### DIFF
--- a/js/toast-queue.js
+++ b/js/toast-queue.js
@@ -73,15 +73,18 @@ export class ToastQueueManager {
 
       container.appendChild(el);
 
-      if (duration > 0) {
-        setTimeout(() => this.dismiss(toastId), duration);
-      }
+      const timerId = duration > 0 ? setTimeout(() => this.dismiss(toastId), duration) : null;
+      toastItem.timerId = timerId;
     }
 
     return toastId;
   }
 
   dismiss(toastId) {
+    const item = this.queue.find((t) => t.id === toastId);
+    if (item && item.timerId) {
+      clearTimeout(item.timerId);
+    }
     this.queue = this.queue.filter((t) => t.id !== toastId);
     if (typeof document !== 'undefined') {
       const el = document.getElementById(toastId);


### PR DESCRIPTION
# 📋 Summary
Fixes memory leaks in `ToastQueueManager` (`js/toast-queue.js`) by tracking active timer handles and clearing timers upon toast dismissal.

---

## 🔗 Related Issue
Closes #6532

---

## 🔄 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

---

## 🛠️ What Was Changed
- Attached `timerId` handle to queued toast items in `js/toast-queue.js`.
- Added `clearTimeout(item.timerId)` inside `dismiss()` method.
- Verified test suite in `tests/unit/toast-queue.test.js`.

---

## why this needed
- Prevents unreleased timer handles and event listener references from accumulating in memory.
- Ensures stable browser memory footprint during frequent notification triggers.

---

## 🧪 How Has This Been Tested?

- [x] Tested frontend locally with `npm run dev`
- [x] Ran `npm run lint` — no errors
- [x] Ran `npm test` — all Vitest tests passed

---

## ✅ Self-Review Checklist

- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #6532`)
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue

---

## 📋 Additional Notes
Zero residual DOM elements or uncleared timers upon calling `clearAll()`.
