### PR TITLE
fix: Enforce Strict Rate Limiting on Admin Analytics & Export Routes (#6534)

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -3,13 +3,14 @@ Admin analytics API endpoints.
 
 Secure route for store managers/admins to fetch aggregates.
 """
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 from sqlalchemy import func
 from typing import List
 
 from .. import models, schemas
 from ..database import get_db
+from ..limiter import limiter
 from .auth import get_current_user
 
 router = APIRouter()
@@ -26,7 +27,9 @@ def _enforce_admin(user: models.User = Depends(get_current_user)):
 
 
 @router.get("/analytics/summary", response_model=schemas.AdminSummaryResponse)
+@limiter.limit("10/minute")
 def get_analytics_summary(
+    request: Request,
     db: Session = Depends(get_db),
     admin_user: models.User = Depends(_enforce_admin)
 ) -> dict:
@@ -58,7 +61,9 @@ def get_analytics_summary(
 
 
 @router.get("/analytics/category-sales", response_model=List[schemas.CategorySalesOut])
+@limiter.limit("10/minute")
 def get_sales_by_category(
+    request: Request,
     db: Session = Depends(get_db),
     admin_user: models.User = Depends(_enforce_admin)
 ) -> list:
@@ -92,7 +97,9 @@ def get_sales_by_category(
 
 
 @router.get("/analytics/order-status-distribution", response_model=List[schemas.StatusDistributionOut])
+@limiter.limit("10/minute")
 def get_status_distribution(
+    request: Request,
     db: Session = Depends(get_db),
     admin_user: models.User = Depends(_enforce_admin)
 ) -> list:


### PR DESCRIPTION
# 📋 Summary
Applies strict rate limiting (`@limiter.limit("10/minute")`) to admin analytics routes in `backend/app/api/admin.py` to protect resource-heavy SQL aggregation queries against DoS attacks.

---

## 🔗 Related Issue
Closes #6534

---

## 🔄 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [ ] Test
- [ ] Chore / dependency update

---

## 🛠️ What Was Changed
- Added `@limiter.limit("10/minute")` rate limiting decorators to `/analytics/summary`, `/analytics/category-sales`, and `/analytics/order-status-distribution` in `backend/app/api/admin.py`.
- Injected required `request: Request` parameter into handler signatures.

---

## why this needed
- Prevents malicious or automated polling from exhausting database connection pools via un-cached aggregation queries.
- Ensures backend stability and availability for administrative functions under high traffic load.

---

## 🧪 How Has This Been Tested?

- [x] Tested backend API endpoints manually
- [x] Ran `npm run lint` — no errors
- [x] Ran `npm test` — all Vitest tests passed

---

## ✅ Self-Review Checklist

- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue (`Closes #6534`)
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue

---

## 📋 Additional Notes
Utilizes SlowAPI rate limiter configured across existing application routes.
