### PR TITLE
feat: add video-product-tour.js module

### DIFF
--- a/js/video-product-tour.js
+++ b/js/video-product-tour.js
@@ -1,0 +1,14 @@
+(function () {
+  'use strict';
+  document.addEventListener('click', (e) => {
+    const trigger = e.target.closest('[data-video-tour]');
+    if (!trigger) return;
+    e.preventDefault();
+    window.dispatchEvent(new CustomEvent('cara:video-open', {
+      detail: { src: trigger.getAttribute('data-video-tour') },
+    }));
+  });
+  document.addEventListener('cara:close-overlays', () => {
+    document.querySelectorAll('[data-video-element]').forEach((v) => v.pause());
+  });
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/video-product-tour.js` for the Cara storefront.

### Why it matters for Cara
Opens product videos in a modal and pauses them on close, delivering richer product detail without navigation.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules