### PR TITLE
fix(receipts): correct verification_url to mounted /api/receipts path (#7843)

### DIFF
--- a/backend/app/api/receipts.py
+++ b/backend/app/api/receipts.py
@@ -33,7 +33,7 @@ def get_digital_receipt(request: Request, order_id: int, db: Session = Depends(g
         "status": order.status,
         "created_at": order.created_at.isoformat() if order.created_at else None,
         "signature": signature,
-        "verification_url": f"/api/orders/verify-receipt/{signature}",
+        "verification_url": f"/api/receipts/verify-receipt/{signature}",
         "items": [
             {
                 "product_name": item.product_name,

--- a/backend/tests/test_receipts_verification_url.py
+++ b/backend/tests/test_receipts_verification_url.py
@@ -1,0 +1,57 @@
+"""Regression test for the digital receipt verification_url (issue #7843).
+
+The receipt payload must return a verification_url that actually resolves to a
+working endpoint and validates the receipt signature.
+"""
+from tests.conftest import TestingSessionLocal
+from app.models import Order, OrderItem
+
+RECEIPTS_URL = "/api/receipts/"
+
+
+def _seed_order() -> int:
+    db = TestingSessionLocal()
+    order = Order(
+        full_name="Verify User",
+        email="verify@example.com",
+        address="1 Verify St",
+        city="Verify City",
+        zip_code="12345",
+        total_amount=80.0,
+        status="CONFIRMED",
+    )
+    db.add(order)
+    db.flush()
+    db.add(
+        OrderItem(
+            order_id=order.id,
+            product_id=11,
+            product_name="Verify Shirt",
+            quantity=1,
+            price=80.0,
+        )
+    )
+    db.commit()
+    db.refresh(order)
+    order_id = order.id
+    db.close()
+    return order_id
+
+
+def test_receipt_verification_url_resolves_and_validates(client):
+    order_id = _seed_order()
+    receipt = client.get(f"{RECEIPTS_URL}{order_id}/receipt")
+    assert receipt.status_code == 200, receipt.text
+    data = receipt.json()
+
+    verification_url = data["verification_url"]
+    # The URL must point at the receipts router mount (/api/receipts/...), not
+    # the non-existent /api/orders/verify-receipt path.
+    assert verification_url.startswith("/api/receipts/verify-receipt/"), verification_url
+
+    # Following the returned URL must succeed (not 404) and validate the receipt.
+    verify_response = client.get(verification_url)
+    assert verify_response.status_code == 200, verify_response.text
+    verified = verify_response.json()
+    assert verified["valid"] is True
+    assert verified["order_id"] == order_id


### PR DESCRIPTION
## Summary

The digital receipt payload returned a `verification_url` pointing to `/api/orders/verify-receipt/{signature}`, but no route exists at that path — the verification endpoint is mounted under the receipts router at `/api/receipts/verify-receipt/{signature}`. Following the returned link returned `404 Not Found`, breaking client-side (and PDF-export) receipt verification.

## Root Cause

`backend/app/main.py` mounts the receipts router at prefix `/api/receipts`, and `receipts.py` defines `@router.get("/verify-receipt/{signature}")`. The live route is therefore `/api/receipts/verify-receipt/{signature}`, but the receipt payload hard-coded the wrong `/api/orders/...` prefix.

## Changes

- `backend/app/api/receipts.py`: correct `verification_url` to `f"/api/receipts/verify-receipt/{signature}"`.

## Testing

- Before fix: `GET <verification_url>` returned `404`; `GET /api/receipts/verify-receipt/{sig}` returned `200 {"valid": true, ...}`.
- Added regression test `tests/test_receipts_verification_url.py` asserting the returned URL starts with `/api/receipts/verify-receipt/` and that following it returns `200` with `valid: true`. Verified the test **fails** on the old code and **passes** with the fix.
- Backend suite: new test passes; only pre-existing failures (unrelated, failing on `main`) remain.

## Related Issue

Closes #7843

_Note: This PR was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._