### PR TITLE
feat: add sales countdown timer on deals page

### DIFF
--- a/deals.html
+++ b/deals.html
@@ -201,6 +201,7 @@
     }
   </script>
   <meta name="description" content="Cara - The best ecommerce store for modern fashion and clothing.">
+    <link rel="stylesheet" href="sale-countdown.css">
     <script type="module" src="js/config.js"></script>
 </head>
 
@@ -234,11 +235,40 @@
 <main id="main-content">
 
 <!-- HERO SECTION -->
-<section class="deals-hero">
+    <section class="deals-hero">
     <div class="deals-content">
         <span class="deals-badge">LIMITED TIME OFFER</span>
         <h1>Buy 1 Get <span>1 Free</span></h1>
         <p>Grab your favorite fashion picks and get another one absolutely free. Limited period combo deals are waiting for you.</p>
+        <div
+            class="sale-countdown"
+            data-sale-countdown
+            data-sale-countdown-end="2026-12-31T23:59:59Z"
+            role="timer"
+            aria-live="polite"
+            aria-label="Sale ends in"
+        >
+            <span class="sale-countdown__label">Offer ends in</span>
+            <div class="sale-countdown__unit" data-unit="days">
+                <span class="sale-countdown__value">00</span>
+                <span class="sale-countdown__unit-label">Days</span>
+            </div>
+            <span class="sale-countdown__sep" aria-hidden="true">:</span>
+            <div class="sale-countdown__unit" data-unit="hours">
+                <span class="sale-countdown__value">00</span>
+                <span class="sale-countdown__unit-label">Hrs</span>
+            </div>
+            <span class="sale-countdown__sep" aria-hidden="true">:</span>
+            <div class="sale-countdown__unit" data-unit="minutes">
+                <span class="sale-countdown__value">00</span>
+                <span class="sale-countdown__unit-label">Min</span>
+            </div>
+            <span class="sale-countdown__sep" aria-hidden="true">:</span>
+            <div class="sale-countdown__unit" data-unit="seconds">
+                <span class="sale-countdown__value">00</span>
+                <span class="sale-countdown__unit-label">Sec</span>
+            </div>
+        </div>
         <a href="#deals-products" class="deals-btn">Shop Deals →</a>
     </div>
 
@@ -383,6 +413,7 @@
 </main>
 
 <script src="app.js"></script>
+<script src="js/sale-countdown.js"></script>
 
 </body>
 </html>

--- a/js/sale-countdown.js
+++ b/js/sale-countdown.js
@@ -1,0 +1,72 @@
+/**
+ * Sale Countdown Timer
+ * Renders a live countdown to a sale end date on any element with
+ * [data-sale-countdown]. The target date is read from the
+ * data-sale-countdown-end attribute (an ISO 8601 string). When the
+ * countdown reaches zero the units freeze at 00 and the container gets
+ * a `sale-countdown--ended` class so the UI can be dimmed.
+ */
+(function () {
+  'use strict';
+
+  var DAY = 86400000;
+  var HOUR = 3600000;
+  var MINUTE = 60000;
+  var SECOND = 1000;
+
+  function pad(n) {
+    return n < 10 ? '0' + n : String(n);
+  }
+
+  function buildUnits(root) {
+    var units = {};
+    root.querySelectorAll('[data-unit]').forEach(function (el) {
+      units[el.getAttribute('data-unit')] = el.querySelector(
+        '.sale-countdown__value',
+      );
+    });
+    return units;
+  }
+
+  function render(root, units, remaining) {
+    if (remaining <= 0) {
+      remaining = 0;
+      root.classList.add('sale-countdown--ended');
+    }
+    units.days.textContent = pad(Math.floor(remaining / DAY));
+    units.hours.textContent = pad(Math.floor((remaining % DAY) / HOUR));
+    units.minutes.textContent = pad(Math.floor((remaining % HOUR) / MINUTE));
+    units.seconds.textContent = pad(Math.floor((remaining % MINUTE) / SECOND));
+  }
+
+  function init(root) {
+    var endAttr = root.getAttribute('data-sale-countdown-end');
+    if (!endAttr) return;
+    var end = Date.parse(endAttr);
+    if (Number.isNaN(end)) return;
+
+    var units = buildUnits(root);
+    var reduce =
+      window.matchMedia &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    function tick() {
+      render(root, units, end - Date.now());
+    }
+    tick();
+    if (reduce) return;
+    root._saleCountdownTimer = setInterval(tick, SECOND);
+  }
+
+  function setup() {
+    document.querySelectorAll('[data-sale-countdown]').forEach(function (root) {
+      if (root._saleCountdownTimer === undefined) init(root);
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setup);
+  } else {
+    setup();
+  }
+})();

--- a/sale-countdown.css
+++ b/sale-countdown.css
@@ -1,0 +1,73 @@
+.sale-countdown {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  margin: 18px 0 8px;
+  font-variant-numeric: tabular-nums;
+}
+
+.sale-countdown__label {
+  width: 100%;
+  text-align: center;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.9;
+}
+
+.sale-countdown__unit {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 64px;
+  padding: 8px 10px;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  backdrop-filter: blur(4px);
+}
+
+.sale-countdown__value {
+  font-size: 1.6rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.sale-countdown__unit-label {
+  margin-top: 4px;
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  opacity: 0.85;
+}
+
+.sale-countdown__sep {
+  font-size: 1.4rem;
+  font-weight: 700;
+  opacity: 0.6;
+}
+
+.sale-countdown--ended .sale-countdown__value {
+  opacity: 0.55;
+}
+
+@media (max-width: 477px) {
+  .sale-countdown__unit {
+    min-width: 52px;
+    padding: 6px 8px;
+  }
+
+  .sale-countdown__value {
+    font-size: 1.25rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sale-countdown__value,
+  .sale-countdown__unit-label {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## 📄 Description

The deals page promotes a "Buy 1 Get 1 Free" limited-time offer but gives shoppers no sense of urgency — there is no visible countdown to the offer end. This PR adds a live sales countdown timer to the deals hero.

### Implementation

- **`js/sale-countdown.js`** — a small, reusable, dependency-free module. Any element marked `data-sale-countdown` with a `data-sale-countdown-end` ISO date is rendered with live Days / Hours / Minutes / Seconds, updating every second. On expiry the units freeze at `00` and the container gains a `sale-countdown--ended` class so it can be dimmed. When the visitor prefers reduced motion the timer renders the remaining time once and does not start an interval.
- **`sale-countdown.css`** — responsive glass-style units with a separator, an ended state, a small-screen breakpoint, and reduced-motion handling.
- **`deals.html`** — wires the stylesheet in `<head>`, renders the countdown inside the `deals-hero` ("Offer ends in"), and loads the script. The end date is set to a future date and is trivial to update per promotion.

## 🔗 Related Issues

Closes #7762

## 🧩 Type of Change

- [x] New feature

## ✅ Checklist

- [x] My branch name follows the convention (`feat/`)
- [x] My commit messages follow the convention (`feat:`)
- [x] I have linked the related issue (`Closes #7762`)
- [x] I have tested my changes locally
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue

---

_Note: This PR was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._
