### PR TITLE
feat: add gift-wrap-toggler.js module

### DIFF
--- a/js/gift-wrap-toggler.js
+++ b/js/gift-wrap-toggler.js
@@ -1,0 +1,17 @@
+(function () {
+  'use strict';
+  document.querySelectorAll('[data-gift-wrap]').forEach((el) => {
+    const box = el.querySelector('[type="checkbox"]');
+    const priceEl = el.querySelector('[data-gift-price]');
+    if (!box || !priceEl) return;
+    const base = parseFloat(priceEl.getAttribute('data-gift-price') || '0');
+    const show = () => {
+      priceEl.textContent = box.checked ? '+' + '\u20B9' + base : '';
+    };
+    box.addEventListener('change', () => {
+      show();
+      window.dispatchEvent(new CustomEvent('cara:gift-wrap-change', { detail: { checked: box.checked } }));
+    });
+    show();
+  });
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/gift-wrap-toggler.js` for the Cara storefront.

### Why it matters for Cara
Optional gift-wrap checkbox that shows the price add-on instantly, without a page reload at checkout.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules