### PR TITLE
feat: add newsletter-popup.js module

### DIFF
--- a/js/newsletter-popup.js
+++ b/js/newsletter-popup.js
@@ -1,0 +1,18 @@
+(function () {
+  'use strict';
+  const KEY = 'cara_newsletter_seen';
+  let seen = false;
+  try { seen = localStorage.getItem(KEY) === '1'; } catch (e) { seen = false; }
+  if (seen) return;
+  const popup = document.getElementById('cara-newsletter-popup');
+  if (!popup) return;
+  const show = () => {
+    popup.hidden = false;
+    try { localStorage.setItem(KEY, '1'); } catch (e) {}
+  };
+  const close = popup.querySelector('[data-newsletter-close]');
+  if (close) close.addEventListener('click', () => { popup.hidden = true; });
+  document.addEventListener('mouseleave', (e) => {
+    if (e.clientY <= 0) show();
+  });
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/newsletter-popup.js` for the Cara storefront.

### Why it matters for Cara
Delays a dismissible newsletter signup popup until exit intent, capturing emails without interrupting browsing.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules