### PR TITLE
feat: add floating-swatches.js module

### DIFF
--- a/js/floating-swatches.js
+++ b/js/floating-swatches.js
@@ -1,0 +1,21 @@
+(function () {
+  'use strict';
+  document.querySelectorAll('[data-floating-swatches]').forEach((card) => {
+    const variants = card.querySelectorAll('[data-quick-variant]');
+    if (!variants.length) return;
+    const bar = document.createElement('div');
+    bar.className = 'cara-floating-swatches';
+    variants.forEach((v) => {
+      const dot = document.createElement('button');
+      dot.type = 'button';
+      dot.className = 'cara-quick-variant';
+      dot.style.background = v.getAttribute('data-color') || '#ccc';
+      dot.setAttribute('aria-label', v.getAttribute('data-label') || 'variant');
+      dot.addEventListener('click', () => {
+        window.dispatchEvent(new CustomEvent('cara:quick-add', { detail: { sku: v.dataset.quickVariant } }));
+      });
+      bar.appendChild(dot);
+    });
+    card.appendChild(bar);
+  });
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/floating-swatches.js` for the Cara storefront.

### Why it matters for Cara
Quick-add color variants from a floating bar on product cards, shortening the path from browse to cart.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules