### PR TITLE
fix(admin-analytics): make _fmtRev currency symbol configurable (#7566)

### DIFF
--- a/js/admin-analytics.js
+++ b/js/admin-analytics.js
@@ -33,7 +33,12 @@
 
   function _fmtRev(val) {
     const num = parseFloat(val);
-    return '₹' + _numberFormat(num, 2, 3);
+    const symbol =
+      (typeof window !== 'undefined' &&
+        window.CARA_CONFIG &&
+        window.CARA_CONFIG.CURRENCY_SYMBOL) ||
+      '₹';
+    return symbol + _numberFormat(num, 2, 3);
   }
 
   function _escape(str) {


### PR DESCRIPTION
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._

## What
Fixes #7566 — `js/admin-analytics.js` `_fmtRev()` hardcodes the Indian Rupee symbol (₹), making the analytics dashboard non-portable.

## Root cause
`_fmtRev()` returned `'₹' + _numberFormat(num, 2, 3)`, so every revenue figure is prefixed with ₹ regardless of deployment locale.

## Fix
Read the currency symbol from `window.CARA_CONFIG.CURRENCY_SYMBOL` when present (the shared config object already exists in `js/config.js`), falling back to `₹` for backward compatibility.

## Verification
- `node --check js/admin-analytics.js` passes.