### PR TITLE
fix: convert var to const in error-boundary.js

### DIFF
--- a/js/error-boundary.js
+++ b/js/error-boundary.js
@@ -3,7 +3,7 @@
 
 window.CaraErrorBoundary = (function () {
   // Internal silent logging hook — replace with error-logger.js wiring in future
-  var _logHook = function (msg, error) {
+  const _logHook = function (msg, error) {
     // Silent by default — no console output in production builds.
     // Wire in window.CaraErrorLogger and call _logHook('error', {msg, error})
     // to integrate with a centralized logging service.
@@ -37,17 +37,17 @@ window.CaraErrorBoundary = (function () {
   }
 
   function wrap(selector, renderFn) {
-    var container = document.querySelector(selector);
+    const container = document.querySelector(selector);
     if (!container) return;
 
-    var attempt = function () {
+    const attempt = function () {
       try {
         renderFn();
       } catch (error) {
         logError(error, selector);
         renderFallback(container, error.message);
 
-        var retryBtn = container.querySelector('.cara-error-retry');
+        const retryBtn = container.querySelector('.cara-error-retry');
         if (retryBtn) {
           retryBtn.addEventListener('click', attempt);
         }


### PR DESCRIPTION
## Summary
Converts `var` to `const` in `js/error-boundary.js`. Block-scoped declarations, identical behavior.

## Checklist
- [x] Verified with `node --check`
- [x] No behavior change