### PR TITLE
feat: add free-shipping-progress.js module

### DIFF
--- a/js/free-shipping-progress.js
+++ b/js/free-shipping-progress.js
@@ -1,0 +1,16 @@
+(function () {
+  'use strict';
+  const bar = document.getElementById('cara-free-shipping-progress');
+  if (!bar) return;
+  const threshold = parseFloat(bar.getAttribute('data-threshold') || '0');
+  const cartTotal = parseFloat(bar.getAttribute('data-cart-total') || '0');
+  const fill = bar.querySelector('.cara-progress-fill');
+  const label = bar.querySelector('.cara-progress-label');
+  const pct = threshold > 0 ? Math.min((cartTotal / threshold) * 100, 100) : 0;
+  if (fill) fill.style.width = pct + '%';
+  if (label) {
+    label.textContent = cartTotal >= threshold
+      ? 'You have unlocked FREE shipping!'
+      : '\u20B9' + Math.ceil(threshold - cartTotal) + ' away from FREE shipping';
+  }
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/free-shipping-progress.js` for the Cara storefront.

### Why it matters for Cara
Visual progress bar toward the free-shipping threshold, nudging cart value up and boosting AOV.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules