### PR TITLE
feat: add save-later-badge.js module

### DIFF
--- a/js/save-later-badge.js
+++ b/js/save-later-badge.js
@@ -1,0 +1,8 @@
+(function () {
+  'use strict';
+  const el = document.querySelector('[data-save-later-count]');
+  if (!el) return;
+  const render = (count) => { el.textContent = String(count || 0); };
+  render(el.getAttribute('data-save-later-count') || '0');
+  window.addEventListener('cara:save-later-updated', (e) => render(e.detail && e.detail.count));
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/save-later-badge.js` for the Cara storefront.

### Why it matters for Cara
Badge count for saved-for-later items kept in sync via manager events, so users can find saved items easily.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules