### PR TITLE
feat: add infinite-scroll.js module

### DIFF
--- a/js/infinite-scroll.js
+++ b/js/infinite-scroll.js
@@ -1,0 +1,14 @@
+(function () {
+  'use strict';
+  const grid = document.querySelector('[data-infinite-grid]');
+  const sentinel = document.querySelector('[data-infinite-sentinel]');
+  if (!grid || !sentinel) return;
+  let loading = false;
+  const observer = new IntersectionObserver((entries) => {
+    if (!entries[0].isIntersecting || loading) return;
+    loading = true;
+    grid.dispatchEvent(new CustomEvent('cara:load-more', { bubbles: true }));
+  }, { rootMargin: '200px' });
+  observer.observe(sentinel);
+  window.addEventListener('cara:load-more-complete', () => { loading = false; });
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/infinite-scroll.js` for the Cara storefront.

### Why it matters for Cara
Loads the next page of the product grid on scroll via a sentinel observer, removing pagination friction.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules