### PR TITLE
feat: add compare-price-ticker.js module

### DIFF
--- a/js/compare-price-ticker.js
+++ b/js/compare-price-ticker.js
@@ -1,0 +1,13 @@
+(function () {
+  'use strict';
+  document.querySelectorAll('[data-compare-price]').forEach((el) => {
+    const sale = parseFloat(el.getAttribute('data-sale-price'));
+    const mrp = parseFloat(el.getAttribute('data-compare-price'));
+    if (Number.isNaN(sale) || Number.isNaN(mrp) || mrp <= sale) return;
+    const pct = Math.round(((mrp - sale) / mrp) * 100);
+    const tag = document.createElement('span');
+    tag.className = 'cara-savings-tag';
+    tag.textContent = pct + '% off';
+    el.appendChild(tag);
+  });
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/compare-price-ticker.js` for the Cara storefront.

### Why it matters for Cara
Surfaces savings vs MRP as a percentage tag so customers instantly see the deal value on product cards.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules