### PR TITLE
fix(ci): repair PR triage size-label JSON parsing and welcome bot permissions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -28,11 +28,6 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
-          sizes: |
-            XS: 0-20
-            S: 21-100
-            M: 101-500
-            L: 501-1000
-            XL: 1001-5000
+          sizes: '{"0":"XS","21":"S","101":"M","501":"L","1001":"XL"}'
 
 # Automatically adds diff size labels (XS, S, M, L, XL) to pull request reviews.

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   welcome:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
     steps:
       - name: Welcome new contributor
         uses: actions/github-script@v7


### PR DESCRIPTION
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._

## Why
Two repo-level GitHub Actions fail on **every** PR (not just mine), so no PR can show all-green checks.

### 1. `PR Triage Workflows/size-label` — SyntaxError
Fails with:
```
SyntaxError: Unexpected token 'X', "XS: 0-20\nS"... is not valid JSON
    at JSON.parse (<anonymous>)
    at getSizesInput (.../size-label-action/v0.4.3/dist/index.js)
```
`pascalgn/size-label-action@v0.4.3` expects the `sizes` input as a **JSON object** mapping a line-count threshold to a label (per the action README, e.g. `{"0":"XS","10":"S",...}`), but `.github/workflows/labeler.yml` passes a YAML-style multiline range string (`XS: 0-20` ...). `JSON.parse` then throws on the literal `X`.

**Fix:** supply the same thresholds as JSON: `{"0":"XS","21":"S","101":"M","501":"L","1001":"XL"}` (matching the original ranges 0–20 / 21–100 / 101–500 / 501–1000 / 1001–5000).

> Note: this removes the parse error. For the job to add labels end-to-end, the labels `XS`, `S`, `M`, `L`, `XL` must exist in the repo (the action does not create them — see its README "Create the needed labels"). None currently exist, so a maintainer should create them; otherwise the action will 422 on label-add. That label-creation step requires maintainer access, so it's out of scope for this PR.

### 2. `Standard Welcome Bot/welcome` — 403
Fails with:
```
HttpError: Resource not accessible by integration (status: 403)
x-accepted-github-permissions: issues=write; pull_requests=write
```
The `welcome` job has **no `permissions:` block**, so the `GITHUB_TOKEN` defaults are read-only and `issues.createComment` is rejected.

**Fix:** add explicit `permissions: { pull-requests: write, issues: write }` to the job, matching what the endpoint requires.

## Scope
- `.github/workflows/labeler.yml`: `sizes` input → JSON object string (same thresholds).
- `.github/workflows/welcome.yml`: add `permissions` to the `welcome` job.

Both are `pull_request_target` workflows; changes are benign (a string format + explicit permissions) and introduce no new secret exposure.