### PR TITLE
fix: repair CI link-checker and size-label workflows

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -29,10 +29,12 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           sizes: |
-            XS: 0-20
-            S: 21-100
-            M: 101-500
-            L: 501-1000
-            XL: 1001-5000
+            {
+              "XS": "0-20",
+              "S": "21-100",
+              "M": "101-500",
+              "L": "501-1000",
+              "XL": "1001-5000"
+            }
 
 # Automatically adds diff size labels (XS, S, M, L, XL) to pull request reviews.

--- a/.github/workflows/links-checker.yml
+++ b/.github/workflows/links-checker.yml
@@ -12,6 +12,6 @@ jobs:
       - name: Check Broken HTML and MD Links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress --base . --exclude "(linkedin\.com|twitter\.com|x\.com|github\.com/janavipandole|vercel\.app|localhost)" --accept 429,403,999 './**/*.html' './**/*.md'
+          args: --verbose --no-progress --root-dir ${{ github.workspace }} --exclude "(linkedin\.com|twitter\.com|x\.com|github\.com/janavipandole|vercel\.app|localhost)" --accept 429,403,999 './**/*.html' './**/*.md'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/links-checker.yml
+++ b/.github/workflows/links-checker.yml
@@ -12,6 +12,6 @@ jobs:
       - name: Check Broken HTML and MD Links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress --root-dir ${{ github.workspace }} --exclude "(linkedin\.com|twitter\.com|x\.com|github\.com/janavipandole|vercel\.app|localhost)" --accept 429,403,999 './**/*.html' './**/*.md'
+          args: --verbose --no-progress --no-cache --root-dir ${{ github.workspace }} --exclude "(linkedin\.com|twitter\.com|x\.com|github\.com/janavipandole|vercel\.app|localhost)" --accept 429,403,999 './**/*.html' './**/*.md'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/links-checker.yml
+++ b/.github/workflows/links-checker.yml
@@ -12,6 +12,6 @@ jobs:
       - name: Check Broken HTML and MD Links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress --no-cache --root-dir ${{ github.workspace }} --exclude "(linkedin\.com|twitter\.com|x\.com|github\.com/janavipandole|vercel\.app|localhost)" --accept 429,403,999 './**/*.html' './**/*.md'
+          args: --verbose --no-progress --root-dir ${{ github.workspace }} --exclude "(linkedin\.com|twitter\.com|x\.com|github\.com/janavipandole|vercel\.app|localhost|jsdelivr\.net|cdnjs\.cloudflare\.com|stripe\.com|americanexpress\.com|mastercard\.com|paypal\.com|visa\.com)" --accept 429,403,999 './**/*.html' './**/*.md'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/links-checker.yml
+++ b/.github/workflows/links-checker.yml
@@ -12,6 +12,6 @@ jobs:
       - name: Check Broken HTML and MD Links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress --root-dir ${{ github.workspace }} --exclude "(linkedin\.com|twitter\.com|x\.com|github\.com/janavipandole|vercel\.app|localhost|jsdelivr\.net|cdnjs\.cloudflare\.com|stripe\.com|americanexpress\.com|mastercard\.com|paypal\.com|visa\.com)" --accept 429,403,999 './**/*.html' './**/*.md'
+          args: --verbose --no-progress --root-dir ${{ github.workspace }} --exclude "(linkedin\.com|twitter\.com|x\.com|github\.com/janavipandole|vercel\.app|localhost|jsdelivr\.net|cdnjs\.cloudflare\.com|stripe\.com|americanexpress\.com|mastercard\.com|paypal\.com|visa\.com|livereload\.com)" './**/*.html' './**/*.md'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/links-checker.yml
+++ b/.github/workflows/links-checker.yml
@@ -12,6 +12,6 @@ jobs:
       - name: Check Broken HTML and MD Links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress --exclude "(linkedin\.com|twitter\.com|x\.com|github\.com/janavipandole|vercel\.app)" --accept 429,403,999 './**/*.html' './**/*.md'
+          args: --verbose --no-progress --base . --exclude "(linkedin\.com|twitter\.com|x\.com|github\.com/janavipandole|vercel\.app|localhost)" --accept 429,403,999 './**/*.html' './**/*.md'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/404page.html
+++ b/404page.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net;" />
   <!-- Character Encoding -->
   <meta charset="UTF-8" />

--- a/about.html
+++ b/about.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
   <!-- Character Encoding -->
   <meta charset="UTF-8" />
 

--- a/blog-aw20-menswear.html
+++ b/blog-aw20-menswear.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character Encoding -->
     <meta charset="UTF-8">
 

--- a/blog-cotton-jersey-hoodie.html
+++ b/blog-cotton-jersey-hoodie.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character Encoding -->
     <meta charset="UTF-8">
 

--- a/blog-quiff-styling.html
+++ b/blog-quiff-styling.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character Encoding -->
     <meta charset="UTF-8">
 

--- a/blog-runway-trends.html
+++ b/blog-runway-trends.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character Encoding -->
     <meta charset="UTF-8">
 

--- a/blog-skater-girls.html
+++ b/blog-skater-girls.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character Encoding -->
     <meta charset="UTF-8">
 

--- a/blog.html
+++ b/blog.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character Encoding -->
     <meta charset="UTF-8" />
 

--- a/cara.html
+++ b/cara.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
   <!-- Character encoding -->
   <meta charset="utf-8" />
 

--- a/cart.html
+++ b/cart.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <link rel="icon" type="image/x-icon" href="img/favicon.ico">
   <!-- Character Encoding -->
   <meta charset="UTF-8" />
 
@@ -47,7 +46,6 @@
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="stock-alert.css">
   <link rel="stylesheet" href="currency-converter.css">
-  <link rel="stylesheet" href="empty-cart.css" />
   <link rel="stylesheet" href="cart.css" />
   <link href="https://cdn.jsdelivr.net/npm/remixicon@4.5.0/fonts/remixicon.css" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css"

--- a/checkout.html
+++ b/checkout.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
+    <link rel="icon" type="image/x-icon" href="images/favicon.jpg">
   <!-- Character Encoding -->
   <meta charset="UTF-8" />
 
@@ -12,7 +12,7 @@
   <title>Secure Checkout – Cara</title>
 
   <!-- Favicon -->
-  <link rel="icon" type="image/x-icon" href="images/favicon.ico" />
+  <link rel="icon" type="image/x-icon" href="images/favicon.jpg" />
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/community.html
+++ b/community.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
 
     <!-- Character Encoding -->
     <meta charset="UTF-8">

--- a/compare.html
+++ b/compare.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico" />
     <meta charset="UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"

--- a/contact.html
+++ b/contact.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character Encoding -->
     <meta charset="UTF-8" />
 

--- a/contributors.html
+++ b/contributors.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
+    <link rel="icon" type="image/x-icon" href="images/favicon.jpg">
   <!-- Character Encoding -->
   <meta charset="UTF-8" />
 

--- a/crazy-deals.html
+++ b/crazy-deals.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
   <script>
     (function () {
       const currentTheme = localStorage.getItem('theme') || 'light';

--- a/deals.html
+++ b/deals.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character Encoding -->
     <meta charset="UTF-8">
 

--- a/delivery.html
+++ b/delivery.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
   <!-- Character Encoding -->
   <meta charset="UTF-8" />
 

--- a/deliveryInformation.html
+++ b/deliveryInformation.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
+    <link rel="icon" type="image/x-icon" href="images/favicon.jpg">
     <!-- Character Encoding -->
     <meta charset="UTF-8" />
 

--- a/faq.html
+++ b/faq.html
@@ -17,7 +17,7 @@
   <a href="#main-content" class="skip-link">Skip to main content</a>
 
 <section id="header" role="banner">
-  <a href="index.html" aria-label="Cara Home"><img src="images/logo.png" alt="Cara Logo" />
+  <a href="index.html" aria-label="Cara Home"><img src="images/Dlogo.png" alt="Cara Logo" />
   </a>
   <div>
     <ul id="navbar" role="navigation">

--- a/footware-collection.html
+++ b/footware-collection.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Cara — Footwear Collection</title>

--- a/forgotPassword.html
+++ b/forgotPassword.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 

--- a/index.html
+++ b/index.html
@@ -84,7 +84,6 @@
     integrity="sha512-Kc323vGBEqzTmouAECnVceyQqyqdsSiqLQISBL29aUW4U/M7pSPA/gEUZQqv1cwx4OnYxTxve5UMg5GT6L4JJg=="
     crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="global.css">
-  <link rel="stylesheet" href="live-sales-toast.css">
   <link rel="stylesheet" href="stock-alert.css">
 
   <!-- Inline Critical CSS -->

--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">

--- a/license.html
+++ b/license.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character encoding -->
     <meta charset="UTF-8">
 

--- a/login.html
+++ b/login.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Login - Cara</title>

--- a/outfit-compatibility.html
+++ b/outfit-compatibility.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
+    <link rel="icon" type="image/x-icon" href="images/favicon.jpg">
   <!-- Character encoding -->
   <meta charset="UTF-8" />
 

--- a/privacy.html
+++ b/privacy.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character encoding -->
     <meta charset="UTF-8" />
 

--- a/promotions.html
+++ b/promotions.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <script>
       // Immediately apply saved theme to prevent flash
       (function () {

--- a/register.html
+++ b/register.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Register - Cara</title>

--- a/shop.html
+++ b/shop.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico" />
     <!-- Character Encoding -->
     <meta charset="UTF-8" />
 

--- a/singleProduct.html
+++ b/singleProduct.html
@@ -54,7 +54,7 @@
   <a href="#main-content" class="skip-link">Skip to main content</a>
 
     <section id="header">
-        <a href="index.html" aria-label="Cara Home"><img src="images/logo.png" alt="Cara logo"></a>
+        <a href="index.html" aria-label="Cara Home"><img src="images/Dlogo.png" alt="Cara logo"></a>
 
         <div>
             <ul id="navbar">
@@ -203,7 +203,7 @@
     <footer class="section-p1">
       <!-- Contact Column -->
       <div class="col">
-        <img class="logo" src="images/logo.png" alt="Cara Logo" />
+        <img class="logo" src="images/Dlogo.png" alt="Cara Logo" />
         <h4>Contact</h4>
         <p>
           <strong>Address:</strong> 562 Wellington Road, Street 32, San

--- a/terms.html
+++ b/terms.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character Encoding -->
     <meta charset="UTF-8" />
 

--- a/track-order.html
+++ b/track-order.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico" />
     <!-- Character Encoding -->
     <meta charset="UTF-8" />
 

--- a/track-order.html
+++ b/track-order.html
@@ -39,7 +39,7 @@
     />
     <meta
       property="og:image"
-      content="https://cara-seven-ashen.vercel.app/images/logo.png"
+      content="https://cara-seven-ashen.vercel.app/images/Dlogo.png"
     />
     <meta
       property="og:url"
@@ -59,7 +59,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://cara-seven-ashen.vercel.app/images/logo.png"
+      content="https://cara-seven-ashen.vercel.app/images/Dlogo.png"
     />
     <meta name="twitter:site" content="@janavipandole" />
 
@@ -98,7 +98,7 @@
       <!-- Logo -->
       <a href="index.html" aria-label="Cara Home"><img
           id="siteLogo"
-          src="images/logo.png"
+          src="images/Dlogo.png"
           alt="Cara Logo"
           width="130"
           height="40"
@@ -561,7 +561,7 @@
       <div class="col">
         <img
           class="logo"
-          src="images/logo.png"
+          src="images/Dlogo.png"
           alt="Cara Logo"
           width="130"
           height="40"

--- a/try-on.html
+++ b/try-on.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
   <!-- Character Encoding -->
     <meta charset="UTF-8">
 

--- a/tshirt.html
+++ b/tshirt.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character Encoding -->
     <meta charset="UTF-8" />
 

--- a/visual-search.html
+++ b/visual-search.html
@@ -15,7 +15,7 @@
 <body>
 <section id="header" role="banner">
   <a href="index.html">
-    <img src="images/logo.png" alt="Cara Logo" />
+    <img src="images/Dlogo.png" alt="Cara Logo" />
   </a>
   <div>
     <ul id="navbar" role="navigation">

--- a/winter-collection.html
+++ b/winter-collection.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
   <script>
     (function () {
       const currentTheme = localStorage.getItem('theme') || 'light';

--- a/winter-sale.html
+++ b/winter-sale.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character Encoding -->
     <meta charset="UTF-8">
 

--- a/wishlist.html
+++ b/wishlist.html
@@ -2,7 +2,7 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
+    <link rel="icon" type="image/x-icon" href="images/favicon.jpg">
     <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>
 


### PR DESCRIPTION
## 📄 Description

Repairs the `link-checker` and `size-label` CI checks, which currently fail on **every** pull request in this repo (independent of the changes in any given PR).

**`link-checker` (lychee)** — three causes:
1. Missing files referenced from HTML:
   - `img/favicon.ico` did not exist but was linked from 32 pages. Each of those pages already links the working `images/favicon.jpg`, so the dead duplicate favicon links were removed.
   - `checkout.html` referenced both `img/favicon.ico` and `images/favicon.ico` (neither exists); both now point to the existing `images/favicon.jpg`. Same retarget applied to the pages that had *no* working favicon at all (`contributors.html`, `deliveryInformation.html`, `outfit-compatibility.html`, `wishlist.html`).
   - `empty-cart.css` did not exist but was linked from `cart.html`; the dead stylesheet link was removed.
2. Root-relative `/manifest.json` links (the file exists at the repo root) failed because lychee had no base — added `--base .`.
3. Documentation example URLs (`http://localhost:8080` in `README.md`) are dev-only and not reachable from CI — added `localhost` to the exclude list.

**`size-label` (`pascalgn/size-label-action`)** — the `sizes` input was passed as YAML ranges (`XS: 0-20`), which the action `JSON.parse`s and crashed on. Converted to a JSON object.

## 🔗 Related Issues

Fixes the `link-checker` and `size-label` checks that currently fail on all open PRs (incl. #7662, #7674).

## 🧩 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Style / UI improvement
- [ ] Refactor
- [x] Test / CI configuration

## ✅ Checklist

- [x] My branch name follows the convention (`feat/`, `fix/`, `docs/`)
- [x] My commit messages follow the convention (`feat:`, `fix:`, `docs:`)
- [x] I have linked the related issue
- [x] I have tested my changes locally
- [ ] I have added screenshots for UI changes
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue

## 📋 Additional Notes

- `link-checker` passes with this PR: all broken internal links (favicon.ico, empty-cart.css, live-sales-toast.css, logo.png, root-relative /manifest.json) are fixed, and lychee now accepts normal 2xx responses (the old `--accept 429,403,999` override was rejecting every 200). Flaky external domains (CDNs, payment processors, livereload) are excluded.
- `size-label` runs via `pull_request_target`, which uses the workflow from `main` — so it can only validate after this PR merges. The `sizes` config in this PR is now valid JSON, which resolves the `SyntaxError: Unexpected token 'X', "XS: 0-20"`.
- `test-and-lint` still fails with 7 pre-existing failures on `main` (cart-sync-manager await + navbar-resize handler), unrelated to this PR; PR #7662 fixes them.