### PR TITLE
fix: convert var to const/let in error-logger.js

### DIFF
--- a/js/error-logger.js
+++ b/js/error-logger.js
@@ -1,17 +1,18 @@
 // Client-Side Error Boundary and Logger
 
 // Internal silent logging hook — replace with window.CaraErrorLogger in future
-var _logHook = function (msg, error) {
+const _logHook = function (msg, error) {
   // Silent by default — no console output in production builds.
   // Wire in a centralized logging service to capture these.
 };
 
 window.addEventListener('error', (event) => {
   _logHook('[error-logger] Runtime exception caught: ', event.error);
+  let errors = [];
   try {
-    var errors = JSON.parse(localStorage.getItem('cara_runtime_errors')) || [];
+    errors = JSON.parse(localStorage.getItem('cara_runtime_errors')) || [];
   } catch (e) {
-    var errors = [];
+    // keep empty array if localStorage unavailable
   }
   errors.push({
     message: String(event.message || '').slice(0, 2000),


### PR DESCRIPTION
## Summary
Converts `var` to `const`/`let` in `js/error-logger.js`. Also fixes the duplicate `var errors` declaration across try/catch into a single `let errors` hoisted before the try block (identical behavior).

## Checklist
- [x] Verified with `node --check`
- [x] No behavior change