### PR TITLE
feat: add toast-role.js module

### DIFF
--- a/js/toast-role.js
+++ b/js/toast-role.js
@@ -1,0 +1,8 @@
+(function () {
+  'use strict';
+  const container = document.getElementById('cara-notif-container');
+  if (!container) return;
+  container.setAttribute('role', 'region');
+  container.setAttribute('aria-live', 'polite');
+  container.setAttribute('aria-atomic', 'false');
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/toast-role.js` for the Cara storefront.

### Why it matters for Cara
Adds ARIA live-region semantics to the toast container so screen readers announce notifications, improving a11y.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules