### PR TITLE
test: add regression tests for UK postal code space handling (#7571)

### DIFF
--- a/tests/unit/pincode-validation-engine.test.js
+++ b/tests/unit/pincode-validation-engine.test.js
@@ -34,7 +34,7 @@ describe('PincodeValidationEngine', () => {
     const zone = engine.getDeliveryZone('110001', 'IN');
     expect(zone).toEqual({
       zone: 'Express Zone',
-      estimatedDaysText: '1-3 business days'
+      estimatedDaysText: '1-3 business days',
     });
   });
 
@@ -56,5 +56,26 @@ describe('PincodeValidationEngine', () => {
     expect(engine.validatePostalCode('SW1A 1AA', 'UK').valid).toBe(true);
     expect(engine.validatePostalCode('K1A 0B1', 'CA').valid).toBe(true);
     expect(engine.validatePostalCode('BAD', 'UK').valid).toBe(false);
+  });
+
+  it('should validate UK postal codes with an optional correctly placed space separator', () => {
+    const validPostcodes = [
+      'SW1A 1AA',
+      'SW1A1AA',
+      'M1 1AE',
+      'M11AE',
+      'CR2 6XH',
+      'DN55 1PT',
+    ];
+
+    validPostcodes.forEach((postcode) => {
+      expect(engine.validatePostalCode(postcode, 'UK').valid).toBe(true);
+    });
+
+    const invalidPostcodes = ['SW1 A1AA', 'SW1A  1AA', 'DN551 PT', '12345'];
+
+    invalidPostcodes.forEach((postcode) => {
+      expect(engine.validatePostalCode(postcode, 'UK').valid).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
# 📋 Summary
Investigated #7571, which claimed the UK postal code regex fails to correctly handle the space separator in postcodes like "SW1A 1AA". I verified this against the exact regex currently in `js/pincode-validation-engine.js` and found it already validates all the cited examples correctly — the reported bug does not reproduce.

Since a proposed regex fix would have been functionally identical to the existing pattern (just different syntax for the same optional-space logic), I did not make a behavior change. Instead, this PR adds regression tests to lock in the correct existing behavior and prevent future regressions.

---
## 🔗 Related Issue
Related to #7571 (does not change behavior — see comment on the issue)

---
## 🛠️ What Was Changed
- Added regression tests in `tests/unit/pincode-validation-engine.test.js` verifying the UK postal pattern correctly validates multiple valid formats (with and without space): `SW1A 1AA`, `SW1A1AA`, `M1 1AE`, `M11AE`, `CR2 6XH`, `DN55 1PT`
- Added invalid-format test cases to confirm malformed postcodes are still correctly rejected

---
## why this needed
- The existing regex was untested for this specific case, even though it was already correct
- Adds regression coverage so future changes to this pattern don't silently break UK postcode validation

---
## 🧪 How Has This Been Tested?
- [x] Ran `npx vitest run tests/unit/pincode-validation-engine.test.js` — all 9 tests pass
- [x] Ran `npm run lint` on changed files — no new issues

---
## ✅ Self-Review Checklist
- [x] My branch name follows the convention (`fix/`)
- [x] My commit messages follow the convention (`test:`)
- [x] I have linked the related issue
- [x] I have tested my changes locally
- [ ] I have added screenshots for UI changes
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue

---
## 📋 Additional Notes
No regex/behavior change was made — see comment on issue #7571 explaining why the reported bug does not reproduce against the current pattern.