### PR TITLE
fix(admin-analytics): re-query dashboard containers inside initDashboard (#7380)

### DIFF
--- a/js/admin-analytics.js
+++ b/js/admin-analytics.js
@@ -154,8 +154,15 @@
 
   // ── Initialise ─────────────────────────────────────────────────────────────
   function initDashboard() {
-    // Only load if dashboard components exist on page
-    if (revEl || catTable || statusWrap) {
+    // Re-query the dashboard containers here rather than relying on the
+    // module-level refs, which are captured at script load time and may still
+    // be null when the script runs during initial parsing (before the DOM is
+    // ready). Only load if a dashboard container actually exists on the page.
+    if (
+      document.getElementById('analyticsRevenue') ||
+      document.getElementById('analyticsCategoryTable') ||
+      document.getElementById('analyticsStatusWrap')
+    ) {
       loadDashboard();
     }
   }


### PR DESCRIPTION
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._

## What
Fixes #7380 — `js/admin-analytics.js` `initDashboard()` checks module-level refs that are stale (captured before the DOM is ready), so `loadDashboard()` is never called.

## Root cause
`revEl`, `catTable`, and `statusWrap` are assigned once at the top of the module (`getElementById` at script load time). `initDashboard()` is called both immediately (line 166, during initial parsing — before the DOM is ready) and on `DOMContentLoaded`. Because those module-level refs are `null` when captured early and are never re-queried, the `if (revEl || catTable || statusWrap)` guard is false on every invocation, so the dashboard never loads.

## Fix
Re-query the containers inside `initDashboard()` (via `document.getElementById(...)`) so the guard reflects the current DOM, matching the issue's suggested fix.

## Verification
- `node --check js/admin-analytics.js` passes.