### PR TITLE
fix(security): add frame protection headers to nginx for static pages (#7560)

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -4,6 +4,13 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Frame protection: prevent the static shop pages from being embedded in
+    # <iframe>/(frameset) by another origin (UI redressing / clickjacking). The
+    # FastAPI backend already sets X-Frame-Options: DENY for /api/* responses;
+    # these headers cover the static HTML pages served by nginx (#7560).
+    add_header X-Frame-Options "DENY" always;
+    add_header Content-Security-Policy "frame-ancestors 'none'" always;
+
     # SPA-ish static site: serve files directly
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._

## What
Fixes #7560 — the static shop pages lack frame protection and can be embedded in an iframe by a malicious origin (UI redressing / clickjacking).

## Root cause
The FastAPI backend already sets `X-Frame-Options: DENY` on `/api/*` responses (`backend/app/main.py`), but `nginx.conf` (which serves the static HTML pages) sends no frame-protection headers. A malicious page can therefore embed `index.html`/product pages in an `<iframe>` and overlay invisible UI to trick the user — the classic clickjacking attack.

## Fix
Add to the `nginx` server block:
- `add_header X-Frame-Options "DENY" always;`
- `add_header Content-Security-Policy "frame-ancestors 'none'" always;`

`always` ensures the headers are sent on error responses too. These cover all static pages (and the API responses are already covered by the backend). `frame-ancestors 'none'` is the CSP-level successor that modern browsers honor; `X-Frame-Options: DENY` covers legacy browsers.

## Verification
- Verified the two `add_header` directives are present and well-formed.
- The directives are placed at the `server` level so they apply to every location that does not define its own `add_header` (none of the existing locations do).