### PR TITLE
feat: add product-quickview.js module

### DIFF
--- a/js/product-quickview.js
+++ b/js/product-quickview.js
@@ -1,0 +1,11 @@
+(function () {
+  'use strict';
+  document.addEventListener('click', (e) => {
+    const trigger = e.target.closest('[data-quickview]');
+    if (!trigger) return;
+    e.preventDefault();
+    window.dispatchEvent(new CustomEvent('cara:quickview-open', {
+      detail: { url: trigger.getAttribute('data-quickview') },
+    }));
+  });
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/product-quickview.js` for the Cara storefront.

### Why it matters for Cara
Opens a lightweight quick-view modal for product cards via data attributes, keeping shoppers on the grid.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules