### PR TITLE
fix(store): debounce persist() to reduce localStorage write churn (#7569)

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -7,7 +7,8 @@ class Store {
   constructor(initialState = {}, storageKey = 'app_state') {
     this.storageKey = storageKey;
     this.listeners = [];
-    
+    this._persistTimer = null;
+
     let savedState = {};
     try {
       savedState = JSON.parse(localStorage.getItem(this.storageKey)) || {};
@@ -23,10 +24,16 @@ class Store {
       set(target, property, value) {
         target[property] = value;
         self.notifyListeners(property, value);
-        self.persist();
+        self.schedulePersist();
         return true;
       }
     });
+
+    // Flush any pending debounced write before the page unloads so the latest
+    // state is not lost.
+    if (typeof window !== 'undefined') {
+      window.addEventListener('pagehide', () => this.flushPersist());
+    }
   }
 
   subscribe(listener) {
@@ -42,6 +49,25 @@ class Store {
 
   persist() {
     localStorage.setItem(this.storageKey, JSON.stringify(this.state));
+  }
+
+  // Debounce localStorage writes so rapid successive state changes coalesce into
+  // a single setItem call instead of one per Proxy set trap (#7569).
+  schedulePersist(delay = 300) {
+    if (this._persistTimer !== null) clearTimeout(this._persistTimer);
+    this._persistTimer = setTimeout(() => {
+      this._persistTimer = null;
+      this.persist();
+    }, delay);
+  }
+
+  // Flush a pending debounced write immediately (used on pagehide).
+  flushPersist() {
+    if (this._persistTimer !== null) {
+      clearTimeout(this._persistTimer);
+      this._persistTimer = null;
+      this.persist();
+    }
   }
 }
 


### PR DESCRIPTION
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._

## What
Fixes #7569 — `js/store.js` calls `localStorage.setItem()` synchronously on every Proxy `set` trap, causing excessive writes during rapid state updates.

## Root cause
The `Store` Proxy `set` trap calls `self.persist()` (which runs `localStorage.setItem(this.storageKey, JSON.stringify(this.state))`) on every single state mutation. On pages with frequent state updates this causes redundant synchronous `localStorage` writes.

## Fix
- Add `schedulePersist(delay = 300)` which debounces the write so successive state changes coalesce into a single `setItem` call.
- The Proxy `set` trap now calls `schedulePersist()` instead of `persist()` directly.
- Add `flushPersist()` and register a one-time `pagehide` listener in the constructor that flushes any pending debounced write, so the latest state is not lost if the page unloads within the debounce window.
- `persist()` is left intact so direct callers/tests that expect a synchronous write are unaffected.

## Verification
- `node --check js/store.js` passes (valid syntax).
- The existing `tests/unit/store.test.js` replicates the `Store` class inline (it does not import `js/store.js`), so this change does not affect those tests.

## Notes on CI
I will monitor CI once it runs; if any checks fail due to pre-existing repo infrastructure I will note it here.