### PR TITLE
feat: add slide-out-cart.js module

### DIFF
--- a/js/slide-out-cart.js
+++ b/js/slide-out-cart.js
@@ -1,0 +1,24 @@
+(function () {
+  'use strict';
+  const drawer = document.querySelector('[data-slideout-cart]');
+  const openBtn = document.querySelector('[data-cart-trigger]');
+  const closeBtn = drawer && drawer.querySelector('[data-cart-close]');
+  if (!drawer || !openBtn) return;
+  let lastFocus = null;
+  const open = () => {
+    lastFocus = document.activeElement;
+    drawer.hidden = false;
+    document.body.classList.add('cara-cart-open');
+    const first = drawer.querySelector('a, button');
+    if (first) first.focus();
+  };
+  const close = () => {
+    drawer.hidden = true;
+    document.body.classList.remove('cara-cart-open');
+    if (lastFocus) lastFocus.focus();
+  };
+  openBtn.addEventListener('click', open);
+  if (closeBtn) closeBtn.addEventListener('click', close);
+  document.addEventListener('cara:close-overlays', close);
+  document.addEventListener('cara:cart-updated', open);
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/slide-out-cart.js` for the Cara storefront.

### Why it matters for Cara
Slide-out mini cart drawer that reacts to cart update events with focus-return, improving the add-to-cart flow.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules