### PR TITLE
fix(backend): add required request param to @limiter.limit-decorated handlers (#7782)

### DIFF
--- a/backend/app/api/inventory_lock.py
+++ b/backend/app/api/inventory_lock.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy.orm import Session
 from sqlalchemy import func
 from pydantic import BaseModel, Field
@@ -22,6 +22,7 @@ class ReleaseInventoryRequest(BaseModel):
 @router.post("/reserve")
 @limiter.limit("30/minute")
 def reserve_inventory(
+    request: Request,
     payload: ReserveInventoryRequest,
     db: Session = Depends(get_db)
 ):

--- a/backend/app/api/receipts.py
+++ b/backend/app/api/receipts.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy.orm import Session
 import hmac
 import hashlib
@@ -17,7 +17,7 @@ def generate_receipt_signature(order: models.Order) -> str:
 
 @router.get("/{order_id}/receipt")
 @limiter.limit("20/minute")
-def get_digital_receipt(order_id: int, db: Session = Depends(get_db)):
+def get_digital_receipt(request: Request, order_id: int, db: Session = Depends(get_db)):
     order = db.query(models.Order).filter(models.Order.id == order_id).first()
     if not order:
         raise HTTPException(status_code=404, detail="Order not found")

--- a/backend/tests/test_limiter_request_param.py
+++ b/backend/tests/test_limiter_request_param.py
@@ -1,0 +1,38 @@
+"""Regression tests for issue #7782.
+
+slowapi's `@limiter.limit(...)` decorator inspects the wrapped function's
+signature and requires a `request` (or `websocket`) parameter to key the
+rate limit. Two handlers — `receipts.get_digital_receipt` and
+`inventory_lock.reserve_inventory` — were decorated without that parameter,
+so slowapi raised `Exception: No "request" or "websocket" argument on
+function "<...>"` at import time. Because `app.main` imports both routers,
+this prevented the FastAPI app from importing entirely.
+"""
+
+import inspect
+
+
+def test_receipts_module_imports():
+    import app.api.receipts as receipts  # noqa: F401
+
+    sig = inspect.signature(receipts.get_digital_receipt)
+    assert "request" in sig.parameters, (
+        "get_digital_receipt must declare a `request` parameter for @limiter.limit"
+    )
+
+
+def test_inventory_lock_module_imports():
+    import app.api.inventory_lock as inventory_lock  # noqa: F401
+
+    sig = inspect.signature(inventory_lock.reserve_inventory)
+    assert "request" in sig.parameters, (
+        "reserve_inventory must declare a `request` parameter for @limiter.limit"
+    )
+
+
+def test_app_imports_cleanly():
+    # A slowapi import-time exception anywhere in the router package surfaces
+    # here; before the fix this raised instead of returning the app.
+    from app.main import app
+
+    assert app is not None


### PR DESCRIPTION
> _This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._

## Fixes #7782

## Summary
Two route handlers were decorated with `@limiter.limit(...)` (slowapi) but did not declare a `request: Request` parameter, which slowapi requires to key the rate limit. At import time slowapi raised:

```
Exception: No "request" or "websocket" argument on function "<...>"
```

Because `app/main.py` imports both routers unconditionally, this prevented the FastAPI app from importing — blocking all e2e auth endpoints and the test suite (same boot-failure class as #7780, different root cause).

## Changes
- `backend/app/api/receipts.py`: add `Request` import and `request: Request` to `get_digital_receipt`.
- `backend/app/api/inventory_lock.py`: add `Request` import and `request: Request` to `reserve_inventory`.

Both now follow the same pattern already used in `auth.py`, `orders.py`, and `recommendation.py`.

## Verification
Added `backend/tests/test_limiter_request_param.py` which asserts:
- `app.api.receipts` and `app.api.inventory_lock` import cleanly,
- `get_digital_receipt` and `reserve_inventory` declare a `request` parameter,
- `app.main` imports without raising.

With this fix (together with #7781) `python -c "from app.main import app"` succeeds and the e2e auth tests (`test_auth.py`, `test_refresh_logout.py`) run green.

## Notes
- Scoped to the two handlers described in #7782. No new dependencies.