### PR TITLE
feat: add favorite-sync.js module

### DIFF
--- a/js/favorite-sync.js
+++ b/js/favorite-sync.js
@@ -1,0 +1,15 @@
+(function () {
+  'use strict';
+  const el = document.querySelector('[data-wishlist-count]');
+  if (!el) return;
+  const KEY = 'cara_favorites';
+  const render = () => {
+    let list = [];
+    try { list = JSON.parse(localStorage.getItem(KEY)) || []; } catch (e) { list = []; }
+    el.textContent = String(list.length);
+  };
+  render();
+  window.addEventListener('storage', (e) => {
+    if (e.key === KEY) render();
+  });
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/favorite-sync.js` for the Cara storefront.

### Why it matters for Cara
Keeps the wishlist count consistent across open tabs via storage events, preventing stale counts after multi-tab browsing.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules