### PR TITLE
feat: add breadcrumb-schema.js module

### DIFF
--- a/js/breadcrumb-schema.js
+++ b/js/breadcrumb-schema.js
@@ -1,0 +1,23 @@
+(function () {
+  'use strict';
+  const nav = document.querySelector('nav[aria-label="breadcrumb"]');
+  if (!nav) return;
+  const items = Array.from(nav.querySelectorAll('a')).map((a) => ({
+    name: a.textContent.trim(),
+    item: a.href,
+  }));
+  if (!items.length) return;
+  const script = document.createElement('script');
+  script.type = 'application/ld+json';
+  script.textContent = JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((it, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      name: it.name,
+      item: it.item,
+    })),
+  });
+  document.head.appendChild(script);
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/breadcrumb-schema.js` for the Cara storefront.

### Why it matters for Cara
Injects JSON-LD BreadcrumbList markup from the existing nav for better SEO visibility in Google search results.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules