### PR TITLE
feat: add payment-icons.js module

### DIFF
--- a/js/payment-icons.js
+++ b/js/payment-icons.js
@@ -1,0 +1,12 @@
+(function () {
+  'use strict';
+  const el = document.querySelector('[data-payment-methods]');
+  if (!el) return;
+  const methods = (el.getAttribute('data-payment-methods') || 'upi,cod').split(',');
+  methods.forEach((m) => {
+    const badge = document.createElement('span');
+    badge.className = 'cara-payment-badge';
+    badge.textContent = m.trim().toUpperCase();
+    el.appendChild(badge);
+  });
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/payment-icons.js` for the Cara storefront.

### Why it matters for Cara
Renders accepted payment method badges from a data attribute, building checkout trust and reducing abandonment.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules