### PR TITLE
feat: add theme-toggle.js module

### DIFF
--- a/js/theme-toggle.js
+++ b/js/theme-toggle.js
@@ -1,0 +1,18 @@
+(function () {
+  'use strict';
+  const btn = document.querySelector('[data-theme-toggle]');
+  if (!btn) return;
+  const KEY = 'cara_theme';
+  const apply = (theme) => {
+    document.documentElement.setAttribute('data-theme', theme);
+    btn.setAttribute('aria-pressed', String(theme === 'dark'));
+  };
+  const saved = (() => { try { return localStorage.getItem(KEY); } catch (e) { return null; } })();
+  const initial = saved || (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+  apply(initial);
+  btn.addEventListener('click', () => {
+    const next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    apply(next);
+    try { localStorage.setItem(KEY, next); } catch (e) {}
+  });
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/theme-toggle.js` for the Cara storefront.

### Why it matters for Cara
Light/dark theme toggle with localStorage persistence and system-preference fallback for accessibility.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules