### PR TITLE
feat: add back-to-top-progress.js module

### DIFF
--- a/js/back-to-top-progress.js
+++ b/js/back-to-top-progress.js
@@ -1,0 +1,15 @@
+(function () {
+  'use strict';
+  const ring = document.getElementById('cara-scroll-progress-ring');
+  if (!ring || !window.ScrollToTop) return;
+  const indicator = ring.querySelector('.cara-progress-indicator');
+  if (!indicator) return;
+  const update = () => {
+    const max = document.documentElement.scrollHeight - window.innerHeight;
+    const ratio = max > 0 ? Math.min(window.scrollY / max, 1) : 0;
+    indicator.setAttribute('stroke-dashoffset', String(100 - ratio * 100));
+    ring.style.display = window.scrollY > 200 ? 'inline-flex' : 'none';
+  };
+  window.addEventListener('scroll', update, { passive: true });
+  update();
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/back-to-top-progress.js` for the Cara storefront.

### Why it matters for Cara
Shows reading progress alongside the scroll-to-top control so customers always know how much of the page remains.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules