### PR TITLE
fix(security): enforce auth + ownership on digital receipt endpoint (#7842)

### DIFF
--- a/backend/app/api/receipts.py
+++ b/backend/app/api/receipts.py
@@ -5,6 +5,8 @@ import hashlib
 import os
 from ..database import get_db
 from .. import models
+from .auth import get_current_user
+from .orders import verify_order_ownership
 from ..limiter import limiter
 
 router = APIRouter()
@@ -17,10 +19,20 @@ def generate_receipt_signature(order: models.Order) -> str:
 
 @router.get("/{order_id}/receipt")
 @limiter.limit("20/minute")
-def get_digital_receipt(request: Request, order_id: int, db: Session = Depends(get_db)):
+def get_digital_receipt(
+    request: Request,
+    order_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
     order = db.query(models.Order).filter(models.Order.id == order_id).first()
     if not order:
         raise HTTPException(status_code=404, detail="Order not found")
+
+    # Enforce the same BOLA/ownership check as the order-detail endpoint so a
+    # customer's PII (full_name, email, total) cannot be harvested by other
+    # users or unauthenticated callers enumerating sequential order ids.
+    verify_order_ownership(order, current_user)
 
     items = db.query(models.OrderItem).filter(models.OrderItem.order_id == order.id).all()
     signature = generate_receipt_signature(order)

--- a/backend/tests/test_receipts.py
+++ b/backend/tests/test_receipts.py
@@ -1,0 +1,93 @@
+"""Regression tests for GET /api/receipts/{id}/receipt authorization (issue #7842).
+
+The endpoint must not expose customer PII (full_name, email, total) to
+unauthenticated callers or to authenticated users who do not own the order.
+"""
+from passlib.context import CryptContext
+
+from app.models import Order, OrderItem, User
+from tests.conftest import TestingSessionLocal
+
+RECEIPTS_URL = "/api/receipts/"
+pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def _auth_headers(client, *, username, email):
+    db = TestingSessionLocal()
+    user = db.query(User).filter(User.email == email).first()
+    if user is None:
+        user = User(
+            username=username,
+            email=email,
+            hashed_password=pwd.hash("Test@1234"),
+        )
+        db.add(user)
+        db.commit()
+    db.close()
+
+    response = client.post(
+        "/api/auth/login",
+        json={"email": email, "password": "Test@1234"},
+    )
+    assert response.status_code == 200, response.text
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+def _seed_order(*, email: str, full_name: str = "Receipt Owner") -> int:
+    db = TestingSessionLocal()
+    order = Order(
+        full_name=full_name,
+        email=email,
+        address="1 Receipt St",
+        city="Receipt City",
+        zip_code="55555",
+        total_amount=240.0,
+        status="CONFIRMED",
+    )
+    db.add(order)
+    db.flush()
+    db.add(
+        OrderItem(
+            order_id=order.id,
+            product_id=7,
+            product_name="Receipt Shirt",
+            quantity=2,
+            price=120.0,
+        )
+    )
+    db.commit()
+    db.refresh(order)
+    order_id = order.id
+    db.close()
+    return order_id
+
+
+def test_receipt_requires_auth(client):
+    order_id = _seed_order(email="victim@example.com", full_name="Victim Name")
+    response = client.get(f"{RECEIPTS_URL}{order_id}/receipt")
+    assert response.status_code == 401, response.text
+
+
+def test_receipt_forbidden_for_non_owner(client):
+    _auth_headers(client, username="rcpt_owner", email="rcpt_owner@example.com")
+    order_id = _seed_order(email="rcpt_owner@example.com", full_name="Owner Name")
+
+    other_headers = _auth_headers(
+        client, username="rcpt_other", email="rcpt_other@example.com"
+    )
+    response = client.get(f"{RECEIPTS_URL}{order_id}/receipt", headers=other_headers)
+    assert response.status_code == 403, response.text
+
+
+def test_receipt_returns_payload_for_owner(client):
+    headers = _auth_headers(client, username="rcpt_owner2", email="rcpt_owner2@example.com")
+    order_id = _seed_order(email="rcpt_owner2@example.com", full_name="Owner Two")
+
+    response = client.get(f"{RECEIPTS_URL}{order_id}/receipt", headers=headers)
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["order_id"] == order_id
+    assert data["email"] == "rcpt_owner2@example.com"
+    assert data["full_name"] == "Owner Two"
+    assert "signature" in data
+    assert len(data["items"]) == 1


### PR DESCRIPTION
## Summary

`GET /api/receipts/{order_id}/receipt` exposed a customer's PII (full name, email, order total, status, and line items) to **any unauthenticated caller**. Because order ids are sequential integers, an attacker could enumerate them to harvest customer names, emails, and spend amounts.

The handler now requires an authenticated user and enforces order ownership, mirroring the existing `GET /api/orders/{id}` authorization (admin override + owner email match).

## Root Cause

`backend/app/api/receipts.py::get_digital_receipt` had no `current_user` dependency and never called `verify_order_ownership`, so access was not authorized — unlike its sibling `get_order_detail`.

## Changes

- `backend/app/api/receipts.py`: add `current_user: models.User = Depends(get_current_user)` to `get_digital_receipt` and call `verify_order_ownership(order, current_user)` after the order lookup. Unauthorized callers now get `401` (no token) / `403` (not owner); the public signature-based verification endpoint is unchanged.

## Testing

- Reproduced the leak before the fix: `GET /api/receipts/1/receipt` → `200` with `email`/`full_name`.
- After the fix: unauthenticated → `401`, authenticated non-owner → `403`, authenticated owner → `200` with full payload + signature.
- Added regression tests in `backend/tests/test_receipts.py` (auth required, non-owner forbidden, owner receives payload). All 3 pass.
- Full backend suite: `163 passed`, with only **5 pre-existing failures** unrelated to this change (`test_newsletter`×2, `test_order_cancel`, `test_order_detail`, `test_order_email_match` — failing on `main` before this PR).
- Frontend `vitest` suite has pre-existing environmental failures (ESM/CJS module loading, missing `canvas` package) unrelated to this backend-only change.

## Related Issue

Closes #7842

_Note: This PR was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._