### PR TITLE
feat: add referral-copier.js module

### DIFF
--- a/js/referral-copier.js
+++ b/js/referral-copier.js
@@ -1,0 +1,21 @@
+(function () {
+  'use strict';
+  document.addEventListener('click', async (e) => {
+    const btn = e.target.closest('[data-copy-referral]');
+    if (!btn) return;
+    const text = btn.getAttribute('data-copy-referral');
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch (err) {
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      ta.remove();
+    }
+    const prev = btn.textContent;
+    btn.textContent = 'Copied!';
+    setTimeout(() => { btn.textContent = prev; }, 1500);
+  });
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/referral-copier.js` for the Cara storefront.

### Why it matters for Cara
One-click copy of referral links with clipboard fallback and success feedback, boosting referral conversions.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules