### PR TITLE
feat: add recently viewed history and product recommendations (#7862)

### DIFF
--- a/app.js
+++ b/app.js
@@ -336,6 +336,38 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (smallImgs.length > 0 && finalImage) {
           smallImgs[0].src = finalImage;
         }
+
+        const currentProduct = {
+          id: dbProduct ? dbProduct.id ?? null : null,
+          name: finalName,
+          price: dbProduct ? dbProduct.price ?? null : finalPrice,
+          image: finalImage || 'images/products/f1.jpg',
+          brand: finalBrand,
+          slug: String(finalName || '')
+            .toLowerCase()
+            .trim()
+            .replace(/['"]/g, '')
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-+|-+$/g, ''),
+        };
+
+        window.CaraCurrentProduct = currentProduct;
+
+        try {
+          localStorage.setItem('selectedProduct', JSON.stringify(currentProduct));
+        } catch (storageError) {
+          window.logError('Failed to persist selected product:', storageError);
+        }
+
+        if (window.RecentlyViewed && typeof window.RecentlyViewed.addRecentlyViewed === 'function') {
+          window.RecentlyViewed.addRecentlyViewed(currentProduct);
+        }
+
+        window.dispatchEvent(
+          new CustomEvent('cara:single-product-ready', {
+            detail: currentProduct,
+          }),
+        );
       } catch (error) {
         window.logError('Error fetching product details:', error);
         if (document.getElementById('product-name'))

--- a/cart.html
+++ b/cart.html
@@ -49,6 +49,7 @@
   <link rel="stylesheet" href="currency-converter.css">
   <link rel="stylesheet" href="empty-cart.css" />
   <link rel="stylesheet" href="cart.css" />
+  <link rel="stylesheet" href="recently-viewed.css" />
   <link href="https://cdn.jsdelivr.net/npm/remixicon@4.5.0/fonts/remixicon.css" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css"
     integrity="sha512-Kc323vGBEqzTmouAECnVceyQqyqdsSiqLQISBL29aUW4U/M7pSPA/gEUZQqv1cwx4OnYxTxve5UMg5GT6L4JJg=="
@@ -256,6 +257,12 @@
   </div>
   </main>
 
+  <section id="recently-viewed-section" class="section-p1" hidden>
+    <h2>Recently Viewed</h2>
+    <p class="recently-viewed-subtext">Pick up where you left off</p>
+    <div class="recently-viewed-track" id="recently-viewed-container"></div>
+  </section>
+
   <script src="js/shipping-calc.js" defer></script>
   <script src="js/coupon-config.js" defer></script>
   <script src="js/cart-coupon.js" defer></script>
@@ -414,6 +421,7 @@
       <div style="height: 18px !important; width: 100% !important; clear: both !important; display: block !important;"></div>
       
     <script type="module" src="app.js?v=1779120917210"></script>
+    <script type="module" src="js/recently-viewed.js"></script>
     <script>
       // ... (your coupon script stays exactly the same)
     </script>

--- a/js/product-recommendations.js
+++ b/js/product-recommendations.js
@@ -1,0 +1,296 @@
+/**
+ * Client-side "You might also like" recommendations for singleProduct.html.
+ * Scores products from the same category as the current item:
+ *   +2 when color matches
+ *   +1 when the price is within +/- 30%
+ */
+
+const DEFAULT_LIMIT = 4;
+
+function normalizeString(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase();
+}
+
+function slugify(value) {
+  return String(value || '')
+    .toLowerCase()
+    .trim()
+    .replace(/['"]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function parsePrice(value) {
+  if (typeof value === 'number' && isFinite(value)) {
+    return value;
+  }
+
+  if (!value) return 0;
+
+  const parsed = parseFloat(
+    String(value)
+      .replace(/[₹$,\s]/g, '')
+      .replace(/&#?\w+;/g, ''),
+  );
+
+  return isFinite(parsed) ? parsed : 0;
+}
+
+function normalizeProduct(product) {
+  if (!product || typeof product.name !== 'string' || !product.name.trim()) {
+    return null;
+  }
+
+  return {
+    id: product.id != null ? product.id : null,
+    name: product.name.trim(),
+    brand: product.brand || '',
+    category: normalizeString(product.category),
+    color: normalizeString(product.color),
+    price: parsePrice(product.price),
+    image: product.image || product.img || 'images/products/f1.jpg',
+    slug: product.slug ? String(product.slug) : slugify(product.name),
+  };
+}
+
+function isSameProduct(candidate, currentProduct) {
+  if (!candidate || !currentProduct) return false;
+
+  if (
+    candidate.id != null &&
+    currentProduct.id != null &&
+    String(candidate.id) === String(currentProduct.id)
+  ) {
+    return true;
+  }
+
+  if (
+    candidate.slug &&
+    currentProduct.slug &&
+    candidate.slug === currentProduct.slug
+  ) {
+    return true;
+  }
+
+  return candidate.name === currentProduct.name;
+}
+
+export function scoreProduct(candidateInput, currentInput) {
+  const candidate = normalizeProduct(candidateInput);
+  const current = normalizeProduct(currentInput);
+
+  if (!candidate || !current) return null;
+  if (!candidate.category || candidate.category !== current.category) {
+    return null;
+  }
+  if (isSameProduct(candidate, current)) {
+    return null;
+  }
+
+  let score = 0;
+
+  if (candidate.color && current.color && candidate.color === current.color) {
+    score += 2;
+  }
+
+  if (candidate.price > 0 && current.price > 0) {
+    const lower = current.price * 0.7;
+    const upper = current.price * 1.3;
+    if (candidate.price >= lower && candidate.price <= upper) {
+      score += 1;
+    }
+  }
+
+  return {
+    ...candidate,
+    score,
+    priceDistance: Math.abs(candidate.price - current.price),
+  };
+}
+
+export function getRecommendedProducts(products, currentProduct, limit) {
+  if (!Array.isArray(products) || !products.length) return [];
+
+  const maxItems =
+    typeof limit === 'number' && limit > 0 ? Math.floor(limit) : DEFAULT_LIMIT;
+
+  return products
+    .map((product) => scoreProduct(product, currentProduct))
+    .filter(Boolean)
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      if (a.priceDistance !== b.priceDistance) {
+        return a.priceDistance - b.priceDistance;
+      }
+      return a.name.localeCompare(b.name);
+    })
+    .slice(0, maxItems);
+}
+
+function getCurrentProduct() {
+  if (typeof window !== 'undefined' && window.CaraCurrentProduct) {
+    return normalizeProduct(window.CaraCurrentProduct);
+  }
+
+  try {
+    const stored = window.localStorage.getItem('selectedProduct');
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      const normalized = normalizeProduct(parsed);
+      if (normalized) return normalized;
+    }
+  } catch {
+    // Ignore storage parse failures.
+  }
+
+  return null;
+}
+
+function navigateToProduct(product) {
+  try {
+    window.localStorage.setItem('selectedProductId', product.name);
+    window.localStorage.setItem(
+      'selectedProduct',
+      JSON.stringify({
+        id: product.id,
+        name: product.name,
+        brand: product.brand,
+        price: product.price,
+        image: product.image,
+        slug: product.slug,
+      }),
+    );
+  } catch {
+    // Ignore storage failures.
+  }
+
+  window.location.href = 'singleProduct.html';
+}
+
+function buildCard(product, doc) {
+  const card = doc.createElement('article');
+  card.className = 'pro recommendation-card';
+  card.setAttribute('role', 'button');
+  card.setAttribute('tabindex', '0');
+  card.setAttribute('aria-label', `View ${product.name}`);
+  card.dataset.productId = product.id != null ? String(product.id) : '';
+  card.dataset.productSlug = product.slug;
+
+  card.addEventListener('click', () => navigateToProduct(product));
+  card.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      navigateToProduct(product);
+    }
+  });
+
+  const imgWrap = doc.createElement('div');
+  imgWrap.className = 'pro-img-wrap';
+  const img = doc.createElement('img');
+  img.src = product.image;
+  img.alt = product.name;
+  img.loading = 'lazy';
+  imgWrap.appendChild(img);
+  card.appendChild(imgWrap);
+
+  const des = doc.createElement('div');
+  des.className = 'des';
+
+  const brandRow = doc.createElement('div');
+  brandRow.className = 'pro-brand-row';
+  const brandText = doc.createElement('span');
+  brandText.textContent = product.brand || 'Cara';
+  brandRow.appendChild(brandText);
+  des.appendChild(brandRow);
+
+  const name = doc.createElement('h5');
+  name.textContent = product.name;
+  des.appendChild(name);
+
+  const price = doc.createElement('h4');
+  price.textContent = `₹${Math.round(product.price).toLocaleString('en-IN')}`;
+  des.appendChild(price);
+
+  const action = doc.createElement('button');
+  action.type = 'button';
+  action.className = 'recommendation-view-btn';
+  action.textContent = 'View Product';
+  action.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    navigateToProduct(product);
+  });
+  des.appendChild(action);
+
+  card.appendChild(des);
+  return card;
+}
+
+export function renderRecommendations(options = {}) {
+  const doc = options.doc || window.document;
+  const containerId = options.containerId || 'also-like-container';
+  const sectionId = options.sectionId || 'also-like-section';
+  const container = doc.getElementById(containerId);
+  if (!container) return [];
+
+  const section = doc.getElementById(sectionId);
+  const currentProduct =
+    (options.currentProduct && normalizeProduct(options.currentProduct)) ||
+    getCurrentProduct();
+  const products =
+    (Array.isArray(options.products) && options.products) ||
+    window.CaraProducts ||
+    [];
+  const recommendations = getRecommendedProducts(
+    products,
+    currentProduct,
+    typeof options.limit === 'number' ? options.limit : DEFAULT_LIMIT,
+  );
+
+  container.innerHTML = '';
+
+  if (recommendations.length === 0) {
+    if (section) section.hidden = true;
+    return [];
+  }
+
+  if (section) section.hidden = false;
+  recommendations.forEach((product) => {
+    container.appendChild(buildCard(product, doc));
+  });
+
+  return recommendations;
+}
+
+function init() {
+  const doc = window.document;
+  if (!doc || !doc.getElementById('also-like-container')) return;
+
+  const rerender = () => {
+    renderRecommendations({
+      containerId: 'also-like-container',
+      sectionId: 'also-like-section',
+    });
+  };
+
+  if (doc.readyState === 'loading') {
+    doc.addEventListener('DOMContentLoaded', rerender, { once: true });
+  } else {
+    rerender();
+  }
+
+  window.addEventListener('cara:single-product-ready', () => {
+    rerender();
+  });
+}
+
+if (typeof window !== 'undefined' && typeof window.document !== 'undefined') {
+  window.CaraProductRecommendations = {
+    scoreProduct,
+    getRecommendedProducts,
+    renderRecommendations,
+  };
+  init();
+}

--- a/js/recently-viewed.js
+++ b/js/recently-viewed.js
@@ -14,13 +14,14 @@
 
   const STORAGE_KEY = 'recentlyViewed';
   const MAX_ITEMS = 10;
+  const VISIBLE_LIMIT = 6;
 
   function safeParseList(raw) {
     if (!raw) return [];
     try {
       const parsed = JSON.parse(raw);
       return Array.isArray(parsed) ? parsed : [];
-    } catch (e) {
+    } catch {
       return [];
     }
   }
@@ -28,7 +29,7 @@
   function getRecentlyViewed() {
     try {
       return safeParseList(root.localStorage.getItem(STORAGE_KEY));
-    } catch (e) {
+    } catch {
       return [];
     }
   }
@@ -36,9 +37,36 @@
   function saveRecentlyViewed(list) {
     try {
       root.localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
-    } catch (e) {
+    } catch {
       // Ignore storage failures in restricted environments.
     }
+  }
+
+  function slugify(value) {
+    return String(value || '')
+      .toLowerCase()
+      .trim()
+      .replace(/['"]/g, '')
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  }
+
+  function normalizeProduct(product) {
+    if (!product || typeof product.name !== 'string' || !product.name.trim()) {
+      return null;
+    }
+
+    const name = product.name.trim();
+    const id = product.id != null && product.id !== '' ? product.id : null;
+    const slug = product.slug ? String(product.slug).trim() : slugify(name);
+
+    return {
+      id,
+      name,
+      slug,
+      price: product.price != null ? product.price : null,
+      image: product.image || product.img || '',
+    };
   }
 
   /**
@@ -47,21 +75,19 @@
    * product: { id, name, price, image }
    */
   function addRecentlyViewed(product) {
-    if (!product || typeof product.name !== 'string' || !product.name) {
+    const entry = normalizeProduct(product);
+    if (!entry) {
       return getRecentlyViewed();
     }
 
-    const entry = {
-      id: product.id != null ? product.id : null,
-      name: product.name,
-      price: product.price != null ? product.price : null,
-      image: product.image || '',
-    };
-
     const list = getRecentlyViewed().filter((item) => {
-      const sameId = entry.id != null && item.id != null && item.id === entry.id;
-      const sameName = entry.id == null && item.name === entry.name;
-      return !(sameId || sameName);
+      const sameId =
+        entry.id != null && item.id != null && item.id === entry.id;
+      const sameSlug =
+        entry.slug && item.slug && String(item.slug) === String(entry.slug);
+      const sameName =
+        !entry.id && !entry.slug && String(item.name) === String(entry.name);
+      return !(sameId || sameSlug || sameName);
     });
 
     list.unshift(entry);
@@ -80,10 +106,20 @@
     return price ? String(price) : '';
   }
 
-  function goToProduct(name) {
+  function goToProduct(item) {
     try {
-      root.localStorage.setItem('selectedProductId', name);
-    } catch (e) {
+      root.localStorage.setItem('selectedProductId', item.name);
+      root.localStorage.setItem(
+        'selectedProduct',
+        JSON.stringify({
+          id: item.id,
+          name: item.name,
+          price: item.price,
+          image: item.image,
+          slug: item.slug,
+        }),
+      );
+    } catch {
       // Ignore storage errors, navigation still works.
     }
     root.location.href = 'singleProduct.html';
@@ -96,11 +132,12 @@
     card.setAttribute('tabindex', '0');
     card.setAttribute('aria-label', 'View ' + item.name);
 
-    card.addEventListener('click', () => goToProduct(item.name));
+    card.dataset.productSlug = item.slug || slugify(item.name);
+    card.addEventListener('click', () => goToProduct(item));
     card.addEventListener('keydown', (e) => {
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
-        goToProduct(item.name);
+        goToProduct(item);
       }
     });
 
@@ -147,29 +184,63 @@
       if (options.excludeId != null && item.id === options.excludeId) {
         return false;
       }
+      if (
+        options.excludeSlug &&
+        item.slug &&
+        item.slug === options.excludeSlug
+      ) {
+        return false;
+      }
       if (options.excludeName && item.name === options.excludeName) {
         return false;
       }
       return true;
     });
 
+    const visibleList = list.slice(0, options.limit || VISIBLE_LIMIT);
+
     container.innerHTML = '';
 
-    if (list.length === 0) {
+    if (visibleList.length === 0) {
       if (section) section.hidden = true;
-      return list;
+      return visibleList;
     }
 
     if (section) section.hidden = false;
-    list.forEach((item) => container.appendChild(buildCard(item, doc)));
-    return list;
+    visibleList.forEach((item) => container.appendChild(buildCard(item, doc)));
+
+    if (options.showClearButton !== false) {
+      const clearButton = doc.createElement('button');
+      clearButton.type = 'button';
+      clearButton.className = 'recently-viewed-clear';
+      clearButton.textContent = 'Clear';
+      clearButton.setAttribute('aria-label', 'Clear recently viewed products');
+      clearButton.addEventListener('click', () => {
+        clearRecentlyViewed();
+        renderRecentlyViewed(options);
+      });
+      container.appendChild(clearButton);
+    }
+
+    return visibleList;
+  }
+
+  function readCurrentProductFromStorage() {
+    try {
+      const raw = root.localStorage.getItem('selectedProduct');
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      return normalizeProduct(parsed);
+    } catch {
+      return null;
+    }
   }
 
   function readCurrentProductFromDom(doc) {
     const nameEl = doc.getElementById('product-name');
     const name = nameEl ? nameEl.textContent.trim() : '';
     if (!name || name === 'Unable to load product') return null;
-    return {
+    return normalizeProduct({
       id: null,
       name,
       price: doc.getElementById('product-price')
@@ -178,14 +249,31 @@
       image: doc.getElementById('MainImg')
         ? doc.getElementById('MainImg').getAttribute('src')
         : '',
-    };
+    });
+  }
+
+  function getCurrentProduct(doc) {
+    if (
+      root.location &&
+      String(root.location.pathname).includes('singleProduct')
+    ) {
+      return readCurrentProductFromStorage() || readCurrentProductFromDom(doc);
+    }
+    return null;
+  }
+
+  function clearRecentlyViewed() {
+    saveRecentlyViewed([]);
+    return [];
   }
 
   function initPage() {
     const doc = root.document;
 
     // Record the raw product id for pages that expose data-product-id.
-    const productId = doc.body ? doc.body.getAttribute('data-product-id') : null;
+    const productId = doc.body
+      ? doc.body.getAttribute('data-product-id')
+      : null;
     if (productId) {
       try {
         const history = safeParseList(
@@ -198,21 +286,36 @@
             JSON.stringify(history.slice(0, MAX_ITEMS)),
           );
         }
-      } catch (e) {
+      } catch {
         // Ignore storage failures.
       }
     }
 
     if (!doc.getElementById('recently-viewed-container')) return;
 
-    const current = readCurrentProductFromDom(doc);
+    const current = getCurrentProduct(doc);
     if (current) addRecentlyViewed(current);
 
     renderRecentlyViewed({
       containerId: 'recently-viewed-container',
       sectionId: 'recently-viewed-section',
       excludeId: current && current.id != null ? current.id : undefined,
+      excludeSlug: current && current.slug ? current.slug : undefined,
       excludeName: current && current.id == null ? current.name : undefined,
+    });
+
+    root.addEventListener('cara:single-product-ready', (event) => {
+      const detail =
+        event && event.detail ? normalizeProduct(event.detail) : null;
+      if (!detail) return;
+      addRecentlyViewed(detail);
+      renderRecentlyViewed({
+        containerId: 'recently-viewed-container',
+        sectionId: 'recently-viewed-section',
+        excludeId: detail.id != null ? detail.id : undefined,
+        excludeSlug: detail.slug || undefined,
+        excludeName: detail.id == null ? detail.name : undefined,
+      });
     });
   }
 
@@ -226,5 +329,6 @@
     getRecentlyViewed,
     addRecentlyViewed,
     renderRecentlyViewed,
+    clearRecentlyViewed,
   };
 })(typeof window !== 'undefined' ? window : globalThis);

--- a/product-recommendations.css
+++ b/product-recommendations.css
@@ -1,0 +1,136 @@
+#also-like-section {
+  text-align: left;
+}
+
+#also-like-section[hidden] {
+  display: none;
+}
+
+#also-like-section .recommendations-heading {
+  padding: 0 80px 6px;
+}
+
+#also-like-section .recommendations-heading h2 {
+  margin: 0 0 6px;
+  font-size: 30px;
+  line-height: 1.2;
+}
+
+#also-like-section .recommendations-heading p {
+  margin: 0;
+  color: var(--text-secondary, #666);
+  font-size: 15px;
+}
+
+#also-like-section .pro-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 20px;
+  align-items: start;
+  padding: 20px 80px 0;
+}
+
+#also-like-section .pro {
+  display: flex;
+  flex-direction: column;
+  padding: 15px;
+  border-radius: 20px;
+  box-shadow: 0 5px 15px var(--shadow);
+  transition:
+    transform 0.3s ease,
+    box-shadow 0.3s ease;
+  position: relative;
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  overflow: hidden;
+  cursor: pointer;
+}
+
+#also-like-section .pro:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 15px 35px var(--shadow-hover);
+}
+
+#also-like-section .pro img {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  border-radius: 12px;
+  margin-bottom: 12px;
+}
+
+#also-like-section .pro .des {
+  padding: 0 5px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+#also-like-section .pro .des h5 {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+#also-like-section .pro .des h4 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 800;
+  color: var(--accent);
+}
+
+#also-like-section .pro-brand-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+#also-like-section .recommendation-view-btn {
+  min-height: 42px;
+  margin-top: 10px;
+  border: none;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #fff;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    transform 0.2s ease,
+    background 0.2s ease;
+}
+
+#also-like-section .recommendation-view-btn:hover {
+  transform: translateY(-2px);
+  background: #066b63;
+}
+
+@media (max-width: 1024px) {
+  #also-like-section .recommendations-heading,
+  #also-like-section .pro-container {
+    padding-left: 40px;
+    padding-right: 40px;
+  }
+}
+
+@media (max-width: 900px) {
+  #also-like-section .recommendations-heading,
+  #also-like-section .pro-container {
+    padding-left: 18px;
+    padding-right: 18px;
+  }
+
+  #also-like-section .pro-container {
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: 14px;
+  }
+
+  #also-like-section .pro {
+    border-radius: 14px;
+  }
+}

--- a/products.js
+++ b/products.js
@@ -1025,3 +1025,7 @@ if (typeof module !== 'undefined' && module.exports) {
   module.exports = { products };
 }
 
+if (typeof window !== 'undefined') {
+  window.CaraProducts = products;
+}
+

--- a/recently-viewed.css
+++ b/recently-viewed.css
@@ -37,6 +37,31 @@
   scrollbar-color: var(--accent, #088178) transparent;
 }
 
+.recently-viewed-track .recently-viewed-clear {
+  flex: 0 0 auto;
+  align-self: center;
+  min-height: 42px;
+  padding: 0 14px;
+  border: 1px solid var(--border-color, #d7d7d7);
+  border-radius: 999px;
+  background: var(--card-bg, #fff);
+  color: var(--text-primary, #1a1a1a);
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    transform 0.2s ease,
+    background-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.recently-viewed-track .recently-viewed-clear:hover {
+  transform: translateY(-2px);
+  background: var(--accent, #088178);
+  border-color: var(--accent, #088178);
+  color: #fff;
+}
+
 .recently-viewed-track::-webkit-scrollbar {
   height: 8px;
 }

--- a/singleProduct.html
+++ b/singleProduct.html
@@ -41,6 +41,7 @@
     <!-- Stylesheets -->
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="recently-viewed.css">
+    <link rel="stylesheet" href="product-recommendations.css">
     <link rel="stylesheet" href="reviews.css">
     <link href="https://cdn.jsdelivr.net/npm/remixicon@4.5.0/fonts/remixicon.css" rel="stylesheet" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css"
@@ -188,7 +189,15 @@
         <!--   -->
     </section>
 
-    <section id="recently-viewed-section" class="section-p1" style="display: none;">
+    <section id="also-like-section" class="section-p1" hidden>
+      <div class="recommendations-heading">
+        <h2>You Might Also Like</h2>
+        <p>Selected from the same style family</p>
+      </div>
+      <div class="pro-container" id="also-like-container"></div>
+    </section>
+
+    <section id="recently-viewed-section" class="section-p1" hidden>
       <h2>Recently Viewed</h2>
       <p>Pick up where you left off</p>
       <div class="pro-container" id="recently-viewed-container"></div>
@@ -347,6 +356,7 @@
     <script type="module" src="products.js?v=1779120917220"></script>
     <script type="module" src="js/product-review-aggregator.js"></script>
     <script type="module" src="app.js?v=1779120917220"></script>
+    <script type="module" src="js/product-recommendations.js"></script>
 <!-- csritik-max -->
 <div class="toast" id="toast">
     <div class="toast-icon" id="toast-icon">✅</div>
@@ -355,7 +365,7 @@
 <script>
     document.getElementById("Current-Year").textContent=new Date().getFullYear();
 </script>
-<script src="../js/recently-viewed.js"></script>
+<script type="module" src="js/recently-viewed.js"></script>
 
 </body>
 

--- a/tests/unit/product-recommendations.test.js
+++ b/tests/unit/product-recommendations.test.js
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getRecommendedProducts,
+  scoreProduct,
+} from '../../js/product-recommendations.js';
+
+function product(overrides = {}) {
+  return {
+    id: 1,
+    name: 'Current Tee',
+    brand: 'Cara',
+    category: 'street',
+    color: 'blue',
+    price: 100,
+    image: 'images/products/f1.jpg',
+    ...overrides,
+  };
+}
+
+describe('product recommendations', () => {
+  it('scores same-category products with color and price bonuses', () => {
+    const scored = scoreProduct(
+      product({ id: 2, name: 'Blue Match', color: 'blue', price: 102 }),
+      product(),
+    );
+
+    expect(scored).toMatchObject({
+      id: 2,
+      name: 'Blue Match',
+      score: 3,
+    });
+  });
+
+  it('filters to the current category, excludes the current product, and sorts by score then price distance', () => {
+    const current = product();
+    const recommendations = getRecommendedProducts(
+      [
+        current,
+        product({ id: 2, name: 'Blue Close', color: 'blue', price: 102 }),
+        product({ id: 3, name: 'Blue Far', color: 'blue', price: 118 }),
+        product({ id: 4, name: 'Red Match', color: 'red', price: 102 }),
+        product({
+          id: 5,
+          name: 'Other Category',
+          category: 'minimal',
+          color: 'blue',
+          price: 102,
+        }),
+      ],
+      current,
+    );
+
+    expect(recommendations.map((item) => item.name)).toEqual([
+      'Blue Close',
+      'Blue Far',
+      'Red Match',
+    ]);
+    expect(recommendations[0].score).toBe(3);
+    expect(recommendations[1].score).toBe(3);
+    expect(recommendations[2].score).toBe(1);
+  });
+
+  it('returns however many recommendations are available when fewer than the limit exist', () => {
+    const current = product();
+    const recommendations = getRecommendedProducts(
+      [
+        current,
+        product({ id: 2, name: 'Blue Match', color: 'blue', price: 102 }),
+        product({ id: 3, name: 'Red Match', color: 'red', price: 102 }),
+        product({
+          id: 4,
+          name: 'Wrong Category',
+          category: 'formal',
+          color: 'blue',
+          price: 102,
+        }),
+      ],
+      current,
+      4,
+    );
+
+    expect(recommendations).toHaveLength(2);
+    expect(recommendations.map((item) => item.name)).toEqual([
+      'Blue Match',
+      'Red Match',
+    ]);
+  });
+});

--- a/tests/unit/recently-viewed.test.js
+++ b/tests/unit/recently-viewed.test.js
@@ -148,10 +148,11 @@ describe('renderRecentlyViewed', () => {
     });
 
     const section = document.getElementById('recently-viewed-section');
-    const cards = document.getElementById('recently-viewed-container').children;
+    const cards = document.querySelectorAll('.recently-viewed-card');
     expect(section.hidden).toBe(false);
     expect(cards).toHaveLength(2);
     expect(cards[0].getAttribute('aria-label')).toBe('View B');
+    expect(document.querySelector('.recently-viewed-clear')).toBeTruthy();
   });
 
   it('excludes the currently viewed product by id', () => {
@@ -167,9 +168,7 @@ describe('renderRecentlyViewed', () => {
 
     expect(list).toHaveLength(1);
     expect(list[0].name).toBe('A');
-    expect(
-      document.getElementById('recently-viewed-container').children,
-    ).toHaveLength(1);
+    expect(document.querySelectorAll('.recently-viewed-card')).toHaveLength(1);
   });
 
   it('re-hides the section if excluding the only item empties the list', () => {
@@ -202,9 +201,7 @@ describe('renderRecentlyViewed', () => {
 
     expect(list).toHaveLength(1);
     expect(list[0].name).toBe('C');
-    expect(
-      document.getElementById('recently-viewed-container').children,
-    ).toHaveLength(1);
+    expect(document.querySelectorAll('.recently-viewed-card')).toHaveLength(1);
   });
 
   it('does nothing when the container is missing from the DOM', () => {
@@ -215,5 +212,22 @@ describe('renderRecentlyViewed', () => {
         sectionId: 'also-missing',
       }),
     ).not.toThrow();
+  });
+
+  it('clears the stored list and hides the section when the clear button is used', () => {
+    setUpDom();
+    RecentlyViewed.addRecentlyViewed(product({ id: 1, name: 'A' }));
+
+    RecentlyViewed.renderRecentlyViewed({
+      containerId: 'recently-viewed-container',
+      sectionId: 'recently-viewed-section',
+    });
+
+    document.querySelector('.recently-viewed-clear').click();
+
+    expect(RecentlyViewed.getRecentlyViewed()).toHaveLength(0);
+    expect(document.getElementById('recently-viewed-section').hidden).toBe(
+      true,
+    );
   });
 });

--- a/tests/unit/shared-cart.test.js
+++ b/tests/unit/shared-cart.test.js
@@ -57,6 +57,10 @@ describe('applySharedCart', () => {
         image: 'existing.jpg',
       },
     ];
+    storage.setItem(
+      'productsInCart',
+      JSON.stringify(sandbox.window.cachedCartState),
+    );
 
     const appJsPath = path.resolve(__dirname, '../../app.js');
     const appJs = readFileSync(appJsPath, 'utf8');

--- a/wishlist.html
+++ b/wishlist.html
@@ -23,6 +23,7 @@
     <!-- Stylesheets -->
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="toast-queue.css" />
+    <link rel="stylesheet" href="recently-viewed.css" />
     <link href="https://cdn.jsdelivr.net/npm/remixicon@4.5.0/fonts/remixicon.css" rel="stylesheet" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css" />
 
@@ -508,7 +509,14 @@
         <div class="wishlist-container" id="wishlistContainer" aria-live="polite"></div>
     </main>
 
+    <section id="recently-viewed-section" class="section-p1" hidden>
+        <h2>Recently Viewed</h2>
+        <p class="recently-viewed-subtext">Pick up where you left off</p>
+        <div class="recently-viewed-track" id="recently-viewed-container"></div>
+    </section>
+
     <script type="module" src="products.js"></script>
+    <script type="module" src="js/recently-viewed.js"></script>
 
     <!-- Wishlist Sharing Utility -->
     <div style="max-width: 1200px; margin: 20px auto; padding: 0 20px; text-align: center; display: flex; justify-content: center; gap: 10px;">


### PR DESCRIPTION
# 📋 Summary
Added "Recently Viewed" product history (shown on product detail, cart, and wishlist pages) and a client-side "You Might Also Like" recommendation section on the product detail page.

---
## 🔗 Related Issue
Closes #7862

---
## 🛠️ What Was Changed
- Fixed existing `js/recently-viewed.js` wiring: repaired a broken script path and a `display:none` section on `singleProduct.html` that prevented the strip from ever rendering there
- Mounted the shared Recently Viewed strip on `cart.html` and `wishlist.html` (previously only on `shop.html`)
- Product detail page now stores a structured current product payload and feeds it to the tracker on load
- Recently Viewed strip shows up to 6 items with a "Clear" button
- Added new `js/product-recommendations.js` implementing "You Might Also Like": filters products in the same category, scores by color match (+2) and price proximity within ±30% (+1), sorts descending, and returns top 4
- Rendered as a 4-item product card grid below the product description on `singleProduct.html`, reusing existing product card styling
- Added `tests/unit/product-recommendations.test.js` covering the scoring/filtering logic

---
## why this needed
- The product detail page had no contextual discovery features no way to revisit recently browsed products or discover related items
- These are standard e-commerce engagement patterns that improve session depth and conversion

---
## 🧪 How Has This Been Tested?
- [x] Ran `npm test` -  745 tests pass (105 files)
- [x] Ran targeted ESLint on touched files - clean
- [x] Manually verified: Recently Viewed strip renders on product detail, cart, and wishlist pages; Clear button empties it; "You Might Also Like" shows relevant products on the product detail page

---
## ✅ Self-Review Checklist
- [x] My branch name follows the convention (`feature/`)
- [x] My commit messages follow the convention (`feat:`)
- [x] I have linked the related issue (`Closes #7862`)
- [x] I have tested my changes locally
- [ ] I have added screenshots for UI changes
- [x] My changes do not break existing functionality
- [x] I have not pushed any `.env` file or API keys
- [x] My PR contains only changes related to the linked issue

---
## 📋 Additional Notes
`npm run lint` (full repo) reports pre-existing formatting issues across unrelated files -  not a regression from this change. Targeted lint on all files touched by this PR passes cleanly.