### PR TITLE
fix: convert var to const in admin-products.js

### DIFF
--- a/js/admin-products.js
+++ b/js/admin-products.js
@@ -1,9 +1,9 @@
-var API_BASE = window.CARA_API_BASE_URL || '';
+const API_BASE = window.CARA_API_BASE_URL || '';
 
 
 
 function adminRequest(method, path, body) {
-  var opts = {
+  const opts = {
     method: method,
     credentials: 'include',
     headers: {


### PR DESCRIPTION
## Summary
Converts `var` to `const` in `js/admin-products.js`. Block-scoped declarations, identical behavior.

## Checklist
- [x] Verified with `node --check`
- [x] No behavior change