### PR TITLE
fix: remove broken favicon link referencing non-existent img/ directory

### DIFF
--- a/404page.html
+++ b/404page.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net;" />
   <!-- Character Encoding -->
   <meta charset="UTF-8" />

--- a/about.html
+++ b/about.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
   <!-- Character Encoding -->
   <meta charset="UTF-8" />
 

--- a/blog-aw20-menswear.html
+++ b/blog-aw20-menswear.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character Encoding -->
     <meta charset="UTF-8">
 

--- a/blog-cotton-jersey-hoodie.html
+++ b/blog-cotton-jersey-hoodie.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character Encoding -->
     <meta charset="UTF-8">
 

--- a/blog-quiff-styling.html
+++ b/blog-quiff-styling.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character Encoding -->
     <meta charset="UTF-8">
 

--- a/blog-runway-trends.html
+++ b/blog-runway-trends.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character Encoding -->
     <meta charset="UTF-8">
 

--- a/blog-skater-girls.html
+++ b/blog-skater-girls.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character Encoding -->
     <meta charset="UTF-8">
 

--- a/blog.html
+++ b/blog.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character Encoding -->
     <meta charset="UTF-8" />
 

--- a/cara.html
+++ b/cara.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
   <!-- Character encoding -->
   <meta charset="utf-8" />
 

--- a/cart.html
+++ b/cart.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <link rel="icon" type="image/x-icon" href="img/favicon.ico">
   <!-- Character Encoding -->
   <meta charset="UTF-8" />
 

--- a/checkout.html
+++ b/checkout.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
   <!-- Character Encoding -->
   <meta charset="UTF-8" />
 

--- a/community.html
+++ b/community.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
 
     <!-- Character Encoding -->
     <meta charset="UTF-8">

--- a/compare.html
+++ b/compare.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico" />
     <meta charset="UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"

--- a/contact.html
+++ b/contact.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character Encoding -->
     <meta charset="UTF-8" />
 

--- a/contributors.html
+++ b/contributors.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
   <!-- Character Encoding -->
   <meta charset="UTF-8" />
 

--- a/crazy-deals.html
+++ b/crazy-deals.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
   <script>
     (function () {
       const currentTheme = localStorage.getItem('theme') || 'light';

--- a/deals.html
+++ b/deals.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character Encoding -->
     <meta charset="UTF-8">
 

--- a/delivery.html
+++ b/delivery.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
   <!-- Character Encoding -->
   <meta charset="UTF-8" />
 

--- a/deliveryInformation.html
+++ b/deliveryInformation.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character Encoding -->
     <meta charset="UTF-8" />
 

--- a/footware-collection.html
+++ b/footware-collection.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Cara — Footwear Collection</title>

--- a/forgotPassword.html
+++ b/forgotPassword.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 

--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">

--- a/license.html
+++ b/license.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character encoding -->
     <meta charset="UTF-8">
 

--- a/login.html
+++ b/login.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Login - Cara</title>

--- a/outfit-compatibility.html
+++ b/outfit-compatibility.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
   <!-- Character encoding -->
   <meta charset="UTF-8" />
 

--- a/privacy.html
+++ b/privacy.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character encoding -->
     <meta charset="UTF-8" />
 

--- a/promotions.html
+++ b/promotions.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <script>
       // Immediately apply saved theme to prevent flash
       (function () {

--- a/register.html
+++ b/register.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Register - Cara</title>

--- a/shop.html
+++ b/shop.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico" />
     <!-- Character Encoding -->
     <meta charset="UTF-8" />
 

--- a/terms.html
+++ b/terms.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character Encoding -->
     <meta charset="UTF-8" />
 

--- a/track-order.html
+++ b/track-order.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico" />
     <!-- Character Encoding -->
     <meta charset="UTF-8" />
 

--- a/try-on.html
+++ b/try-on.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
   <!-- Character Encoding -->
     <meta charset="UTF-8">
 

--- a/tshirt.html
+++ b/tshirt.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character Encoding -->
     <meta charset="UTF-8" />
 

--- a/winter-collection.html
+++ b/winter-collection.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
   <script>
     (function () {
       const currentTheme = localStorage.getItem('theme') || 'light';

--- a/winter-sale.html
+++ b/winter-sale.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <!-- Character Encoding -->
     <meta charset="UTF-8">
 

--- a/wishlist.html
+++ b/wishlist.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>
 


### PR DESCRIPTION
## 📄 Description

Every page in the site included a favicon `<link>` tag pointing at `img/favicon.ico`:

```html
<link rel="icon" type="image/x-icon" href="img/favicon.ico">
```

There is **no `img/` directory** anywhere in the repository (all image assets live under `images/`), so this tag always 404s on every page load. Each affected page also has a second, working favicon tag:

```html
<link rel="icon" type="image/jpg" sizes="32x32" href="images/favicon.jpg" />
```

This PR removes the broken `img/favicon.ico` reference from all 36 affected HTML pages, leaving a single correct favicon reference per page (the working `images/favicon.jpg` tag) — exactly as the issue requested. No functional/visual change for browsers that were already falling through to the working tag; this eliminates the guaranteed 404 request on every page load.

## 🔗 Related Issues

Closes #7676

## 🧩 Type of Change

- [x] Bug fix

## ✅ Checklist

- [x] My branch name follows the convention (`fix/`)
- [x] My commit messages follow the convention (`fix:`)
- [x] I have linked the related issue (`Closes #7676`)
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue

---

_Note: This PR was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._
