### PR TITLE
fix(gift-options): merge duplicate gift message input listeners (#7568)

### DIFF
--- a/js/gift-options.js
+++ b/js/gift-options.js
@@ -43,12 +43,10 @@ document.addEventListener('DOMContentLoaded', () => {
     counter.style.cssText = 'font-size:11px; color:#888; display:block; text-align:right;';
     counter.textContent = `0/${MAX_GIFT_MSG_LENGTH}`;
     giftMsgInput.parentNode.appendChild(counter);
-    giftMsgInput.addEventListener('input', function() {
+    // Single 'input' handler updates the counter and runs validation together,
+    // replacing the two separate listeners that previously fired on each keystroke.
+    giftMsgInput.addEventListener('input', function () {
       counter.textContent = `${giftMsgInput.value.length}/${MAX_GIFT_MSG_LENGTH}`;
-    });
-  }
-  if (giftMsgInput) {
-    giftMsgInput.addEventListener('input', () => {
       const valid = validateGiftMessageLength(giftMsgInput.value, MAX_GIFT_MSG_LENGTH);
       if (!valid) {
         giftMsgInput.setCustomValidity(`Gift message exceeds the ${MAX_GIFT_MSG_LENGTH}-character limit.`);


### PR DESCRIPTION
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._

## What
Fixes #7568 — `js/gift-options.js` registered two separate `input` event listeners on the gift message textarea.

## Root cause
The gift message textarea had one `input` listener updating the character counter and a second `input` listener running length validation. Both fired on every keystroke, with the counter updating before validation ran — redundant and confusing.

## Fix
Merge the two listeners into a single `input` handler that updates the counter and then validates. Behavior (counter + custom validity) is unchanged.

## Verification
- `node --check js/gift-options.js` passes.