### PR TITLE
feat: add image-aspect-ratio.js module

### DIFF
--- a/js/image-aspect-ratio.js
+++ b/js/image-aspect-ratio.js
@@ -1,0 +1,11 @@
+(function () {
+  'use strict';
+  document.querySelectorAll('img[width][height]').forEach((img) => {
+    if (img.hasAttribute('data-aspect-applied')) return;
+    const w = parseInt(img.getAttribute('width'), 10);
+    const h = parseInt(img.getAttribute('height'), 10);
+    if (Number.isNaN(w) || Number.isNaN(h) || h === 0) return;
+    img.style.aspectRatio = String(w) + ' / ' + String(h);
+    img.setAttribute('data-aspect-applied', 'true');
+  });
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/image-aspect-ratio.js` for the Cara storefront.

### Why it matters for Cara
Reserves image box space from width/height attributes to prevent Cumulative Layout Shift on product imagery.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules