### PR TITLE
feat: add share-product.js module

### DIFF
--- a/js/share-product.js
+++ b/js/share-product.js
@@ -1,0 +1,20 @@
+(function () {
+  'use strict';
+  document.addEventListener('click', async (e) => {
+    const btn = e.target.closest('[data-share-product]');
+    if (!btn) return;
+    const data = {
+      title: btn.getAttribute('data-share-title') || document.title,
+      text: btn.getAttribute('data-share-text') || '',
+      url: btn.getAttribute('data-share-url') || location.href,
+    };
+    if (navigator.share) {
+      try { await navigator.share(data); } catch (err) {}
+    } else if (navigator.clipboard) {
+      await navigator.clipboard.writeText(data.url);
+      const prev = btn.textContent;
+      btn.textContent = 'Link copied';
+      setTimeout(() => { btn.textContent = prev; }, 1500);
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/share-product.js` for the Cara storefront.

### Why it matters for Cara
Shares products via the native Web Share API with a copy-link fallback, expanding organic reach.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules