### PR TITLE
feat: add Share This Product button on product page

### DIFF
--- a/js/share-product.js
+++ b/js/share-product.js
@@ -4,7 +4,11 @@
     const btn = e.target.closest('[data-share-product]');
     if (!btn) return;
     const data = {
-      title: btn.getAttribute('data-share-title') || document.title,
+      title:
+        btn.getAttribute('data-share-title') ||
+        (document.getElementById('product-name') &&
+          document.getElementById('product-name').textContent.trim()) ||
+        document.title,
       text: btn.getAttribute('data-share-text') || '',
       url: btn.getAttribute('data-share-url') || location.href,
     };

--- a/singleProduct.html
+++ b/singleProduct.html
@@ -142,6 +142,9 @@
                 </div>
                 <button class="normal" onclick="handleAddToCart()">Add to Cart</button>
                 <button class="normal" style="background: var(--accent); color: white; margin-left: 10px;" onclick="window.location.href='try-on.html'">Try it On Virtually!</button>
+                <button type="button" class="normal share-product-btn" data-share-product data-share-text="Check out this product on Cara" aria-label="Share this product" title="Share this product">
+                    <i class="fa-solid fa-share-nodes" aria-hidden="true"></i> Share
+                </button>
             </div>
             <h4>Product Details</h4>
             <p>Lorem ipsum, dolor sit amet consectetur adipisicing elit. Officia tenetur, exercitationem velit maxime
@@ -352,6 +355,7 @@
     <script type="module" src="js/product-review-aggregator.js"></script>
     <script src="js/ar-product-viewer.js"></script>
     <script src="js/image-zoom.js"></script>
+    <script src="js/share-product.js"></script>
     <script src="js/dynamic-pricing.js"></script>
     <script>
       document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## 📄 Description

The product page had no way for a shopper to share a product. A generic `js/share-product.js` handler already existed in the repo (it wires up `[data-share-product]` buttons with a Web Share API + clipboard fallback), but it was never loaded on `singleProduct.html` and no product page exposed a share button.

This PR adds the missing "Share This Product" UI on the product details page:

- Adds a **Share** button to the `singleProduct.html` cart-action group (next to "Add to Cart" / "Try it On"), using `data-share-product` so the existing handler picks it up.
- Loads `js/share-product.js` on `singleProduct.html`.
- Enhances `js/share-product.js` so the share `title` falls back to the live `#product-name` text on product pages (the element `app.js` updates per product) before `document.title`. No behaviour change on pages without `#product-name`.

On supported browsers/mobile the native share sheet opens (title = product name, url = product URL); elsewhere the link is copied to the clipboard with a "Link copied" confirmation.

## 🔗 Related Issues

Closes #7741

## 🧩 Type of Change

- [x] New feature

## ✅ Checklist

- [x] My branch name follows the convention (`feat/`)
- [x] My commit messages follow the convention (`feat:`)
- [x] I have linked the related issue (`Closes #7741`)
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue

---

_Note: This PR was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._
