### PR TITLE
feat: add mobile-menu.js module

### DIFF
--- a/js/mobile-menu.js
+++ b/js/mobile-menu.js
@@ -1,0 +1,17 @@
+(function () {
+  'use strict';
+  const btn = document.querySelector('[data-menu-toggle]');
+  const nav = document.querySelector('[data-mobile-menu]');
+  if (!btn || !nav) return;
+  const toggle = (open) => {
+    nav.hidden = !open;
+    btn.setAttribute('aria-expanded', String(open));
+    document.body.classList.toggle('cara-menu-open', open);
+    if (open) {
+      const first = nav.querySelector('a, button');
+      if (first) first.focus();
+    }
+  };
+  btn.addEventListener('click', () => toggle(nav.hidden));
+  document.addEventListener('cara:close-overlays', () => toggle(false));
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/mobile-menu.js` for the Cara storefront.

### Why it matters for Cara
Accessible off-canvas mobile navigation drawer with focus handling and ARIA state, improving mobile navigation UX.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules