### PR TITLE
feat: add wishlist-heart-animator.js module

### DIFF
--- a/js/wishlist-heart-animator.js
+++ b/js/wishlist-heart-animator.js
@@ -1,0 +1,11 @@
+(function () {
+  'use strict';
+  document.addEventListener('click', (e) => {
+    const heart = e.target.closest('[data-wishlist-heart]');
+    if (!heart) return;
+    heart.classList.remove('cara-heart-burst');
+    void heart.offsetWidth;
+    heart.classList.add('cara-heart-burst');
+    heart.setAttribute('aria-pressed', String(!(heart.getAttribute('aria-pressed') === 'true')));
+  });
+})();


### PR DESCRIPTION
## Summary
Adds a new isolated browser module `js/wishlist-heart-animator.js` for the Cara storefront.

### Why it matters for Cara
Adds a burst animation to wishlist heart toggles with ARIA pressed state, providing tactile feedback on wishlist actions.

### Scope
- Adds a single new file under `js/`; no existing files touched, no new dependencies.
- Follows the existing IIFE + `'use strict'` module convention.
- Guarded so it is a no-op when the expected DOM hooks are absent.

### Checklist
- [x] Validated with `node --check`
- [x] No behavior change to existing modules