### PR TITLE
fix(ar-product-viewer): log error in relList feature-detection catch (#7564)

### DIFF
--- a/js/ar-product-viewer.js
+++ b/js/ar-product-viewer.js
@@ -31,7 +31,8 @@
         try {
           const a = document.createElement('a');
           return a.relList && a.relList.supports && a.relList.supports('ar');
-        } catch {
+        } catch (err) {
+          console.warn('[AR Viewer] relList AR support check failed:', err);
           return false;
         }
       })();


### PR DESCRIPTION
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._

## What
Fixes #7564 — `js/ar-product-viewer.js` `isARSupported()` uses a bare `catch {}` that silently swallows feature-detection errors.

## Root cause
The iOS AR detection IIFE wraps `document.createElement('a').relList.supports('ar')` in `try { ... } catch { return false; }`. A bare catch hides any unexpected error and provides no debugging signal.

## Fix
Replace the bare `catch` with `catch (err)` that logs the failure via `console.warn('[AR Viewer] relList AR support check failed:', err)` and still returns `false` (AR unsupported), so behavior is unchanged apart from the added diagnostic.

## Verification
- `node --check js/ar-product-viewer.js` passes.