### PR TITLE
feat: add voice-command-navigation.js module

### DIFF
--- a/js/voice-command-navigation.js
+++ b/js/voice-command-navigation.js
@@ -1,0 +1,20 @@
+(function () {
+  'use strict';
+  const btn = document.querySelector('[data-voice-command]');
+  if (!btn || !('webkitSpeechRecognition' in window)) return;
+  const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
+  const rec = new SR();
+  rec.lang = 'en-IN';
+  rec.interimResults = false;
+  const onResult = (e) => {
+    const text = (e.results[0][0].transcript || '').toLowerCase().trim();
+    if (!text) return;
+    window.dispatchEvent(new CustomEvent('cara:voice-command', { detail: { text } }));
+  };
+  rec.onresult = onResult;
+  rec.onend = () => { btn.classList.remove('is-listening'); };
+  btn.addEventListener('click', () => {
+    btn.classList.add('is-listening');
+    try { rec.start(); } catch (err) {}
+  });
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/voice-command-navigation.js` for the Cara storefront.

### Why it matters for Cara
Minimal Web Speech API voice commands for search and navigation on supported browsers, a differentiator for accessibility.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules