### PR TITLE
feat: add size-guide-tooltip.js module

### DIFF
--- a/js/size-guide-tooltip.js
+++ b/js/size-guide-tooltip.js
@@ -1,0 +1,14 @@
+(function () {
+  'use strict';
+  document.querySelectorAll('[data-size-guide-trigger]').forEach((trigger) => {
+    const target = document.querySelector(trigger.getAttribute('data-size-guide-trigger'));
+    if (!target) return;
+    const show = () => { target.hidden = false; };
+    const hide = () => { target.hidden = true; };
+    trigger.addEventListener('mouseenter', show);
+    trigger.addEventListener('mouseleave', hide);
+    trigger.addEventListener('focus', show);
+    trigger.addEventListener('blur', hide);
+    target.hidden = true;
+  });
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/size-guide-tooltip.js` for the Cara storefront.

### Why it matters for Cara
Hover/press size-guide tooltip next to size selectors, reducing return rates caused by wrong-size purchases.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules