### PR TITLE
fix: add missing live-sales-toast.css for sales notification toast

### DIFF
--- a/live-sales-toast.css
+++ b/live-sales-toast.css
@@ -1,0 +1,153 @@
+/* live-sales-toast.css
+ * Styles for the social-proof "live sales" toast rendered by js/live-sales-toast.js.
+ * The toast slides in from the bottom-left of the viewport, shows a recent purchase
+ * (buyer + city + product + thumbnail), auto-dismisses after a few seconds, pauses
+ * on hover, and is fully disabled when the user prefers reduced motion.
+ */
+
+#live-sales-container {
+  position: fixed;
+  bottom: 1.25rem;
+  left: 1.25rem;
+  z-index: 1080;
+  pointer-events: none;
+  max-width: calc(100vw - 2.5rem);
+}
+
+.live-sales-toast {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 320px;
+  max-width: 100%;
+  padding: 0.75rem 1rem;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.625rem;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.12);
+  pointer-events: auto;
+  opacity: 0;
+  transform: translateY(1rem);
+  transition:
+    opacity 0.35s ease,
+    transform 0.35s ease;
+  font-family: inherit;
+  color: #111827;
+}
+
+/* Slide-in / slide-out states driven by js/live-sales-toast.js */
+.live-sales-toast.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.live-sales-toast.hide {
+  opacity: 0;
+  transform: translateY(1rem);
+}
+
+/* Thumbnail */
+.live-sales-img-wrapper {
+  flex: 0 0 auto;
+  width: 44px;
+  height: 44px;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  background: #f3f4f6;
+}
+
+.live-sales-img-wrapper img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+/* Text column */
+.live-sales-details {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.live-sales-title {
+  margin: 0 0 0.125rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #6b7280;
+}
+
+.live-sales-message {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.35;
+  color: #111827;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.live-sales-message .buyer,
+.live-sales-message .product {
+  font-weight: 600;
+  color: #088178;
+}
+
+.live-sales-time {
+  display: inline-block;
+  margin-top: 0.25rem;
+  font-size: 0.7rem;
+  color: #9ca3af;
+}
+
+/* Dismiss button */
+.live-sales-close {
+  flex: 0 0 auto;
+  align-self: flex-start;
+  width: 1.25rem;
+  height: 1.25rem;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: #9ca3af;
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: 0.25rem;
+  transition:
+    color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.live-sales-close:hover,
+.live-sales-close:focus-visible {
+  color: #4b5563;
+  background: #f3f4f6;
+  outline: none;
+}
+
+/* Compact screens */
+@media (max-width: 480px) {
+  #live-sales-container {
+    bottom: 0.75rem;
+    left: 0.75rem;
+    right: 0.75rem;
+  }
+
+  .live-sales-toast {
+    width: 100%;
+  }
+}
+
+/* Respect reduced-motion: keep the toast visible without animation */
+@media (prefers-reduced-motion: reduce) {
+  .live-sales-toast,
+  .live-sales-toast.show,
+  .live-sales-toast.hide {
+    transition: none;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## 📄 Description

`index.html` (line 86) references `live-sales-toast.css`, but that stylesheet did not exist anywhere in the repository. As a result, the social-proof "live sales" toast injected by `js/live-sales-toast.js` rendered with no styling (invisible) and every page load produced a `404` for `live-sales-toast.css` in the Network tab.

This PR adds the missing `live-sales-toast.css` file. The styles target exactly the classes/elements that `js/live-sales-toast.js` creates:

- `#live-sales-container` — fixed bottom-left viewport container
- `.live-sales-toast` with `.show` / `.hide` states (slide-in/out transitions driven by the JS)
- `.live-sales-img-wrapper` / thumbnail
- `.live-sales-details`, `.live-sales-title`, `.live-sales-message` (`.buyer`, `.product`), `.live-sales-time`
- `.live-sales-close` dismiss button (with `:focus-visible` and hover states)

Behaviour matches what the JS expects: the toast slides in from the bottom-left, pauses on hover, auto-dismisses, and the stylesheet disables transitions when the user prefers reduced motion (the JS already skips the cycle entirely for reduced-motion users). A responsive breakpoint keeps the toast readable on small screens.

## 🔗 Related Issues

Closes #7678

## 🧩 Type of Change

- [x] Bug fix

## ✅ Checklist

- [x] My branch name follows the convention (`fix/`)
- [x] My commit messages follow the convention (`fix:`)
- [x] I have linked the related issue (`Closes #7678`)
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue

---

_Note: This PR was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._
