### PR TITLE
feat: add form-save-indicator.js module

### DIFF
--- a/js/form-save-indicator.js
+++ b/js/form-save-indicator.js
@@ -1,0 +1,24 @@
+(function () {
+  'use strict';
+  document.querySelectorAll('[data-autosave-form]').forEach((form) => {
+    const chip = document.createElement('span');
+    chip.className = 'cara-autosave-status';
+    chip.setAttribute('role', 'status');
+    chip.textContent = 'Saved';
+    form.appendChild(chip);
+    let timer = null;
+    form.addEventListener('input', () => {
+      chip.textContent = 'Saving...';
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        try {
+          const data = Object.fromEntries(new FormData(form).entries());
+          localStorage.setItem('cara_form_draft_' + form.id, JSON.stringify(data));
+          chip.textContent = 'Saved';
+        } catch (e) {
+          chip.textContent = 'Save unavailable';
+        }
+      }, 600);
+    });
+  });
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/form-save-indicator.js` for the Cara storefront.

### Why it matters for Cara
Shows an autosave status chip on forms so users know their draft is persisted locally before submitting.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules