### PR TITLE
feat: add sticky-add-to-cart.js module

### DIFF
--- a/js/sticky-add-to-cart.js
+++ b/js/sticky-add-to-cart.js
@@ -1,0 +1,13 @@
+(function () {
+  'use strict';
+  const bar = document.querySelector('[data-sticky-atc]');
+  const mainCta = document.querySelector('[data-pdp-add-to-cart]');
+  if (!bar || !mainCta) return;
+  const onScroll = () => {
+    const rect = mainCta.getBoundingClientRect();
+    const show = rect.bottom < 0;
+    bar.classList.toggle('cara-sticky-atc-visible', show);
+  };
+  window.addEventListener('scroll', onScroll, { passive: true });
+  onScroll();
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/sticky-add-to-cart.js` for the Cara storefront.

### Why it matters for Cara
Sticky add-to-cart bar that appears after scrolling past the main CTA on mobile, recovering late purchase intent.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules