### PR TITLE
feat: add search-suggestions.js module

### DIFF
--- a/js/search-suggestions.js
+++ b/js/search-suggestions.js
@@ -1,0 +1,31 @@
+(function () {
+  'use strict';
+  const input = document.querySelector('[data-search-autocomplete]');
+  if (!input) return;
+  const source = (input.getAttribute('data-search-autocomplete') || '').split('|').filter(Boolean);
+  const list = document.createElement('ul');
+  list.hidden = true;
+  list.className = 'cara-search-suggestions';
+  input.parentNode.appendChild(list);
+  input.addEventListener('input', () => {
+    const q = input.value.trim().toLowerCase();
+    if (q.length < 2) { list.hidden = true; return; }
+    const matches = source.filter((s) => s.toLowerCase().includes(q)).slice(0, 6);
+    list.innerHTML = '';
+    matches.forEach((m) => {
+      const li = document.createElement('li');
+      const b = document.createElement('button');
+      b.type = 'button';
+      b.textContent = m;
+      b.addEventListener('click', () => {
+        input.value = m;
+        list.hidden = true;
+        input.form && input.form.submit();
+      });
+      li.appendChild(b);
+      list.appendChild(li);
+    });
+    list.hidden = matches.length === 0;
+  });
+  input.addEventListener('blur', () => setTimeout(() => { list.hidden = true; }, 150));
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/search-suggestions.js` for the Cara storefront.

### Why it matters for Cara
Dropdown autocomplete for the search box fed from a data attribute, speeding up product discovery.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules