### PR TITLE
fix(checkout-timer): use crypto.randomUUID for inventory hold session id (#7567)

### DIFF
--- a/js/checkout-timer.js
+++ b/js/checkout-timer.js
@@ -18,7 +18,11 @@ document.addEventListener('DOMContentLoaded', async () => {
   try {
     const apiBaseUrl = window.CARA_API_BASE_URL || '';
     const fetchFunc = typeof window.fetchWithTimeout === 'function' ? window.fetchWithTimeout : fetch;
-    const sessionId = 'session_' + Math.random().toString(36).substring(2, 9);
+    const sessionId =
+      'session_' +
+      (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+        ? crypto.randomUUID()
+        : Math.random().toString(36).substring(2, 9));
 
     await fetchFunc(`${apiBaseUrl}/api/inventory/reserve`, {
       method: 'POST',


### PR DESCRIPTION
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._

## What
Fixes #7567 — `js/checkout-timer.js` generates the inventory hold `session_id` with `Math.random()`, which is not cryptographically random.

## Root cause
Line 21 generated `sessionId = 'session_' + Math.random().toString(36).substring(2, 9)`. `Math.random()` is not cryptographically secure, so the reservation session id could theoretically be predicted in adversarial conditions.

## Fix
Prefer `crypto.randomUUID()` (available in all modern browsers and secure contexts), falling back to the previous `Math.random()` scheme when `crypto.randomUUID` is unavailable (older browsers / insecure context).

## Verification
- `node --check js/checkout-timer.js` passes (valid syntax).