### PR TITLE
feat: add lazy-image-priority.js module

### DIFF
--- a/js/lazy-image-priority.js
+++ b/js/lazy-image-priority.js
@@ -1,0 +1,12 @@
+(function () {
+  'use strict';
+  const images = Array.from(document.querySelectorAll('img[data-lazy-priority]'));
+  images.forEach((img, i) => {
+    if (i < 2) {
+      img.loading = 'eager';
+      img.fetchPriority = 'high';
+    } else if (img.loading !== 'lazy') {
+      img.loading = 'lazy';
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/lazy-image-priority.js` for the Cara storefront.

### Why it matters for Cara
Promotes above-the-fold images to eager loading and defers the rest, improving LCP without markup edits.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules