### PR TITLE
feat: add price-drop-alert.js module

### DIFF
--- a/js/price-drop-alert.js
+++ b/js/price-drop-alert.js
@@ -1,0 +1,17 @@
+(function () {
+  'use strict';
+  const KEY = 'cara_price_watch';
+  const read = () => { try { return JSON.parse(localStorage.getItem(KEY)) || {}; } catch (e) { return {}; } };
+  const write = (v) => { try { localStorage.setItem(KEY, JSON.stringify(v)); } catch (e) {} };
+  document.querySelectorAll('[data-price-watch]').forEach((el) => {
+    const sku = el.getAttribute('data-price-watch');
+    const price = parseFloat(el.getAttribute('data-current-price'));
+    if (!sku || Number.isNaN(price)) return;
+    const watch = read();
+    if (watch[sku] !== undefined && price < watch[sku]) {
+      window.dispatchEvent(new CustomEvent('cara:price-drop', { detail: { sku, from: watch[sku], to: price } }));
+    }
+    watch[sku] = price;
+    write(watch);
+  });
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/price-drop-alert.js` for the Cara storefront.

### Why it matters for Cara
Tracks wishlisted item prices in localStorage and fires an event when a drop is detected, enabling restock/price notifications.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules